### PR TITLE
Add run --all-files option to pre-commit documentation

### DIFF
--- a/web/contribute.rst
+++ b/web/contribute.rst
@@ -220,6 +220,10 @@ Scikit-bio streamlines the installation process by including Ruff's linter and f
 
 Once installed, the pre-commit hooks will automatically execute every time you commit changes. By default, they enforce Ruff's formatter and linter rules, ensuring code consistency and adherence to standards.
 
+If you have made commits prior to the installation of Ruff and pre-commit, you will need to run the pre-commit hook on all files as illustrated `here <https://pre-commit.com/#4-optional-run-against-all-the-files>`_. To run the pre-commit hook on all files run::
+
+    pre-commit run --all-files
+
 Make necessary changes and commit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds documentation regarding running Ruff and pre-commit if changes have been made before their installation.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
