### PR TITLE
Updated _state_decorator string formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Dropped support for NumPy < 1.17.0 in order to utilize the new random generator.
 * Use CYTHON by default during build ([#1874](https://github.com/biocore/scikit-bio/pull/1874))
 * Implemented augmented assignments proposed in issue [#1789](https://github.com/scikit-bio/scikit-bio/issues/1789)
+* Updated code style to reflect latest python standards.
 
 ## Version 0.5.9
 

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -137,7 +137,7 @@ class stable(_state_decorator):
         self.as_of = kwargs['as_of']
 
     def __call__(self, func):
-        state_desc = 'Stable as of %s.' % self.as_of
+        state_desc = f'Stable as of {self.as_of}.'
         func.__doc__ = self._update_docstring(func.__doc__, state_desc)
         return func
 
@@ -186,7 +186,7 @@ class experimental(_state_decorator):
         self.as_of = kwargs['as_of']
 
     def __call__(self, func):
-        state_desc = 'Experimental as of %s.' % self.as_of
+        state_desc = f'Experimental as of {self.as_of}.'
         func.__doc__ = self._update_docstring(func.__doc__, state_desc)
         return func
 
@@ -244,15 +244,15 @@ class deprecated(_state_decorator):
         self.reason = kwargs['reason']
 
     def __call__(self, func, *args, **kwargs):
-        state_desc = 'Deprecated as of %s for removal in %s. %s' %\
-            (self.as_of, self.until, self.reason)
+        state_desc = f'Deprecated as of {self.as_of} for removal in '\
+                     f'{self.until}. {self.reason}'
         func.__doc__ = self._update_docstring(func.__doc__, state_desc,
                                               state_desc_prefix='.. note:: ')
 
         def wrapped_f(*args, **kwargs):
-            warnings.warn('%s is deprecated as of scikit-bio version %s, and '
-                          'will be removed in version %s. %s' %
-                          (func.__name__, self.as_of, self.until, self.reason),
+            warnings.warn(f'{func.__name__} is deprecated as of scikit-bio '
+                          f'version {self.as_of}, and will be removed in '
+                          f'version {self.until}. {self.reason}',
                           SkbioDeprecationWarning)
             # args[0] is the function being wrapped when this is called
             # after wrapping with decorator.decorator, but why???
@@ -289,8 +289,8 @@ def overrides(interface_class):
     """
     def overrider(method):
         if method.__name__ not in dir(interface_class):
-            raise OverrideError("%r is not present in parent class: %r." %
-                                (method.__name__, interface_class.__name__))
+            raise OverrideError(f'{method.__name__} is not present in parent '
+                                f'class: {interface_class.__name__}.')
         backup = classproperty.__get__
         classproperty.__get__ = lambda x, y, z: x
         if method.__doc__ is None:
@@ -342,7 +342,8 @@ class classonlymethod(classmethod):
 
     def __get__(self, obj, cls=None):
         if obj is not None:
-            raise TypeError("Class-only method called on an instance. Use"
-                            " '%s.%s' instead."
-                            % (cls.__name__, self.__func__.__name__))
+            raise TypeError('Class-only method called on an instance. Use'
+                            f' {cls.__name__}.{self.__func__.__name__} '
+                            'instead.')
+
         return super().__get__(obj, cls)

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -84,14 +84,14 @@ class _state_decorator:
             state_desc_lines[i] = f'{header_spaces}{line}'
 
         new_doc_lines = '\n'.join(state_desc_lines)
-        docstring_lines[0] = '%s\n\n%s' % (docstring_lines[0], new_doc_lines)
+        docstring_lines[0] = f'{docstring_lines[0]}\n\n{new_doc_lines}'
         return '\n'.join(docstring_lines)
 
     def _validate_kwargs(self, **kwargs):
         for required_kwarg in self._required_kwargs:
             if required_kwarg not in kwargs:
-                raise ValueError('%s decorator requires parameter: %s' %
-                                 (self.__class__, required_kwarg))
+                raise ValueError(f'{self.__class__} decorator requires \
+                                 parameter: {required_kwarg}')
 
 
 class stable(_state_decorator):

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -76,8 +76,8 @@ class _state_decorator:
         # the text in this section. This is for consistency with numpydoc
         # formatting of deprecation notices, which are done using the note
         # Sphinx directive.
-        state_desc_lines[0] = f'{' ' * docstring_content_indentation}\
-                                {state_desc_prefix}{state_desc_lines[0]}'
+        state_desc_lines[0] = f'{' ' * docstring_content_indentation}'\
+                              f'{state_desc_prefix}{state_desc_lines[0]}'
         header_spaces = ' ' * (docstring_content_indentation +
                                len_state_desc_prefix)
         for i, line in enumerate(state_desc_lines[1:], 1):

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -244,8 +244,8 @@ class deprecated(_state_decorator):
         self.reason = kwargs['reason']
 
     def __call__(self, func, *args, **kwargs):
-        state_desc = f'Deprecated as of {self.as_of} for removal in '\
-                     f'{self.until}. {self.reason}'
+        state_desc = (f'Deprecated as of {self.as_of} for removal in \
+                      {self.until}. {self.reason}')
         func.__doc__ = self._update_docstring(func.__doc__, state_desc,
                                               state_desc_prefix='.. note:: ')
 
@@ -289,8 +289,8 @@ def overrides(interface_class):
     """
     def overrider(method):
         if method.__name__ not in dir(interface_class):
-            raise OverrideError(f'{method.__name__} is not present in parent '
-                                f'class: {interface_class.__name__}.')
+            raise OverrideError(f'{method.__name__} is not present in parent \
+                                class: {interface_class.__name__}.')
         backup = classproperty.__get__
         classproperty.__get__ = lambda x, y, z: x
         if method.__doc__ is None:
@@ -342,8 +342,6 @@ class classonlymethod(classmethod):
 
     def __get__(self, obj, cls=None):
         if obj is not None:
-            raise TypeError('Class-only method called on an instance. Use'
-                            f' {cls.__name__}.{self.__func__.__name__} '
-                            'instead.')
-
+            raise TypeError(f'Class-only method called on an instance. Use \
+                            {cls.__name__}.{self.__func__.__name__} instead.')
         return super().__get__(obj, cls)

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -76,8 +76,8 @@ class _state_decorator:
         # the text in this section. This is for consistency with numpydoc
         # formatting of deprecation notices, which are done using the note
         # Sphinx directive.
-        state_desc_lines[0] = f'{' ' * docstring_content_indentation}'\
-                              f'{state_desc_prefix}{state_desc_lines[0]}'
+        state_desc_lines[0] = (f'{' ' * docstring_content_indentation}\
+                               {state_desc_prefix}{state_desc_lines[0]}')
         header_spaces = ' ' * (docstring_content_indentation +
                                len_state_desc_prefix)
         for i, line in enumerate(state_desc_lines[1:], 1):

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -244,8 +244,8 @@ class deprecated(_state_decorator):
         self.reason = kwargs['reason']
 
     def __call__(self, func, *args, **kwargs):
-        state_desc = (f'Deprecated as of {self.as_of} for removal in \
-                      {self.until}. {self.reason}')
+        state_desc = (f'Deprecated as of {self.as_of} for removal in '
+                      f'{self.until}. {self.reason}')
         func.__doc__ = self._update_docstring(func.__doc__, state_desc,
                                               state_desc_prefix='.. note:: ')
 

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -60,7 +60,7 @@ class _state_decorator:
                           state_desc_prefix='State: '):
         # Hande the case of no initial docstring
         if docstring is None:
-            return "%s%s" % (state_desc_prefix, state_desc)
+            return f'{state_desc_prefix}{state_desc}'
 
         docstring_lines = docstring.split('\n')
         docstring_content_indentation = \
@@ -76,13 +76,12 @@ class _state_decorator:
         # the text in this section. This is for consistency with numpydoc
         # formatting of deprecation notices, which are done using the note
         # Sphinx directive.
-        state_desc_lines[0] = '%s%s%s' % (' ' * docstring_content_indentation,
-                                          state_desc_prefix,
-                                          state_desc_lines[0])
+        state_desc_lines[0] = f'{' ' * docstring_content_indentation}\
+                                {state_desc_prefix}{state_desc_lines[0]}'
         header_spaces = ' ' * (docstring_content_indentation +
                                len_state_desc_prefix)
         for i, line in enumerate(state_desc_lines[1:], 1):
-            state_desc_lines[i] = '%s%s' % (header_spaces, line)
+            state_desc_lines[i] = f'{header_spaces}{line}'
 
         new_doc_lines = '\n'.join(state_desc_lines)
         docstring_lines[0] = '%s\n\n%s' % (docstring_lines[0], new_doc_lines)

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -76,7 +76,7 @@ class _state_decorator:
         # the text in this section. This is for consistency with numpydoc
         # formatting of deprecation notices, which are done using the note
         # Sphinx directive.
-        state_desc_lines[0] = (f'{' ' * docstring_content_indentation}\
+        state_desc_lines[0] = (f'{" " * docstring_content_indentation}\
                                {state_desc_prefix}{state_desc_lines[0]}')
         header_spaces = ' ' * (docstring_content_indentation +
                                len_state_desc_prefix)

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -76,8 +76,8 @@ class _state_decorator:
         # the text in this section. This is for consistency with numpydoc
         # formatting of deprecation notices, which are done using the note
         # Sphinx directive.
-        state_desc_lines[0] = (f'{" " * docstring_content_indentation}\
-                               {state_desc_prefix}{state_desc_lines[0]}')
+        state_desc_lines[0] = (f'{" " * docstring_content_indentation}'
+                               f'{state_desc_prefix}{state_desc_lines[0]}')
         header_spaces = ' ' * (docstring_content_indentation +
                                len_state_desc_prefix)
         for i, line in enumerate(state_desc_lines[1:], 1):

--- a/skbio/util/_decorator.py
+++ b/skbio/util/_decorator.py
@@ -90,8 +90,8 @@ class _state_decorator:
     def _validate_kwargs(self, **kwargs):
         for required_kwarg in self._required_kwargs:
             if required_kwarg not in kwargs:
-                raise ValueError(f'{self.__class__} decorator requires \
-                                 parameter: {required_kwarg}')
+                raise ValueError(f'{self.__class__} decorator requires '
+                                 f'parameter: {required_kwarg}')
 
 
 class stable(_state_decorator):
@@ -289,8 +289,8 @@ def overrides(interface_class):
     """
     def overrider(method):
         if method.__name__ not in dir(interface_class):
-            raise OverrideError(f'{method.__name__} is not present in parent \
-                                class: {interface_class.__name__}.')
+            raise OverrideError(f'{method.__name__} is not present in parent '
+                                f'class: {interface_class.__name__}.')
         backup = classproperty.__get__
         classproperty.__get__ = lambda x, y, z: x
         if method.__doc__ is None:
@@ -342,6 +342,7 @@ class classonlymethod(classmethod):
 
     def __get__(self, obj, cls=None):
         if obj is not None:
-            raise TypeError(f'Class-only method called on an instance. Use \
-                            {cls.__name__}.{self.__func__.__name__} instead.')
+            raise TypeError(f'Class-only method called on an instance. Use '
+                            f'{cls.__name__}.{self.__func__.__name__} '
+                            'instead.')
         return super().__get__(obj, cls)


### PR DESCRIPTION
This PR updated the string formatting of the `_state_decorator` class from modulo based formatting to more current f-string formatting. This is the beginning of what will be an ongoing effort to modernize the skbio package. 

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/biocore/scikit-bio/blob/master/.github/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/biocore/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/biocore/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/biocore/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
