### PR TITLE
WIP: Sequence character conversion

### DIFF
--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -749,6 +749,34 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
 
         return re.compile(regex_string)
 
+    def to_definites(self, degenerate="wild", char=None):
+        """Convert degenerate or non-canonical characters to definite characters."""
+        sequence = str(self)
+        # print(f"original sequence: {sequence}")
+        # print(len(sequence))
+
+        if degenerate == "wild":
+            for degenerate_char in self.degenerate_chars:
+                sequence = sequence.replace(
+                    degenerate_char, "".join(self.wildcard_char)
+                )
+        elif degenerate == "gap":
+            for degenerate_char in self.degenerate_chars:
+                sequence = sequence.replace(
+                    degenerate_char, "".join(self.default_gap_char)
+                )
+        elif degenerate == "char":
+            for degenerate_char in self.degenerate_chars:
+                sequence = sequence.replace(degenerate_char, "".join(char))
+        # print(f"modified sequence: {sequence}")
+        # print(len(sequence))
+
+        return self._constructor(
+            sequence=sequence,
+            metadata=self.metadata,
+            positional_metadata=self.positional_metadata,
+        )
+
     @stable(as_of="0.4.0")
     def find_motifs(self, motif_type, min_length=1, ignore=None):
         """Search the biological sequence for motifs.

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -750,32 +750,48 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         return re.compile(regex_string)
 
     def to_definites(self, degenerate="wild", char=None):
-        """Convert degenerate or non-canonical characters to definite characters."""
+        """Convert degenerate or non-canonical characters to definite characters.
+
+        Parameters
+        ----------
+        degenerate : {"wild", "gap", "char", "trim", "raise"}
+            "wild" replace degenerate characters with wildcard characters.
+            "gap" replace degenerate characters with default gap characters.
+            "char" replace degenerate characters with user-defined character.
+            "trim" remove degenerate characters.
+            "raise" raise an error.
+        char : str
+            String object to replace degenerate characters.
+
+        Returns
+        -------
+        GrammaredSequence
+            Definite version of the sequence
+
+        """
         sequence = str(self)
-        # print(f"original sequence: {sequence}")
-        # print(len(sequence))
+        degenerates = self.degenerate_chars
 
         if degenerate == "wild":
-            for degenerate_char in self.degenerate_chars:
+            for degenerate_char in degenerates:
                 sequence = sequence.replace(
                     degenerate_char, "".join(self.wildcard_char)
                 )
         elif degenerate == "gap":
-            for degenerate_char in self.degenerate_chars:
+            for degenerate_char in degenerates:
                 sequence = sequence.replace(
                     degenerate_char, "".join(self.default_gap_char)
                 )
         elif degenerate == "char":
-            for degenerate_char in self.degenerate_chars:
+            for degenerate_char in degenerates:
                 sequence = sequence.replace(degenerate_char, "".join(char))
-        # print(f"modified sequence: {sequence}")
-        # print(len(sequence))
+        elif degenerate == "trim":
+            for degenerate_char in degenerates:
+                sequence = sequence.replace(degenerate_char, "")
+        # elif degenerate == "raise":
+        # raise an error?
 
-        return self._constructor(
-            sequence=sequence,
-            metadata=self.metadata,
-            positional_metadata=self.positional_metadata,
-        )
+        return self._constructor(sequence=sequence)
 
     @stable(as_of="0.4.0")
     def find_motifs(self, motif_type, min_length=1, ignore=None):

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -286,6 +286,18 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         raise NotImplementedError
 
+    @classproperty
+    def non_canonical_chars(cls):
+        """Return non-canonical characters.
+
+        Returns
+        -------
+        set
+            Non-canonical characters.
+
+        """
+        return set()
+
     @abstractproperty
     @classproperty
     @stable(as_of="0.4.0")
@@ -749,7 +761,7 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
 
         return re.compile(regex_string)
 
-    def to_definites(self, degenerate="wild", char=None):
+    def to_definites(self, degenerate="wild", char=None, canonical=True):
         """Convert degenerate or non-canonical characters to definite characters.
 
         Parameters
@@ -762,15 +774,22 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
             "raise" raise an error.
         char : str
             String object to replace degenerate characters.
+        canonical : bool
+            If True, non-canonical amino acids are included in the set of
+            degenerate characters.
 
         Returns
         -------
         GrammaredSequence
-            Definite version of the sequence
+            Definite version of the sequence.
 
         """
         sequence = str(self)
-        degenerates = self.degenerate_chars
+
+        if canonical:
+            degenerates = self.degenerate_chars.union(self.non_canonical_chars)
+        else:
+            degenerates = self.degenerate_chars
 
         if degenerate == "wild":
             for degenerate_char in degenerates:

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -187,6 +187,11 @@ class Protein(GrammaredSequence):
 
     @classproperty
     @overrides(GrammaredSequence)
+    def canonical_chars(cls):
+        return set("ACDEFGHIKLMNPQRSTVWY")
+
+    @classproperty
+    @overrides(GrammaredSequence)
     def degenerate_map(cls):
         return {
             "B": set("DN"),

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -187,8 +187,8 @@ class Protein(GrammaredSequence):
 
     @classproperty
     @overrides(GrammaredSequence)
-    def canonical_chars(cls):
-        return set("ACDEFGHIKLMNPQRSTVWY")
+    def non_canonical_chars(cls):
+        return set("OU")
 
     @classproperty
     @overrides(GrammaredSequence)


### PR DESCRIPTION
This function will enable conversion of non-canonical or degenerate characters to characters of the user's choosing. Options for replacement include:

- wildcard:  replace the degenerate/non-canonical characters with 'N' or 'X'
- gap:  replace with gap character
- char:  replace with a single letter string
- trim:  remove all degenerate/non-canonical characters
- raise:  raise an error

This function is a step in the direction of tokenization support for language models, as outlined in issue #1920. The rationale is that skbio needs to be able to convert sequences into alphabets which match those used by the language models. For instance, [ProTrans](https://huggingface.co/Rostlab/prot_t5_xl_uniref50) converted the amino acids `['B', 'U', 'Z', 'O']` to `'X'` prior to tokenization.

@qiyunzhu The docstring needs work, and I'll need to write a unittest, update the `CHANGELOG.md`, and finish the 'raise' option, but what are your thoughts as it is?

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/master/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/master/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
