### PR TITLE
Fix text formatting for tables in sequence subpackages

### DIFF
--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -61,13 +61,13 @@ class DNA(GrammaredSequence, NucleotideMixin):
     +-----+-----------+
     |Code |Nucleobase |
     +=====+===========+
-    |`A`  |Adenine    |
+    |``A``|Adenine    |
     +-----+-----------+
-    |`C`  |Cytosine   |
+    |``C``|Cytosine   |
     +-----+-----------+
-    |`G`  |Guanine    |
+    |``G``|Guanine    |
     +-----+-----------+
-    |`T`  |Thymine    |
+    |``T``|Thymine    |
     +-----+-----------+
 
     And the following 11 degenerate characters, each of which representing 2-4
@@ -76,33 +76,33 @@ class DNA(GrammaredSequence, NucleotideMixin):
     +-----+-------------+-----------+
     |Code |Nucleobases  |Meaning    |
     +=====+=============+===========+
-    |`R`  |A or G       |Purine     |
+    |``R``|A or G       |Purine     |
     +-----+-------------+-----------+
-    |`Y`  |C or T       |Pyrimidine |
+    |``Y``|C or T       |Pyrimidine |
     +-----+-------------+-----------+
-    |`S`  |G or C       |Strong     |
+    |``S``|G or C       |Strong     |
     +-----+-------------+-----------+
-    |`W`  |A or T       |Weak       |
+    |``W``|A or T       |Weak       |
     +-----+-------------+-----------+
-    |`K`  |G or T       |Keto       |
+    |``K``|G or T       |Keto       |
     +-----+-------------+-----------+
-    |`M`  |A or C       |Amino      |
+    |``M``|A or C       |Amino      |
     +-----+-------------+-----------+
-    |`B`  |C, G or T    |Not A      |
+    |``B``|C, G or T    |Not A      |
     +-----+-------------+-----------+
-    |`D`  |A, G or T    |Not C      |
+    |``D``|A, G or T    |Not C      |
     +-----+-------------+-----------+
-    |`H`  |A, C or T    |Not G      |
+    |``H``|A, C or T    |Not G      |
     +-----+-------------+-----------+
-    |`V`  |A, C or G    |Not T      |
+    |``V``|A, C or G    |Not T      |
     +-----+-------------+-----------+
-    |`N`  |A, C, G or T |Any        |
+    |``N``|A, C, G or T |Any        |
     +-----+-------------+-----------+
 
-    Plus two gap characters: `-` and `.`.
+    Plus two gap characters: ``-`` and ``.``.
 
     Characters other than the above 17 are not allowed. If you intend to use
-    additional characters to represent non-canonical nucleobases, such as `I`
+    additional characters to represent non-canonical nucleobases, such as ``I``
     (Inosine), you may create a custom alphabet using ``GrammaredSequence``.
     Directly modifying the alphabet of ``DNA`` may break methods that rely on
     the IUPAC alphabet.

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -59,45 +59,45 @@ class Protein(GrammaredSequence):
     +-----+---------+--------------+
     |Code |3-letter |Amino acid    |
     +=====+=========+==============+
-    |`A`  |Ala      |Alanine       |
+    |``A``|Ala      |Alanine       |
     +-----+---------+--------------+
-    |`C`  |Cys      |Cysteine      |
+    |``C``|Cys      |Cysteine      |
     +-----+---------+--------------+
-    |`D`  |Asp      |Aspartic acid |
+    |``D``|Asp      |Aspartic acid |
     +-----+---------+--------------+
-    |`E`  |Glu      |Glutamic acid |
+    |``E``|Glu      |Glutamic acid |
     +-----+---------+--------------+
-    |`F`  |Phe      |Phenylalanine |
+    |``F``|Phe      |Phenylalanine |
     +-----+---------+--------------+
-    |`G`  |Gly      |Glycine       |
+    |``G``|Gly      |Glycine       |
     +-----+---------+--------------+
-    |`H`  |His      |Histidine     |
+    |``H``|His      |Histidine     |
     +-----+---------+--------------+
-    |`I`  |Ile      |Isoleucine    |
+    |``I``|Ile      |Isoleucine    |
     +-----+---------+--------------+
-    |`K`  |Lys      |Lysine        |
+    |``K``|Lys      |Lysine        |
     +-----+---------+--------------+
-    |`L`  |Leu      |Leucine       |
+    |``L``|Leu      |Leucine       |
     +-----+---------+--------------+
-    |`M`  |Met      |Methionine    |
+    |``M``|Met      |Methionine    |
     +-----+---------+--------------+
-    |`N`  |Asn      |Asparagine    |
+    |``N``|Asn      |Asparagine    |
     +-----+---------+--------------+
-    |`P`  |Pro      |Proline       |
+    |``P``|Pro      |Proline       |
     +-----+---------+--------------+
-    |`Q`  |Gln      |Glutamine     |
+    |``Q``|Gln      |Glutamine     |
     +-----+---------+--------------+
-    |`R`  |Arg      |Arginine      |
+    |``R``|Arg      |Arginine      |
     +-----+---------+--------------+
-    |`S`  |Ser      |Serine        |
+    |``S``|Ser      |Serine        |
     +-----+---------+--------------+
-    |`T`  |Thr      |Threonine     |
+    |``T``|Thr      |Threonine     |
     +-----+---------+--------------+
-    |`V`  |Val      |Valine        |
+    |``V``|Val      |Valine        |
     +-----+---------+--------------+
-    |`W`  |Trp      |Tryptophan    |
+    |``W``|Trp      |Tryptophan    |
     +-----+---------+--------------+
-    |`Y`  |Tyr      |Tyrosine      |
+    |``Y``|Tyr      |Tyrosine      |
     +-----+---------+--------------+
 
     And the following four degenerate characters, each of which representing
@@ -106,27 +106,27 @@ class Protein(GrammaredSequence):
     +-----+---------+------------+
     |Code |3-letter |Amino acids |
     +=====+=========+============+
-    |`B`  |Asx      |D or N      |
+    |``B``|Asx      |D or N      |
     +-----+---------+------------+
-    |`Z`  |Glx      |E or Q      |
+    |``Z``|Glx      |E or Q      |
     +-----+---------+------------+
-    |`J`  |Xle      |I or L      |
+    |``J``|Xle      |I or L      |
     +-----+---------+------------+
-    |`X`  |Xaa      |All 20      |
+    |``X``|Xaa      |All 20      |
     +-----+---------+------------+
 
-    Plus one stop character: `*` (Ter), and two gap characters: `-` and `.`.
+    Plus one stop character: ``*`` (Ter), and two gap characters: ``-`` and ``.``.
 
     Characters other than the above 27 are not allowed. If you intend to use
-    additional characters to represent non-canonical amino acids, such as `U`
-    (Sec, Selenocysteine) and `O` (Pyl, Pyrrolysine), you may create a custom
+    additional characters to represent non-canonical amino acids, such as ``U``
+    (Sec, Selenocysteine) and ``O`` (Pyl, Pyrrolysine), you may create a custom
     alphabet using ``GrammaredSequence``. Directly modifying the alphabet of
     ``Protein`` may break functions that rely on the IUPAC alphabet.
 
     It should be noted that some functions do not support certain characters.
-    For example, the BLOSUM and PAM substitution matrices do not support `J`
+    For example, the BLOSUM and PAM substitution matrices do not support ``J``
     (Xle). In such circumstances, unsupported characters will be replaced with
-    `X` to represent any of the canonical amino acids.
+    ``X`` to represent any of the canonical amino acids.
 
     References
     ----------

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -60,19 +60,19 @@ class RNA(GrammaredSequence, NucleotideMixin):
     +-----+-----------+
     |Code |Nucleobase |
     +=====+===========+
-    |`A`  |Adenine    |
+    |``A``|Adenine    |
     +-----+-----------+
-    |`C`  |Cytosine   |
+    |``C``|Cytosine   |
     +-----+-----------+
-    |`G`  |Guanine    |
+    |``G``|Guanine    |
     +-----+-----------+
-    |`U`  |Uracil     |
+    |``U``|Uracil     |
     +-----+-----------+
 
-    Plus 11 degenerate characters: `R`, `Y`, `S`, `W`, `K`, `M`, `B`, `D`, `H`,
-    `V` and `N`, and two gap characters: `-` and `.`. The definitions of
-    degenerate characters are provided in ``DNA``, in which `T` should be
-    replaced with `U` for RNA sequences.
+    Plus 11 degenerate characters: ``R``, ``Y``, ``S``, ``W``, ``K``, ``M``, ``B``,
+    ``D``, ``H``, ``V`` and ``N``, and two gap characters: ``-`` and ``.``. The
+    definitions of degenerate characters are provided in ``DNA``, in which ``T`` should
+    be replaced with ``U`` for RNA sequences.
 
     Characters other than the above 17 are not allowed. To include additional
     characters, you may create a custom alphabet using ``GrammaredSequence``.


### PR DESCRIPTION
Fixes text formatting issues in `Sequence` subpackages.

This:
<img width="466" alt="Screenshot 2024-02-26 121659" src="https://github.com/scikit-bio/scikit-bio/assets/62309966/1036721e-34df-47e9-a257-7887330f1a2e">


Becomes this:
<img width="466" alt="Screenshot 2024-02-26 133046" src="https://github.com/scikit-bio/scikit-bio/assets/62309966/57477006-14d4-4387-8783-1d20807b555e">


Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
