### PR TITLE
Issue 1723

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Safely handle `Sequence.iter_kmers` where `k` is greater than the sequence length ([#1723](https://github.com/scikit-bio/scikit-bio/issues/1723))
 * Re-enabled OpenMP support, which has been mistakenly disabled in 0.5.8  ([#1874](https://github.com/biocore/scikit-bio/pull/1874))
 * `permanova` and `permdist` operate on a `DistanceMatrix` and a grouping object. Element IDs must be synchronized to compare correct sets of pairwise distances. This failed in case the grouping was provided as a `pandas.Series`, because it was interpreted as an ordered `list` and indices were ignored (see issue [#1877](https://github.com/biocore/scikit-bio/issues/1877) for an example). Note: `pandas.DataFrame` was handled correctly. This behavior has been fixed with PR [#1879](https://github.com/biocore/scikit-bio/pull/1879)
 

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1896,6 +1896,9 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
         if k < 1:
             raise ValueError("k must be greater than 0.")
 
+        if k > len(self):
+            return
+
         if overlap:
             step = 1
             count = len(self) - k + 1

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1593,6 +1593,11 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         obs = list(skbio.Sequence('TATATA').iter_kmers(10))
         exp = []
         self.assertEqual(obs, exp)
+    
+    def test_iter_kmers_issue1723_edgecase(self):
+        obs = list(skbio.Sequence('TATATA').iter_kmers(6))
+        exp = [Sequence('TATATA'), ]
+        self.assertEqual(obs, exp)
 
     def test_iter_kmers(self):
         seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1583,6 +1583,17 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
                                               fillvalue=None):
             self.assertEqual(obs, exp)
 
+    def test_iter_kmers_issue1723_positional_metadata(self):
+        seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})
+        obs = list(seq.iter_kmers(10))
+        exp = []
+        self.assertEqual(obs, exp)
+        
+    def test_iter_kmers_issue1723_no_positional_metadata(self):
+        obs = list(skbio.Sequence('TATATA').iter_kmers(10))
+        exp = []
+        self.assertEqual(obs, exp)
+
     def test_iter_kmers(self):
         seq = Sequence('GATTACA', positional_metadata={'quality': range(7)})
 


### PR DESCRIPTION
This pull request fixes issue 1723, which involved skbio.Sequence.iter_kmers raising an exception when the kmer length was greater than the length of the string. In order to handle this case, we now return an empty generator. 

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/.github/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
