### PR TITLE
Fix TabularMSALoc slicing on Python 3.12 and change documentation for skbio.io.format.stockholm to be independent of OrderedDict repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Safely handle `Sequence.iter_kmers` where `k` is greater than the sequence length ([#1723](https://github.com/scikit-bio/scikit-bio/issues/1723))
 * Re-enabled OpenMP support, which has been mistakenly disabled in 0.5.8  ([#1874](https://github.com/scikit-bio/scikit-bio/pull/1874))
 * `permanova` and `permdist` operate on a `DistanceMatrix` and a grouping object. Element IDs must be synchronized to compare correct sets of pairwise distances. This failed in case the grouping was provided as a `pandas.Series`, because it was interpreted as an ordered `list` and indices were ignored (see issue [#1877](https://github.com/scikit-bio/scikit-bio/issues/1877) for an example). Note: `pandas.DataFrame` was handled correctly. This behavior has been fixed with PR [#1879](https://github.com/scikit-bio/scikit-bio/pull/1879)
+* Fixed slicing for `TabularMSALoc` on Python 3.12. See issue [#1926](https://github.com/scikit-bio/scikit-bio/issues/1926).
 
 ### Miscellaneous
 

--- a/skbio/alignment/_indexing.py
+++ b/skbio/alignment/_indexing.py
@@ -168,7 +168,8 @@ class TabularMSALoc(_Indexing):
                     complete_key = (len(indexable) == len(index.levshape) and
                                     indexable in index)
                 partial_key = not complete_key and indexable in index
-            except (TypeError, pd.errors.InvalidIndexError):  # Unhashable type, no biggie
+            except (TypeError,
+                    pd.errors.InvalidIndexError):  # Unhashable type, no biggie
                 pass
         if index.has_duplicates:
             # for a given Index object index,

--- a/skbio/alignment/_indexing.py
+++ b/skbio/alignment/_indexing.py
@@ -168,7 +168,7 @@ class TabularMSALoc(_Indexing):
                     complete_key = (len(indexable) == len(index.levshape) and
                                     indexable in index)
                 partial_key = not complete_key and indexable in index
-            except TypeError:  # Unhashable type, no biggie
+            except (TypeError, pd.errors.InvalidIndexError):  # Unhashable type, no biggie
                 pass
         if index.has_duplicates:
             # for a given Index object index,

--- a/skbio/io/format/stockholm.py
+++ b/skbio/io/format/stockholm.py
@@ -323,9 +323,9 @@ Index(['O83071/192-246', 'O83071/259-312', 'O31698/18-71', 'O31698/88-139',
 
 The ``TabularMSA`` has GF metadata stored in its ``metadata`` dictionary:
 
->>> msa.metadata
-OrderedDict([('CC', 'CBS domains are small intracellular modules mostly found \
-in 2 or four copies within a protein.')])
+>>> list(msa.metadata.items())
+[('CC', 'CBS domains are small intracellular modules mostly found in 2 or \
+four copies within a protein.')]
 
 GC metadata is stored in the ``TabularMSA`` ``positional_metadata``:
 
@@ -345,8 +345,8 @@ GC metadata is stored in the ``TabularMSA`` ``positional_metadata``:
 
 GS metadata is stored in the sequence-specific ``metadata`` dictionary:
 
->>> msa[0].metadata
-OrderedDict([('AC', 'O83071')])
+>>> list(msa[0].metadata.items())
+[('AC', 'O83071')]
 
 GR metadata is stored in sequence-specific ``positional_metadata``:
 


### PR DESCRIPTION
Since `slice` objects are hashable in Python 3.12, `pd.MultiIndex` no longer raises a `TypeError` when its `__contains__` method is called with a `slice` object. Instead, Pandas checks whether the argument is a `slice` and raises an `InvalidIndexError` instead. This change catches such errors in addition to `TypeError` to fix slicing for `TabularMSALoc`.

Python 3.12 also changes the `repr` for `OrderedDict`. This change revises the docstring for skbio.io.format.stockholm to display `OrderedDict` objects as lists of items so that we get the same results on Python 3.12 as we do on earlier versions of Python.

fixes #1926 

---
Please complete the following checklist:

* [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/scikit-bio/scikit-bio/blob/master/.github/CONTRIBUTING.md).

* [x] I have documented all public-facing changes in [CHANGELOG.md](https://github.com/scikit-bio/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied. **It is your responsibility to disclose code, documentation, or other content derived from external source(s).** If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] **This pull request does not include code, documentation, or other content derived from external source(s).**

**Note:** [REVIEWING.md](https://github.com/scikit-bio/scikit-bio/blob/master/REVIEWING.md) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
