### PR TITLE
Replacing HTTPretty with Responses

### DIFF
--- a/ci/requirements.test.txt
+++ b/ci/requirements.test.txt
@@ -1,4 +1,4 @@
 matplotlib
 pytest
-HTTPretty
+responses
 coverage

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -440,8 +440,6 @@ class TestWriteFilepath(WritableBinarySourceTests, WritableSourceTest):
         with io.open(file, mode='rb') as f:
             return f.read()
 
-# need to rewrite the below test using the responses package
-
 
 @unittest.skipIf(not has_responses, "Responses not available to mock tests.")
 class TestReadURL(ReadableBinarySourceTests, ReadableSourceTest):

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -13,10 +13,10 @@ import io
 import os.path
 
 try:
-    import httpretty
-    has_httpretty = True
+    import responses
+    has_responses = True
 except ImportError:
-    has_httpretty = False
+    has_responses = False
 
 import skbio.io
 from skbio.io.registry import open_file
@@ -443,13 +443,13 @@ class TestWriteFilepath(WritableBinarySourceTests, WritableSourceTest):
 # need to rewrite the below test using the responses package
 
 
-@unittest.skipIf(not has_httpretty, "HTTPretty not available to mock tests.")
+@unittest.skipIf(not has_responses, "Responses not available to mock tests.")
 class TestReadURL(ReadableBinarySourceTests, ReadableSourceTest):
     expected_close = True
 
     def setUp(self):
         super(TestReadURL, self).setUp()
-        httpretty.enable()
+        responses.start()
 
         for file in (get_data_path('example_file'),
                      get_data_path('big5_file'),
@@ -459,13 +459,14 @@ class TestReadURL(ReadableBinarySourceTests, ReadableSourceTest):
                      get_data_path('big5_file.bz2')):
 
             with io.open(file, mode='rb') as f:
-                httpretty.register_uri(httpretty.GET, self.get_fileobj(file),
-                                       body=f.read(),
-                                       content_type="application/octet-stream")
+                responses.add(responses.GET, self.get_fileobj(file),
+                              body=f.read(),
+                              content_type="application/octet-stream")
 
     def tearDown(self):
         super(TestReadURL, self).setUp()
-        httpretty.disable()
+        responses.stop()
+        responses.reset()
 
     def get_fileobj(self, path):
         return "http://example.com/" + os.path.split(path)[1]

--- a/skbio/io/tests/test_util.py
+++ b/skbio/io/tests/test_util.py
@@ -440,6 +440,8 @@ class TestWriteFilepath(WritableBinarySourceTests, WritableSourceTest):
         with io.open(file, mode='rb') as f:
             return f.read()
 
+# need to rewrite the below test using the responses package
+
 
 @unittest.skipIf(not has_httpretty, "HTTPretty not available to mock tests.")
 class TestReadURL(ReadableBinarySourceTests, ReadableSourceTest):


### PR DESCRIPTION
From issue #1919. This PR replaces [HTTPretty](https://github.com/gabrielfalcao/HTTPretty) with [Responses](https://github.com/getsentry/responses) in our unit tests. Responses is a more modern and actively developed package for mocking out the Python Requests library. 

Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/scikit-bio/scikit-bio/blob/master/.github/CONTRIBUTING.md).

* [ ] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/scikit-bio/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/scikit-bio/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
