### PR TITLE
Deprecated "OTU" in favor of "taxon"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 ### Miscellaneous
 
+* Replaced the historical term "OTU" with the more generic term "taxon" (plural: "taxa"). As a consequence, the parameter "otu_ids" in phylogenetic alpha and beta diversity metrics was replaced by "taxa". Meanwhile,
+the old parameter "otu_ids" is still kept as an alias of "taxa" for backward compatibility. However it will be removed in a future release.
 * Revised contributor's guidelines.
 * Enabled code coverage reporting via Codecov. See [#1954](https://github.com/scikit-bio/scikit-bio/pull/1954).
 * Renamed the default branch from "master" to "main". See [#1953](https://github.com/scikit-bio/scikit-bio/pull/1953).

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -42,7 +42,7 @@ individual organism's genome.
    unit (OTU), a historically important term in microbiome research. However,
    as the field advances and the research targets diverge (e.g., amplicon
    sequence variant, or ASV), a more generic term such as "taxon" becomes more
-   appropriate. Therefore, the term OTU was replaced by taxon since scikit-bio
+   appropriate. Therefore, the term OTU was replaced by taxon in scikit-bio
    0.6.0.
 
 Each frequency in a given vector represents the number of individuals observed

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -36,11 +36,14 @@ these could represent all 16S rRNA gene sequences from a single oral swab. In
 a comparative genomics study on the other hand, a sample could represent an
 individual organism's genome.
 
-.. note:: Previous versions of scikit-bio referred to taxon as OTU (operational
-taxonomic unit), a historically important term in microbiome research. However,
-as the field advances and the research targets diverge (e.g., amplicon sequence
-variant, or ASV), a more generic term such as "taxon" becomes more appropriate.
-Therefore, the term OTU was replaced by taxon since scikit-bio 0.6.0.
+.. note::
+
+   Previous versions of scikit-bio referred to taxon as operational taxonomic
+   unit (OTU), a historically important term in microbiome research. However,
+   as the field advances and the research targets diverge (e.g., amplicon
+   sequence variant, or ASV), a more generic term such as "taxon" becomes more
+   appropriate. Therefore, the term OTU was replaced by taxon since scikit-bio
+   0.6.0.
 
 Each frequency in a given vector represents the number of individuals observed
 for a particular taxon. We will refer to the frequencies associated with a

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -18,32 +18,45 @@ The driver functions, ``skbio.diversity.alpha_diversity`` and
 ``skbio.diversity.beta_diversity``, are designed to compute alpha diversity for
 one or more samples, or beta diversity for one or more pairs of samples. The
 diversity driver functions accept a matrix containing vectors of frequencies of
-OTUs within each sample.
+taxa within each sample.
 
-We use the term "OTU" here very loosely, as these can in practice represent
-diverse feature types including bacterial species, genes, and metabolites. The
-term "sample" is also loosely defined for these purposes. These are intended to
-represent a single unit of sampling, and as such what a single sample
-represents can vary widely. For example, in a microbiome survey, these could
-represent all 16S rRNA gene sequences from a single oral swab. In a comparative
-genomics study on the other hand, a sample could represent an individual
-organism's genome.
+The term "taxon" (plural: "taxa") describes a group of biologically related
+organisms that constitute a unit in the community. Taxa are usually defined at
+a uniform taxonomic rank, such as species, genus or family. In community
+ecology, taxon is usually referred to as "species" (singular = plural), but its
+definition is not limited to species as a taxonomic rank. The term "taxonomic
+group" is a synonym of taxon in many situations.
+
+In scikit-bio, the term "taxon/taxa" is used very loosely, as these can in
+practice represent diverse feature types including organisms, genes, and
+metabolites. The term "sample" is also loosely defined for these purposes.
+These are intended to represent a single unit of sampling, and as such what a
+single sample represents can vary widely. For example, in a microbiome survey,
+these could represent all 16S rRNA gene sequences from a single oral swab. In
+a comparative genomics study on the other hand, a sample could represent an
+individual organism's genome.
+
+.. note:: Previous versions of scikit-bio referred to taxon as OTU (operational
+taxonomic unit), a historically important term in microbiome research. However,
+as the field advances and the research targets diverge (e.g., amplicon sequence
+variant, or ASV), a more generic term such as "taxon" becomes more appropriate.
+Therefore, the term OTU was replaced by taxon since scikit-bio 0.6.0.
 
 Each frequency in a given vector represents the number of individuals observed
-for a particular OTU. We will refer to the frequencies associated with a single
-sample as a *counts vector* or ``counts`` throughout the documentation. Counts
-vectors are `array_like`: anything that can be converted into a 1-D numpy array
-is acceptable input. For example, you can provide a numpy array or a native
-Python list and the results will be identical. As mentioned above, the driver
-functions accept one or more of these vectors (representing one or more
+for a particular taxon. We will refer to the frequencies associated with a
+single sample as a *counts vector* or ``counts`` throughout the documentation.
+Counts vectors are `array_like`: anything that can be converted into a 1-D
+numpy array is acceptable input. For example, you can provide a numpy array or
+a native Python list and the results will be identical. As mentioned above, the
+driver functions accept one or more of these vectors (representing one or more
 samples) in a matrix which is also `array_like`. Each row in the matrix
 represents a single sample's count vector, so that rows represent samples and
-columns represent OTUs.
+columns represent taxa.
 
-Some diversity metrics incorporate relationships between the OTUs in their
+Some diversity metrics incorporate relationships between the taxa in their
 computation through reference to a phylogenetic tree. These metrics
-additionally take a ``skbio.TreeNode`` object and a list of OTU identifiers
-mapping the values in the counts vector to tips in the tree.
+additionally take a ``skbio.TreeNode`` object and a list of taxa mapping the
+values in the counts vector to tips in the tree.
 
 The driver functions are optimized so that computing a diversity metric more
 than one time (i.e., for more than one sample for alpha diversity metrics, or
@@ -77,13 +90,13 @@ validation, users should be confident that these conditions are met.
 Additionally, if a phylogenetic diversity metric is being computed, the
 following conditions are also confirmed:
 
-* the provided OTU identifiers are all unique
-* the length of each counts vector is equal to the number of OTU identifiers
+* the provided taxa are all unique
+* the length of each counts vector is equal to the number of taxa
 * the provided tree is rooted
 * the tree has more than one node
 * all nodes in the provided tree except for the root node have branch lengths
 * all tip names in the provided tree are unique
-* all provided OTU identifiers correspond to tip names in the provided tree
+* all provided taxa correspond to tip names in the provided tree
 
 Count vectors
 -------------
@@ -91,24 +104,24 @@ Count vectors
 There are different ways that count vectors are represented in the ecological
 literature and in related software. The diversity measures provided here
 *always* assume that the input contains abundance data: each count represents
-the number of individuals observed for a particular OTU in the sample. For
-example, if you have two OTUs, where three individuals were observed from the
-first OTU and only a single individual was observed from the second OTU, you
-could represent this data in the following forms (among others).
+the number of individuals observed for a particular taxon in the sample. For
+example, if you have two taxa, where three individuals were observed from the
+first taxon and only a single individual was observed from the second taxon,
+you could represent this data in the following forms (among others).
 
 As a vector of counts. This is the expected type of input for the diversity
-measures in this module. There are 3 individuals from the OTU at index 0, and 1
-individual from the OTU at index 1:
+measures in this module. There are 3 individuals from the taxon at index 0,
+and 1 individual from the taxon at index 1:
 
 >>> counts = [3, 1]
 
-As a vector of indices. The OTU at index 0 is observed 3 times, while the
-OTU at index 1 is observed 1 time:
+As a vector of indices. The taxon at index 0 is observed 3 times, while the
+taxon at index 1 is observed 1 time:
 
 >>> indices = [0, 0, 0, 1]
 
-As a vector of frequencies. We have 1 OTU that is a singleton and 1 OTU that
-is a tripleton. We do not have any 0-tons or doubletons:
+As a vector of frequencies. We have 1 taxon that is a singleton and 1 taxon
+that is a tripleton. We do not have any 0-tons or doubletons:
 
 >>> frequencies = [0, 1, 0, 1]
 
@@ -168,7 +181,7 @@ Functions
 
 Examples
 --------
-Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
+Create a matrix containing 6 samples (rows) and 7 taxa (columns):
 
 .. plot::
    :context:
@@ -181,7 +194,7 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
    ...         [0, 0, 25, 35, 0, 19, 0]]
    >>> ids = list('ABCDEF')
 
-   First, we'll compute observed OTUs, an alpha diversity metric, for each
+   First, we'll compute :math:`S_{obs}`, an alpha diversity metric, for each
    sample using the ``alpha_diversity`` driver function:
 
    >>> from skbio.diversity import alpha_diversity
@@ -197,17 +210,17 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
 
    Next we'll compute Faith's PD on the same samples. Since this is a
    phylogenetic diversity metric, we'll first create a tree and an ordered
-   list of OTU identifiers.
+   list of taxa.
 
    >>> from skbio import TreeNode
    >>> from io import StringIO
    >>> tree = TreeNode.read(StringIO(
-   ...                      '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,'
-   ...                      '(OTU4:0.75,(OTU5:0.5,(OTU6:0.5,OTU7:0.5):0.5):'
+   ...                      '(((((U1:0.5,U2:0.5):0.5,U3:1.0):1.0):0.0,'
+   ...                      '(U4:0.75,(U5:0.5,(U6:0.5,U7:0.5):0.5):'
    ...                      '0.5):1.25):0.0)root;'))
-   >>> otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5', 'OTU6', 'OTU7']
+   >>> taxa = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7']
    >>> adiv_faith_pd = alpha_diversity('faith_pd', data, ids=ids,
-   ...                                 otu_ids=otu_ids, tree=tree)
+   ...                                 taxa=taxa, tree=tree)
    >>> adiv_faith_pd
    A    6.75
    B    7.00
@@ -238,11 +251,11 @@ Create a matrix containing 6 samples (rows) and 7 OTUs (columns):
 
    Next, we'll compute weighted UniFrac distances between all pairs of samples.
    Because weighted UniFrac is a phylogenetic beta diversity metric, we'll need
-   to pass the ``skbio.TreeNode`` and list of OTU ids that we created above.
+   to pass the ``skbio.TreeNode`` and list of taxa that we created above.
    Again, these are the same values that were provided to ``alpha_diversity``.
 
    >>> wu_dm = beta_diversity("weighted_unifrac", data, ids, tree=tree,
-   ...                        otu_ids=otu_ids)
+   ...                        taxa=taxa)
    >>> print(wu_dm)
    6x6 distance matrix
    IDs:

--- a/skbio/diversity/_block.py
+++ b/skbio/diversity/_block.py
@@ -74,7 +74,7 @@ def _block_party(counts=None, row_ids=None, col_ids=None, **kwargs):
     ----------
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
-        of OTUs in a given sample.
+        of taxa in a given sample.
     row_ids : 1D np.ndarray of int
         Block row IDs to keep in the counts matrix.
     col_ids : 1D np.ndarray of int
@@ -182,7 +182,7 @@ def _block_compute(**kwargs):
     -----
     This method encapsulates the two expensive operations to perform for each
     block, namely, the "shearing" of the phylogenetic tree to correspond to
-    only the OTUs of interest, and the actual beta diversity calculations.
+    only the taxa of interest, and the actual beta diversity calculations.
 
     Returns
     -------
@@ -264,7 +264,7 @@ def block_beta_diversity(
         callable.
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
-        of OTUs in a given sample.
+        of taxa in a given sample.
     ids : iterable of strs
         Identifiers for each sample in ``counts``.
     validate : bool, optional
@@ -301,7 +301,7 @@ def block_beta_diversity(
     likely the case that `skbio.diversity.beta_diversity` will be faster. The
     original need which motivated the development of this method was processing
     the Earth Microbiome Project [1]_ dataset which at the time spanned over
-    25,000 samples and 7.5 million open reference OTUs.
+    25,000 samples and 7.5 million open reference taxa.
 
     See Also
     --------

--- a/skbio/diversity/_block.py
+++ b/skbio/diversity/_block.py
@@ -88,7 +88,7 @@ def _block_party(counts=None, row_ids=None, col_ids=None, **kwargs):
     -------
     dict
         kwargs that describe the block to compute. A filtered ``counts`` matrix
-        is stored in kwargs. If applicable, a filtered ``tree`` and ``otu_ids``
+        is stored in kwargs. If applicable, a filtered ``tree`` and ``taxa``
         are also stored.
 
     """
@@ -105,9 +105,9 @@ def _block_party(counts=None, row_ids=None, col_ids=None, **kwargs):
     kwargs["counts"] = counts_block
     kwargs["ids"] = ids_to_keep
 
-    if "tree" in kwargs and "otu_ids" in kwargs:
-        kwargs["otu_ids"] = np.asarray(kwargs["otu_ids"])[nonzero_cols]
-        kwargs["tree"] = kwargs["tree"].shear(kwargs["otu_ids"])
+    if "tree" in kwargs and "taxa" in kwargs:
+        kwargs["taxa"] = np.asarray(kwargs["taxa"])[nonzero_cols]
+        kwargs["tree"] = kwargs["tree"].shear(kwargs["taxa"])
 
     return kwargs
 
@@ -159,10 +159,11 @@ def _block_kwargs(**kwargs):
         "counts",
         "ids",
         "tree",
-        "otu_ids",
+        "taxa",
         "metric",
         "id_pairs",
         "validate",
+        "otu_ids",
     }
     for row_ids, col_ids in _generate_id_blocks(kwargs["ids"], kwargs["k"]):
         id_pairs = _pairs_to_compute(row_ids, col_ids)

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -131,7 +131,7 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
         the metric being used.
     counts : 1D or 2D array_like of ints or floats
         Vector or matrix containing count/abundance data. If a matrix, each row
-        should contain counts of OTUs in a given sample.
+        should contain counts of taxa in a given sample.
     ids : iterable of strs, optional
         Identifiers for each sample in ``counts``. By default, samples will be
         assigned integer identifiers in the order that they were provided.
@@ -173,17 +173,17 @@ def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
         counts = _validate_counts_matrix(counts, ids=ids)
 
     if metric == "faith_pd":
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         counts_by_node, branch_lengths = _setup_pd(
-            counts, otu_ids, tree, validate, rooted=True, single_sample=False
+            counts, taxa, tree, validate, rooted=True, single_sample=False
         )
         counts = counts_by_node
         metric = functools.partial(_faith_pd, branch_lengths=branch_lengths, **kwargs)
 
     elif metric == "phydiv":
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         counts_by_node, branch_lengths = _setup_pd(
-            counts, otu_ids, tree, validate, rooted=False, single_sample=False
+            counts, taxa, tree, validate, rooted=False, single_sample=False
         )
         counts = counts_by_node
         if "rooted" not in kwargs:
@@ -225,7 +225,7 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True, **kwarg
         callable.
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
-        of OTUs in a given sample.
+        of taxa in a given sample.
     ids : iterable of strs
         Identifiers for each sample in ``counts``.
     id_pairs : iterable of tuple
@@ -273,18 +273,18 @@ def partial_beta_diversity(metric, counts, ids, id_pairs, validate=True, **kwarg
 
     if metric == "unweighted_unifrac":
         counts = _quantitative_to_qualitative_counts(counts)
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_unweighted_unifrac(
-            counts, otu_ids=otu_ids, tree=tree, validate=validate
+            counts, taxa=taxa, tree=tree, validate=validate
         )
         counts = counts_by_node
     elif metric == "weighted_unifrac":
         # get the value for normalized. if it was not provided, it will fall
         # back to the default value inside of _weighted_unifrac_pdist_f
         normalized = kwargs.pop("normalized", _normalize_weighted_unifrac_by_default)
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_weighted_unifrac(
-            counts, otu_ids=otu_ids, tree=tree, normalized=normalized, validate=validate
+            counts, taxa=taxa, tree=tree, normalized=normalized, validate=validate
         )
         counts = counts_by_node
     elif callable(metric):
@@ -364,7 +364,7 @@ def beta_diversity(
         results in an optimized version of the metric being used.
     counts : 2D array_like of ints or floats or 2D pandas DataFrame
         Matrix containing count/abundance data where each row contains counts
-        of OTUs in a given sample.
+        of taxa in a given sample.
     ids : iterable of strs, optional
         Identifiers for each sample in ``counts``. By default, samples will be
         assigned integer identifiers in the order that they were provided
@@ -425,18 +425,18 @@ def beta_diversity(
 
     if metric == "unweighted_unifrac":
         counts = _quantitative_to_qualitative_counts(counts)
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_unweighted_unifrac(
-            counts, otu_ids=otu_ids, tree=tree, validate=validate
+            counts, taxa=taxa, tree=tree, validate=validate
         )
         counts = counts_by_node
     elif metric == "weighted_unifrac":
         # get the value for normalized. if it was not provided, it will fall
         # back to the default value inside of _weighted_unifrac_pdist_f
         normalized = kwargs.pop("normalized", _normalize_weighted_unifrac_by_default)
-        otu_ids, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
+        taxa, tree, kwargs = _get_phylogenetic_kwargs(counts, **kwargs)
         metric, counts_by_node = _setup_multiple_weighted_unifrac(
-            counts, otu_ids=otu_ids, tree=tree, normalized=normalized, validate=validate
+            counts, taxa=taxa, tree=tree, normalized=normalized, validate=validate
         )
         counts = counts_by_node
     elif metric == "manhattan":

--- a/skbio/diversity/_phylogenetic.pyx
+++ b/skbio/diversity/_phylogenetic.pyx
@@ -166,12 +166,12 @@ def _nodes_by_counts(np.ndarray counts,
     cdef:
         np.ndarray nodes, observed_ids
         np.ndarray[DTYPE_t, ndim=2] count_array, counts_t
-        np.ndarray[DTYPE_t, ndim=1] observed_indices, otus_in_nodes
+        np.ndarray[DTYPE_t, ndim=1] observed_indices, taxa_in_nodes
         Py_ssize_t i, j
         set observed_ids_set
         object n
         dict node_lookup
-        DTYPE_t n_count_vectors, n_count_otus
+        DTYPE_t n_count_vectors, n_count_taxa
 
     nodes = indexed['name']
 
@@ -193,10 +193,10 @@ def _nodes_by_counts(np.ndarray counts,
             node_lookup[n] = i
 
     # determine the positions of the observed IDs in nodes
-    otus_in_nodes = np.zeros(observed_ids.shape[0], dtype=DTYPE)
+    taxa_in_nodes = np.zeros(observed_ids.shape[0], dtype=DTYPE)
     for i in range(observed_ids.shape[0]):
         n = observed_ids[i]
-        otus_in_nodes[i] = node_lookup[n]
+        taxa_in_nodes[i] = node_lookup[n]
 
     # count_array has a row per node (not tip) and a column per env.
     n_count_vectors = counts.shape[0]
@@ -205,10 +205,10 @@ def _nodes_by_counts(np.ndarray counts,
     # populate the counts array with the counts of each observation in each
     # env
     counts_t = counts.transpose()
-    n_count_otus = otus_in_nodes.shape[0]
-    for i in range(n_count_otus):
+    n_count_taxa = taxa_in_nodes.shape[0]
+    for i in range(n_count_taxa):
         for j in range(n_count_vectors):
-            count_array[otus_in_nodes[i], j] = counts_t[observed_indices[i], j]
+            count_array[taxa_in_nodes[i], j] = counts_t[observed_indices[i], j]
 
     child_index = indexed['child_index'].astype(DTYPE, copy=False)
     _traverse_reduce(child_index, count_array)

--- a/skbio/diversity/alpha/_ace.py
+++ b/skbio/diversity/alpha/_ace.py
@@ -23,13 +23,13 @@ def ace(counts, rare_threshold=10):
        S_{ace}=S_{abund}+\frac{S_{rare}}{C_{ace}}+
        \frac{F_1}{C_{ace}}\gamma^2_{ace}
 
-    where :math:`S_{abund}` is the number of abundant OTUs (with more than
+    where :math:`S_{abund}` is the number of abundant taxa (with more than
     `rare_threshold`  individuals) when all samples are pooled,
-    :math:`S_{rare}` is the number of rare OTUs (with less than or equal to
+    :math:`S_{rare}` is the number of rare taxa (with less than or equal to
     `rare_threshold` individuals) when all samples are pooled, :math:`C_{ace}`
     is the sample abundance coverage estimator, :math:`F_1` is the frequency of
     singletons, and :math:`\gamma^2_{ace}` is the estimated coefficient of
-    variation for rare OTUs.
+    variation for rare taxa.
 
     The estimated coefficient of variation is defined as (assuming
     `rare_threshold` is 10, the default):
@@ -45,7 +45,7 @@ def ace(counts, rare_threshold=10):
     counts : 1-D array_like, int
         Vector of counts.
     rare_threshold : int, optional
-        Threshold at which an OTU containing as many or fewer individuals will
+        Threshold at which a taxon containing as many or fewer individuals will
         be considered rare.
 
     Returns
@@ -56,19 +56,19 @@ def ace(counts, rare_threshold=10):
     Raises
     ------
     ValueError
-        If every rare OTU is a singleton.
+        If every rare taxon is a singleton.
 
     Notes
     -----
     ACE was first introduced in [1]_ and [2]_. The implementation here is based
     on the description given in the EstimateS manual [3]_.
 
-    If no rare OTUs exist, returns the number of abundant OTUs. The default
+    If no rare taxa exist, returns the number of abundant taxa. The default
     value of 10 for `rare_threshold` is based on [4]_.
 
-    If `counts` contains zeros, indicating OTUs which are known to exist in the
+    If `counts` contains zeros, indicating taxa which are known to exist in the
     environment but did not appear in the sample, they will be ignored for the
-    purpose of calculating the number of rare OTUs.
+    purpose of calculating the number of rare taxa.
 
     References
     ----------
@@ -86,17 +86,17 @@ def ace(counts, rare_threshold=10):
     """
     counts = _validate_counts_vector(counts)
     freq_counts = np.bincount(counts)
-    s_rare = _otus_rare(freq_counts, rare_threshold)
+    s_rare = _taxa_rare(freq_counts, rare_threshold)
     singles = freq_counts[1]
 
     if singles > 0 and singles == s_rare:
         raise ValueError(
-            "The only rare OTUs are singletons, so the ACE "
+            "The only rare taxa are singletons, so the ACE "
             "metric is undefined. EstimateS suggests using "
             "bias-corrected Chao1 instead."
         )
 
-    s_abun = _otus_abundant(freq_counts, rare_threshold)
+    s_abun = _taxa_abundant(freq_counts, rare_threshold)
     if s_rare == 0:
         return s_abun
 
@@ -113,18 +113,18 @@ def ace(counts, rare_threshold=10):
     return s_abun + (s_rare / c_ace) + ((singles / c_ace) * gamma_ace)
 
 
-def _otus_rare(freq_counts, rare_threshold):
-    """Count number of rare OTUs."""
+def _taxa_rare(freq_counts, rare_threshold):
+    """Count number of rare taxa."""
     return freq_counts[1 : rare_threshold + 1].sum()
 
 
-def _otus_abundant(freq_counts, rare_threshold):
-    """Count number of abundant OTUs."""
+def _taxa_abundant(freq_counts, rare_threshold):
+    """Count number of abundant taxa."""
     return freq_counts[rare_threshold + 1 :].sum()
 
 
 def _number_rare(freq_counts, rare_threshold, gamma=False):
-    """Return number of individuals in rare OTUs.
+    """Return number of individuals in rare taxa.
 
     ``gamma=True`` generates the ``n_rare`` used for the variation coefficient.
 

--- a/skbio/diversity/alpha/_base.py
+++ b/skbio/diversity/alpha/_base.py
@@ -20,15 +20,15 @@ def berger_parker_d(counts):
     r"""Calculate Berger-Parker dominance index.
 
     Berger-Parker dominance index :math:`d` is defined as the fraction of the
-    sample that belongs to the most abundant species:
+    sample that belongs to the most abundant taxon:
 
     .. math::
 
        d = \frac{n_{max}}{N}
 
     where :math:`n_{max}` is the number of individuals in the most abundant
-    species (or any of the most abundant species in the case of ties), and
-    :math:`N` is the total number of individuals in the sample.
+    taxon (or any of the most abundant taxa in the case of ties), and :math:`N`
+    is the total number of individuals in the sample.
 
     Parameters
     ----------
@@ -67,8 +67,8 @@ def brillouin_d(counts):
        H_B = \frac{\ln N!-\sum^s_{i=1}{\ln n_i!}}{N}
 
     where :math:`N` is the total number of individuals in the sample, :math:`s`
-    is the number of species, and :math:`n_i` is the number of individuals in
-    the :math:`i^{\text{th}}` species.
+    is the number of taxa, and :math:`n_i` is the number of individuals in the
+    :math:`i^{\text{th}}` taxon.
 
     Parameters
     ----------
@@ -102,17 +102,17 @@ def dominance(counts):
     r"""Calculate Simpson's dominance index.
 
     Simpson's dominance index, a.k.a. Simpson's :math:`D`, measures the degree
-    of concentration of species composition of a sample. It is defined as
+    of concentration of taxon composition of a sample. It is defined as
 
     .. math::
 
        D = \sum{p_i^2}
 
-    where :math:`p_i` is the proportion of the entire sample that species
+    where :math:`p_i` is the proportion of the entire sample that taxon
     :math:`i` represents.
 
     Simpson's :math:`D` can be interpreted as the probability that two randomly
-    selected individuals belong to the same species. It ranges between 0 and 1.
+    selected individuals belong to the same taxon. It ranges between 0 and 1.
 
     Simpson's :math:`D` is sometimes referred to as "Simpson's index". It
     should be noted that :math:`D` is not a measure of community diversity. It
@@ -156,7 +156,7 @@ def dominance(counts):
 
 @experimental(as_of="0.4.0")
 def doubles(counts):
-    """Calculate number of double-occurrence species (doubletons).
+    """Calculate number of double-occurrence taxa (doubletons).
 
     Parameters
     ----------
@@ -183,8 +183,8 @@ def enspie(counts):
 
        ENS_{pie} = \frac{1}{\sum_{i=1}^s{p_i^2}}
 
-    where :math:`s` is the number of species and :math:`p_i` is the proportion
-    of the sample represented by species :math:`i`.
+    where :math:`s` is the number of taxa and :math:`p_i` is the proportion
+    of the sample represented by taxon :math:`i`.
 
     Parameters
     ----------
@@ -225,7 +225,7 @@ def esty_ci(counts):
 
        F_1/N \pm z\sqrt{W}
 
-    where :math:`F_1` is the number of singleton species, :math:`N` is the
+    where :math:`F_1` is the number of singleton taxa, :math:`N` is the
     total number of individuals, and :math:`z` is a constant that depends on
     the targeted confidence and based on the normal distribution.
 
@@ -235,7 +235,7 @@ def esty_ci(counts):
 
        \frac{F_1(N-F_1)+2NF_2}{N^3}
 
-    where :math:`F_2` is the number of doubleton species.
+    where :math:`F_2` is the number of doubleton taxa.
 
     Parameters
     ----------
@@ -283,7 +283,7 @@ def fisher_alpha(counts):
 
        S=\alpha\ln(1+\frac{N}{\alpha})
 
-    where :math:`S` is the number of species and :math:`N` is the total number
+    where :math:`S` is the number of taxa and :math:`N` is the total number
     of individuals in the sample.
 
     Parameters
@@ -310,15 +310,15 @@ def fisher_alpha(counts):
     SciPy's ``minimize_scalar`` to find alpha. It is deterministic. The result
     should be reasonably close to the true alpha.
 
-    Alpha can become large when most species are singletons. Alpha = +inf when
-    all species are singletons.
+    Alpha can become large when most taxa are singletons. Alpha = +inf when
+    all taxa are singletons.
 
     When the sample is empty (i.e., all counts are zero), alpha = 0.
 
     References
     ----------
     .. [1] Fisher, R.A., Corbet, A.S. and Williams, C.B., 1943. The relation
-       between the number of species and the number of individuals in a random
+       between the number of taxa and the number of individuals in a random
        sample of an animal population. The Journal of Animal Ecology, pp.42-58.
 
     """
@@ -328,7 +328,7 @@ def fisher_alpha(counts):
     if (N := counts.sum()) == 0:
         return 0.0
 
-    # alpha = +inf when all species are singletons
+    # alpha = +inf when all taxa are singletons
     if N == (S := sobs(counts)):
         return np.inf
 
@@ -358,7 +358,7 @@ def goods_coverage(counts):
 
        C = 1 - \frac{F_1}{N}
 
-    where :math:`F_1` is the number of species observed only once (i.e.,
+    where :math:`F_1` is the number of taxa observed only once (i.e.,
     singletons) and :math:`N` is the total number of individuals.
 
     Parameters
@@ -399,7 +399,7 @@ def heip_e(counts):
        \frac{(e^H-1)}{(S-1)}
 
     where :math:`H` is the Shannon-Wiener entropy of counts (using logarithm
-    base :math:`e`) and :math:`S` is the number of species in the sample.
+    base :math:`e`) and :math:`S` is the number of taxa in the sample.
 
     Parameters
     ----------
@@ -458,9 +458,9 @@ def kempton_taylor_q(counts, lower_quantile=0.25, upper_quantile=0.75):
 
     The implementation provided here differs slightly from the results given in
     Magurran 1998. Specifically, we have 14 in the numerator rather than 15.
-    Magurran recommends counting half of the OTUs with the same # counts as the
+    Magurran recommends counting half of the taxa with the same # counts as the
     point where the UQ falls and the point where the LQ falls, but the
-    justification for this is unclear (e.g. if there were a very large # OTUs
+    justification for this is unclear (e.g. if there were a very large # taxa
     that just overlapped one of the quantiles, the results would be
     considerably off). Leaving the calculation as-is for now, but consider
     changing.
@@ -490,7 +490,7 @@ def margalef(counts):
 
        D = \frac{(S - 1)}{\ln N}
 
-    where :math:`S` is the number of species and :math:`N` is the total number
+    where :math:`S` is the number of taxa and :math:`N` is the total number
     of individuals in the sample.
 
     Assumes log accumulation.
@@ -539,7 +539,7 @@ def mcintosh_d(counts):
        U = \sqrt{\sum{{n_i}^2}}
 
     where :math:`n_i` is the number of individuals in the :math:`i^{\text{th}}`
-    species.
+    taxon.
 
     Parameters
     ----------
@@ -583,8 +583,8 @@ def mcintosh_e(counts):
        E = \frac{\sqrt{\sum{n_i^2}}}{\sqrt{((N-S+1)^2 + S -1}}
 
     where :math:`n_i` is the number of individuals in the :math:`i^{\text{th}}`
-    species, :math:`N` is the total number of individuals, and :math:`S` is the
-    number of species in the sample.
+    taxon, :math:`N` is the total number of individuals, and :math:`S` is the
+    number of taxa in the sample.
 
     Parameters
     ----------
@@ -629,7 +629,7 @@ def menhinick(counts):
 
        D_{Mn} = \frac{S}{\sqrt{N}}
 
-    where :math:`S` is the number of species and :math:`N` is the total number
+    where :math:`S` is the number of taxa and :math:`N` is the total number
     of individuals in the sample.
 
     Assumes square-root accumulation.
@@ -660,7 +660,7 @@ def menhinick(counts):
 
 @experimental(as_of="0.4.0")
 def michaelis_menten_fit(counts, num_repeats=1, params_guess=None):
-    r"""Calculate Michaelis-Menten fit to rarefaction curve of observed OTUs.
+    r"""Calculate Michaelis-Menten fit to rarefaction curve of observed taxa.
 
     The Michaelis-Menten equation is defined as:
 
@@ -669,12 +669,12 @@ def michaelis_menten_fit(counts, num_repeats=1, params_guess=None):
        S=\frac{nS_{max}}{n+B}
 
     where :math:`n` is the number of individuals and :math:`S` is the number of
-    OTUs. This function estimates the :math:`S_{max}` parameter.
+    taxa. This function estimates the :math:`S_{max}` parameter.
 
     The fit is made to datapoints for :math:`n=1,2,...,N`, where :math:`N` is
-    the total number of individuals (sum of abundances for all OTUs).
-    :math:`S` is the number of OTUs represented in a random sample of :math:`n`
-    individuals.
+    the total number of individuals (sum of abundances for all taxa).
+    :math:`S` is the number of taxa represented in a random sample of
+    :math:`n` individuals.
 
     Parameters
     ----------
@@ -720,7 +720,7 @@ def michaelis_menten_fit(counts, num_repeats=1, params_guess=None):
         B_guess = int(round(n_indiv / 2))
         params_guess = (S_max_guess, B_guess)
 
-    # observed # of OTUs vs # of individuals sampled, S vs n
+    # observed # of taxa vs # of individuals sampled, S vs n
     xvals = np.arange(1, n_indiv + 1)
     ymtx = np.empty((num_repeats, len(xvals)), dtype=int)
     for i in range(num_repeats):
@@ -744,8 +744,8 @@ def sobs(counts):
     """Calculate the observed species richness of a sample.
 
     Observed species richness, usually denoted as :math:`S_{obs}` or simply
-    :math:`S`, is the number of distinct species, or any discrete groups of
-    biological entities found in a sample.
+    :math:`S`, is the number of distinct species (i.e., taxa), or any discrete
+    groups of biological entities found in a sample.
 
     It should be noted that observed species richness is smaller than or equal
     to the true species richness of a population from which the sample is
@@ -824,7 +824,7 @@ def observed_otus(counts):
 
 @experimental(as_of="0.4.0")
 def osd(counts):
-    """Calculate observed species, singletons, and doubletons.
+    """Calculate observed taxa, singletons, and doubletons.
 
     Parameters
     ----------
@@ -834,7 +834,7 @@ def osd(counts):
     Returns
     -------
     osd : tuple
-        Numbers of observed species, singletons, and doubletons.
+        Numbers of observed taxa, singletons, and doubletons.
 
     See Also
     --------
@@ -864,10 +864,10 @@ def pielou_e(counts):
        J' = \frac{(H)}{\ln(S)}
 
     where :math:`H` is the Shannon index of the sample and :math:`S` is the
-    number of species in the sample.
+    number of taxa in the sample.
 
     That is, :math:`J'` is the ratio of the actual Shannon index of the sample
-    versus the maximum-possible Shannon index when all species have the same
+    versus the maximum-possible Shannon index when all taxa have the same
     number of individuals. :math:`J'` ranges between 0 and 1.
 
     Parameters
@@ -909,7 +909,7 @@ def robbins(counts):
 
        \frac{F_1}{n+1}
 
-    where :math:`F_1` is the number of singleton species.
+    where :math:`F_1` is the number of singleton taxa.
 
     Parameters
     ----------
@@ -946,8 +946,8 @@ def shannon(counts, base=2):
 
        H' = -\sum_{i=1}^s\left(p_i\log_2 p_i\right)
 
-    where :math:`s` is the number of species and :math:`p_i` is the proportion
-    of the sample represented by species :math:`i`.
+    where :math:`s` is the number of taxa and :math:`p_i` is the proportion
+    of the sample represented by taxon :math:`i`.
 
     Parameters
     ----------
@@ -995,7 +995,7 @@ def simpson(counts):
 
        1 - \sum{p_i^2}
 
-    where :math:`p_i` is the proportion of the sample represented by species
+    where :math:`p_i` is the proportion of the sample represented by taxon
     :math:`i`.
 
     Therefore, Simpson's diversity index is also denoted as :math:`1 - D`, in
@@ -1040,10 +1040,10 @@ def simpson_e(counts):
        E_D = \frac{1}{D \times S}
 
     where :math:`D` is the Simpson's dominance index and :math:`S` is the
-    number of species in the sample.
+    number of taxa in the sample.
 
     That is, :math:`E_D` is the ratio of the minimum-possible Simpson's
-    dominance index when all species have the same number of individuals:
+    dominance index when all taxa have the same number of individuals:
     :math:`D_{min} = 1 / S`, versus the actual Simpson's dominance index of the
     sample.
 
@@ -1080,7 +1080,7 @@ def simpson_e(counts):
 
 @experimental(as_of="0.4.0")
 def singles(counts):
-    """Calculate number of single-occurrence species (singletons).
+    """Calculate number of single-occurrence taxa (singletons).
 
     Parameters
     ----------
@@ -1108,11 +1108,11 @@ def strong(counts):
        D_w = max_i[(\frac{b_i}{N})-\frac{i}{S}]
 
     where :math:`b_i` is the sequential cumulative totaling of the
-    :math:`i^{\text{th}}` species abundance values ranked from largest to
+    :math:`i^{\text{th}}` taxon abundance values ranked from largest to
     smallest, :math:`N` is the total number of individuals in the sample, and
-    :math:`S` is the number of species in the sample. The expression in
-    brackets is computed for all species, and :math:`max_i` denotes the maximum
-    value in brackets for any species.
+    :math:`S` is the number of taxa in the sample. The expression in
+    brackets is computed for all taxa, and :math:`max_i` denotes the maximum
+    value in brackets for any taxa.
 
     Parameters
     ----------

--- a/skbio/diversity/alpha/_chao1.py
+++ b/skbio/diversity/alpha/_chao1.py
@@ -182,7 +182,7 @@ def _chao1_var_no_doubletons(s, chao1):
 def _chao1_var_no_singletons(n, o):
     """Calculate chao1 variance in absence of singletons.
 
-    `n` is the number of individuals and `o` is the number of observed OTUs.
+    `n` is the number of individuals and `o` is the number of observed species.
 
     From EstimateS manual, equation 8.
 
@@ -213,7 +213,7 @@ def _chao_confidence_no_singletons(n, s, zscore=1.96):
 
     Uses Eq. 14 of EstimateS manual.
 
-    `n` is the number of individuals and `s` is the number of OTUs.
+    `n` is the number of individuals and `s` is the number of observed species.
 
     """
     P = np.exp(-n / s)

--- a/skbio/diversity/alpha/_chao1.py
+++ b/skbio/diversity/alpha/_chao1.py
@@ -213,7 +213,7 @@ def _chao_confidence_no_singletons(n, s, zscore=1.96):
 
     Uses Eq. 14 of EstimateS manual.
 
-    `n` is the number of individuals and `s` is the number of observed species.
+    `n` is the number of individuals and `s` is the number of observed taxa.
 
     """
     P = np.exp(-n / s)

--- a/skbio/diversity/alpha/_lladser.py
+++ b/skbio/diversity/alpha/_lladser.py
@@ -155,14 +155,14 @@ def _lladser_point_estimates(sample, r=10):
     if r <= 2:
         raise ValueError("r must be greater than or equal to 3.")
 
-    for count, seen, cost, i in _get_interval_for_r_new_otus(sample, r):
+    for count, seen, cost, i in _get_interval_for_r_new_taxa(sample, r):
         t = np.random.gamma(count, 1)
         point_est = (r - 1) / t
         yield point_est, i, t
 
 
-def _get_interval_for_r_new_otus(seq, r):
-    """Compute interval between r new OTUs for seq of samples.
+def _get_interval_for_r_new_taxa(seq, r):
+    """Compute interval between r new taxa for seq of samples.
 
     Imagine an urn with colored balls. Given a drawing of balls from the urn,
     compute how many balls need to be looked at to discover r new colors.
@@ -243,7 +243,7 @@ def _lladser_ci_series(seq, r, alpha=0.95, f=10, ci_type="ULCL"):
         Yields one CI prediction for each new color that is detected and where.
 
     """
-    for count, seen, cost, i in _get_interval_for_r_new_otus(seq, r):
+    for count, seen, cost, i in _get_interval_for_r_new_taxa(seq, r):
         t = np.random.gamma(count, 1)
         yield _lladser_ci_from_r(r, t, alpha, f, ci_type)
 

--- a/skbio/diversity/alpha/_pd.py
+++ b/skbio/diversity/alpha/_pd.py
@@ -156,16 +156,16 @@ def faith_pd(counts, taxa=None, tree=None, validate=True, otu_ids=None):
     Because Faith PD is a phylogenetic diversity metric, we need to know which
     taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
+    >>> taxa = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8']
 
     We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
-    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
-    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((U1:0.5,U2:0.5):0.5,U3:1.0):1.0):0.0,'
+    ...                      '(U4:0.75,(U5:0.5,((U6:0.33,U7:0.62):0.5'
+    ...                      ',U8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     We can then compute the Faith PD of the sample.
 

--- a/skbio/diversity/alpha/_pd.py
+++ b/skbio/diversity/alpha/_pd.py
@@ -11,24 +11,23 @@ import numpy as np
 from skbio.util._decorator import experimental
 from skbio.diversity._util import (
     _validate_counts_vector,
-    _validate_otu_ids_and_tree,
+    _validate_taxa_and_tree,
     _vectorize_counts_and_tree,
+    _check_taxa_alias,
 )
 
 
-def _setup_pd(counts, otu_ids, tree, validate, rooted, single_sample):
+def _setup_pd(counts, taxa, tree, validate, rooted, single_sample):
     if validate:
         if single_sample:
             # only validate count if operating in single sample mode, they
             # will have already been validated otherwise
             counts = _validate_counts_vector(counts)
-            _validate_otu_ids_and_tree(counts, otu_ids, tree, rooted)
+            _validate_taxa_and_tree(counts, taxa, tree, rooted)
         else:
-            _validate_otu_ids_and_tree(counts[0], otu_ids, tree, rooted)
+            _validate_taxa_and_tree(counts[0], taxa, tree, rooted)
 
-    counts_by_node, _, branch_lengths = _vectorize_counts_and_tree(
-        counts, otu_ids, tree
-    )
+    counts_by_node, _, branch_lengths = _vectorize_counts_and_tree(counts, taxa, tree)
 
     return counts_by_node, branch_lengths
 
@@ -39,7 +38,7 @@ def _faith_pd(counts_by_node, branch_lengths):
 
 
 @experimental(as_of="0.4.1")
-def faith_pd(counts, otu_ids, tree, validate=True):
+def faith_pd(counts, taxa=None, tree=None, validate=True, otu_ids=None):
     r"""Calculate Faith's phylogenetic diversity (Faith's PD) metric.
 
     The Faith's PD metric is defined as:
@@ -56,21 +55,24 @@ def faith_pd(counts, otu_ids, tree, validate=True):
     Parameters
     ----------
     counts : 1-D array_like, int
-        Vectors of counts/abundances of OTUs for one sample.
-    otu_ids : list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
-        same length as ``counts``.
+        Vectors of counts/abundances of taxa for one sample.
+    taxa : list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
+        same length as ``counts``. Required.
     tree : skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset. Required.
     validate: bool, optional
-        If `False`, validation of the input won't be performed. This step can
+        If ``False``, validation of the input won't be performed. This step can
         be slow, so if validation is run elsewhere it can be disabled here.
         However, invalid input data can lead to invalid results or error
         messages that are hard to interpret, so this step should not be
         bypassed if you're not certain that your input data are valid. See
         :mod:`skbio.diversity` for the description of what validation entails
         so you can determine if you can safely disable validation.
+    otu_ids : list, np.array
+        Alias of ``taxa`` for backward compatibility. Deprecated and to be
+        removed in a future release.
 
     Returns
     -------
@@ -118,11 +120,10 @@ def faith_pd(counts, otu_ids, tree, validate=True):
     inputs. First, the input tree must be rooted. In PyCogent, if an unrooted
     tree was provided that had a single trifurcating node (a newick convention
     for unrooted trees) that node was considered the root of the tree. Next,
-    all OTU IDs must be tips in the tree. PyCogent would silently ignore OTU
-    IDs that were not present the tree. To reproduce Faith PD results from
-    PyCogent with scikit-bio, ensure that your PyCogent Faith PD calculations
-    are performed on a rooted tree and that all OTU IDs are present in the
-    tree.
+    all taxa must be tips in the tree. PyCogent would silently ignore taxa that
+    were not present the tree. To reproduce Faith PD results from PyCogent with
+    scikit-bio, ensure that your PyCogent Faith PD calculations are performed
+    on a rooted tree and that all taxa are present in the tree.
 
     References
     ----------
@@ -146,38 +147,38 @@ def faith_pd(counts, otu_ids, tree, validate=True):
 
     Examples
     --------
-    Assume we have the following abundance data for a sample ``u``,
-    represented as a counts vector. These counts represent the
-    number of times specific Operational Taxonomic Units, or OTUs, were
-    observed in the sample.
+    Assume we have the following abundance data for a sample ``u``, represented
+    as a counts vector. These counts represent the number of times specific
+    taxa were observed in the sample.
 
     >>> u_counts = [1, 0, 0, 4, 1, 2, 3, 0]
 
     Because Faith PD is a phylogenetic diversity metric, we need to know which
-    OTU each count corresponds to, which we'll provide as ``otu_ids``.
+    taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5', 'OTU6', 'OTU7',
-    ...            'OTU8']
+    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
 
-    We also need a phylogenetic tree that relates the OTUs to one another.
+    We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,'
-    ...                      '(OTU4:0.75,(OTU5:0.5,((OTU6:0.33,OTU7:0.62):0.5'
-    ...                      ',OTU8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
+    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
+    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     We can then compute the Faith PD of the sample.
 
     >>> from skbio.diversity.alpha import faith_pd
-    >>> pd = faith_pd(u_counts, otu_ids, tree)
+    >>> pd = faith_pd(u_counts, taxa, tree)
     >>> print(round(pd, 2))
     6.95
 
     """
+    taxa = _check_taxa_alias(taxa, tree, otu_ids)
+
     counts_by_node, branch_lengths = _setup_pd(
-        counts, otu_ids, tree, validate, rooted=True, single_sample=True
+        counts, taxa, tree, validate, rooted=True, single_sample=True
     )
 
     return _faith_pd(counts_by_node, branch_lengths)
@@ -216,19 +217,21 @@ def _phydiv(counts_by_node, branch_lengths, rooted, weight):
 
 
 @experimental(as_of="0.6.0")
-def phydiv(counts, otu_ids, tree, rooted=None, weight=False, validate=True):
+def phydiv(
+    counts, taxa=None, tree=None, rooted=None, weight=False, validate=True, otu_ids=None
+):
     r"""Calculate generalized phylogenetic diversity (PD) metrics.
 
     Parameters
     ----------
     counts : 1-D array_like, int
-        Vectors of counts/abundances of OTUs for one sample.
-    otu_ids : list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
-        same length as ``counts``.
+        Vectors of counts/abundances of taxa for one sample.
+    taxa : list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
+        same length as ``counts``. Required.
     tree : skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset. Required.
     rooted : bool, optional
         Whether the metric is calculated considering the root of the tree. By
         default, this will be determined based on whether the input tree is
@@ -241,6 +244,9 @@ def phydiv(counts, otu_ids, tree, rooted=None, weight=False, validate=True):
         fully-weighted).
     validate: bool, optional
         Whether validate the input data. See ``faith_pd`` for details.
+    otu_ids : list, np.array
+        Alias of ``taxa`` for backward compatibility. Deprecated and to be
+        removed in a future release.
 
     Returns
     -------
@@ -397,10 +403,12 @@ def phydiv(counts, otu_ids, tree, rooted=None, weight=False, validate=True):
        Bioinformatics, 28(16), 2106-2113.
 
     """
+    taxa = _check_taxa_alias(taxa, tree, otu_ids)
+
     # whether tree is rooted should not affect whether metric can be calculated
     # ; it is common unrooted PD is calculated on a rooted tree
     counts_by_node, branch_lengths = _setup_pd(
-        counts, otu_ids, tree, validate, rooted=False, single_sample=True
+        counts, taxa, tree, validate, rooted=False, single_sample=True
     )
 
     # if not specified, determine whether metric should be calculated in rooted

--- a/skbio/diversity/alpha/tests/test_ace.py
+++ b/skbio/diversity/alpha/tests/test_ace.py
@@ -24,10 +24,10 @@ class AceTests(unittest.TestCase):
         npt.assert_almost_equal(ace(np.array([12, 3, 2, 1])), 4.6)
         npt.assert_almost_equal(ace(np.array([12, 3, 6, 1, 10])), 5.62749672)
 
-        # Just returns the number of OTUs when all are abundant.
+        # Just return the number of taxa when all are abundant.
         npt.assert_almost_equal(ace(np.array([12, 12, 13, 14])), 4.0)
 
-        # Border case: only singletons and 10-tons, no abundant OTUs.
+        # Border case: only singletons and 10-tons, no abundant taxa.
         npt.assert_almost_equal(ace([0, 1, 1, 0, 0, 10, 10, 1, 0, 0]),
                                 9.35681818182)
 

--- a/skbio/diversity/alpha/tests/test_base.py
+++ b/skbio/diversity/alpha/tests/test_base.py
@@ -61,7 +61,7 @@ class BaseTests(TestCase):
         self.assertEqual(doubles(np.array([0, 0])), 0)
 
     def test_enspie(self):
-        # Totally even community should have ENS_pie = number of OTUs.
+        # Totally even community should have ENS_pie = number of taxa.
         self.assertAlmostEqual(enspie(np.array([1, 1, 1, 1, 1, 1])), 6)
         self.assertAlmostEqual(enspie(np.array([13, 13, 13, 13])), 4)
 
@@ -82,7 +82,7 @@ class BaseTests(TestCase):
         def _diversity(indices, f):
             """Calculate diversity index for each window of size 1.
 
-            indices: vector of indices of OTUs
+            indices: vector of indices of taxa
             f: f(counts) -> diversity measure
 
             """
@@ -118,13 +118,13 @@ class BaseTests(TestCase):
         obs = fisher_alpha(arr)
         self.assertAlmostEqual(obs, exp, places=6)
 
-        # Should depend only on S and N (number of OTUs, number of
+        # Should depend only on S and N (number of taxa, number of
         # individuals / seqs), so we should obtain the same output as above.
         obs = fisher_alpha([1, 6, 1, 0, 1, 0, 5])
         self.assertAlmostEqual(obs, exp, places=6)
 
         # Should match another by hand:
-        # 2 OTUs, 62 seqs, alpha is 0.39509
+        # 2 taxa, 62 seqs, alpha is 0.39509
         obs = fisher_alpha([61, 0, 0, 1])
         self.assertAlmostEqual(obs, 0.3950909, places=6)
 
@@ -215,9 +215,9 @@ class BaseTests(TestCase):
 
         obs_few = michaelis_menten_fit(np.arange(4) * 2, num_repeats=10)
         obs_many = michaelis_menten_fit(np.arange(4) * 100, num_repeats=10)
-        # [0,100,200,300] looks like only 3 OTUs.
+        # [0,100,200,300] looks like only 3 taxa.
         self.assertAlmostEqual(obs_many, 3.0, places=1)
-        # [0,2,4,6] looks like 3 OTUs with maybe more to be found.
+        # [0,2,4,6] looks like 3 taxa with maybe more to be found.
         self.assertTrue(obs_few > obs_many)
 
     def test_observed_features(self):

--- a/skbio/diversity/alpha/tests/test_lladser.py
+++ b/skbio/diversity/alpha/tests/test_lladser.py
@@ -15,7 +15,7 @@ from skbio.stats import subsample_counts
 from skbio.diversity.alpha import lladser_pe, lladser_ci
 from skbio.diversity.alpha._lladser import (
     _expand_counts, _lladser_point_estimates,
-    _get_interval_for_r_new_otus, _lladser_ci_series, _lladser_ci_from_r)
+    _get_interval_for_r_new_taxa, _lladser_ci_series, _lladser_ci_from_r)
 
 
 def create_fake_observation():
@@ -124,17 +124,17 @@ class LladserTests(unittest.TestCase):
             list(_lladser_point_estimates([5, 1, 5, 1, 2, 3, 1, 5, 3, 2, 5, 3],
                                           2))
 
-    def test_get_interval_for_r_new_otus(self):
+    def test_get_interval_for_r_new_taxa(self):
         s = [5, 1, 5, 1, 2, 3, 1, 5, 3, 2, 5]
         expected = [(3, set([5]), 4, 0),
                     (4, set([5, 1]), 6, 1),
                     (4, set([5, 1, 2]), 9, 4)]
-        for x, y in zip(_get_interval_for_r_new_otus(s, 2), expected):
+        for x, y in zip(_get_interval_for_r_new_taxa(s, 2), expected):
             self.assertEqual(x, y)
 
         s = [5, 5, 5, 5, 5]
         # never saw new one
-        self.assertEqual(list(_get_interval_for_r_new_otus(s, 2)), [])
+        self.assertEqual(list(_get_interval_for_r_new_taxa(s, 2)), [])
 
     def test_lladser_ci_series_exact(self):
         # have seen RWB

--- a/skbio/diversity/alpha/tests/test_pd.py
+++ b/skbio/diversity/alpha/tests/test_pd.py
@@ -215,6 +215,23 @@ class FaithPDTests(TestCase):
         otu_ids = ['OTU1', 'OTU2', 'OTU42']
         self.assertRaises(MissingNodeError, faith_pd, counts, otu_ids, t)
 
+    def test_faith_pd_taxa_alias(self):
+        # for backward compatibility; will be removed in the future
+        datum, taxa, tree = self.b1[0], self.oids1, self.t1
+        self.assertIsNotNone(faith_pd(datum, taxa, tree))
+        self.assertIsNotNone(faith_pd(datum, taxa=taxa, tree=tree))
+        self.assertIsNotNone(faith_pd(datum, tree=tree, taxa=taxa))
+        self.assertIsNotNone(faith_pd(datum, otu_ids=taxa, tree=tree))
+        self.assertIsNotNone(faith_pd(datum, taxa=taxa, tree=tree, otu_ids=['x', 'y']))
+        msg = "A list of taxon IDs must be provided."
+        with self.assertRaises(ValueError) as cm:
+            faith_pd(datum)
+        self.assertEqual(str(cm.exception), msg)
+        msg = "A phylogenetic tree must be provided."
+        with self.assertRaises(ValueError) as cm:
+            faith_pd(datum, taxa)
+        self.assertEqual(str(cm.exception), msg)
+
 
 class PhyDivTests(TestCase):
 
@@ -395,6 +412,23 @@ class PhyDivTests(TestCase):
         self.assertRaises(ValueError, phydiv, *params, weight='hello')
         self.assertRaises(ValueError, phydiv, *params, weight=-0.5)
         self.assertRaises(ValueError, phydiv, *params, weight=2.0)
+
+    def test_phydiv_taxa_alias(self):
+        # for backward compatibility; will be removed in the future
+        datum, taxa, tree = self.data[0], self.taxa, self.tree
+        self.assertIsNotNone(phydiv(datum, taxa, tree))
+        self.assertIsNotNone(phydiv(datum, taxa=taxa, tree=tree))
+        self.assertIsNotNone(phydiv(datum, tree=tree, taxa=taxa))
+        self.assertIsNotNone(phydiv(datum, otu_ids=taxa, tree=tree))
+        self.assertIsNotNone(phydiv(datum, taxa=taxa, tree=tree, otu_ids=['x', 'y']))
+        msg = "A list of taxon IDs must be provided."
+        with self.assertRaises(ValueError) as cm:
+            phydiv(datum)
+        self.assertEqual(str(cm.exception), msg)
+        msg = "A phylogenetic tree must be provided."
+        with self.assertRaises(ValueError) as cm:
+            phydiv(datum, taxa)
+        self.assertEqual(str(cm.exception), msg)
 
 
 if __name__ == "__main__":

--- a/skbio/diversity/beta/_unifrac.py
+++ b/skbio/diversity/beta/_unifrac.py
@@ -13,8 +13,9 @@ import numpy as np
 from skbio.util._decorator import experimental
 from skbio.diversity._util import (
     _validate_counts_matrix,
-    _validate_otu_ids_and_tree,
+    _validate_taxa_and_tree,
     _vectorize_counts_and_tree,
+    _check_taxa_alias,
 )
 from skbio.diversity._phylogenetic import _tip_distances
 
@@ -27,28 +28,33 @@ _normalize_weighted_unifrac_by_default = False
 
 
 @experimental(as_of="0.4.1")
-def unweighted_unifrac(u_counts, v_counts, otu_ids, tree, validate=True):
+def unweighted_unifrac(
+    u_counts, v_counts, taxa=None, tree=None, validate=True, otu_ids=None
+):
     """Compute unweighted UniFrac.
 
     Parameters
     ----------
     u_counts, v_counts: list, np.array
-        Vectors of counts/abundances of OTUs for two samples. Must be equal
+        Vectors of counts/abundances of taxa for two samples. Must be equal
         length.
-    otu_ids: list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
-        same length as ``u_counts`` and ``v_counts``.
-    tree: skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+    taxa : list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
+        same length as ``u_counts`` and ``v_counts``. Required.
+    tree : skbio.TreeNode
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset. Required.
     validate: bool, optional
-        If `False`, validation of the input won't be performed. This step can
+        If ``False``, validation of the input won't be performed. This step can
         be slow, so if validation is run elsewhere it can be disabled here.
         However, invalid input data can lead to invalid results or error
         messages that are hard to interpret, so this step should not be
         bypassed if you're not certain that your input data are valid. See
         :mod:`skbio.diversity` for the description of what validation entails
         so you can determine if you can safely disable validation.
+    otu_ids : list, np.array
+        Alias of ``taxa`` for backward compatibility. Deprecated and to be
+        removed in a future release.
 
     Returns
     -------
@@ -82,11 +88,10 @@ def unweighted_unifrac(u_counts, v_counts, otu_ids, tree, validate=True):
     inputs. First, the input tree must be rooted. In PyCogent, if an unrooted
     tree was provided that had a single trifurcating node (a newick convention
     for unrooted trees) that node was considered the root of the tree. Next,
-    all OTU IDs must be tips in the tree. PyCogent would silently ignore OTU
-    IDs that were not present the tree. To reproduce UniFrac results from
-    PyCogent with scikit-bio, ensure that your PyCogent UniFrac calculations
-    are performed on a rooted tree and that all OTU IDs are present in the
-    tree.
+    all taxa must be tips in the tree. PyCogent would silently ignore taxa that
+    were not present the tree. To reproduce UniFrac results from PyCogent with
+    scikit-bio, ensure that your PyCogent UniFrac calculations are performed on
+    a rooted tree and that all taxa are present in the tree.
 
     This implementation of unweighted UniFrac is the array-based implementation
     described in [4]_.
@@ -120,37 +125,37 @@ def unweighted_unifrac(u_counts, v_counts, otu_ids, tree, validate=True):
     --------
     Assume we have the following abundance data for two samples, ``u`` and
     ``v``, represented as a pair of counts vectors. These counts represent the
-    number of times specific Operational Taxonomic Units, or OTUs, were
+    number of times specific Operational Taxonomic Units, or taxa, were
     observed in each of the samples.
 
     >>> u_counts = [1, 0, 0, 4, 1, 2, 3, 0]
     >>> v_counts = [0, 1, 1, 6, 0, 1, 0, 0]
 
     Because UniFrac is a phylogenetic diversity metric, we need to know which
-    OTU each count corresponds to, which we'll provide as ``otu_ids``.
+    taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5', 'OTU6', 'OTU7',
-    ...            'OTU8']
+    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
 
-    We also need a phylogenetic tree that relates the OTUs to one another.
+    We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,'
-    ...                      '(OTU4:0.75,(OTU5:0.5,((OTU6:0.33,OTU7:0.62):0.5'
-    ...                      ',OTU8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
+    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
+    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     We can then compute the unweighted UniFrac distance between the samples.
 
     >>> from skbio.diversity.beta import unweighted_unifrac
-    >>> uu = unweighted_unifrac(u_counts, v_counts, otu_ids, tree)
+    >>> uu = unweighted_unifrac(u_counts, v_counts, taxa, tree)
     >>> print(round(uu, 2))
     0.37
 
     """
+    taxa = _check_taxa_alias(taxa, tree, otu_ids)
     u_node_counts, v_node_counts, _, _, tree_index = _setup_pairwise_unifrac(
-        u_counts, v_counts, otu_ids, tree, validate, normalized=False, unweighted=True
+        u_counts, v_counts, taxa, tree, validate, normalized=False, unweighted=True
     )
     return _unweighted_unifrac(u_node_counts, v_node_counts, tree_index["length"])
 
@@ -159,35 +164,39 @@ def unweighted_unifrac(u_counts, v_counts, otu_ids, tree, validate=True):
 def weighted_unifrac(
     u_counts,
     v_counts,
-    otu_ids,
-    tree,
+    taxa=None,
+    tree=None,
     normalized=_normalize_weighted_unifrac_by_default,
     validate=True,
+    otu_ids=None,
 ):
     """Compute weighted UniFrac with or without branch length normalization.
 
     Parameters
     ----------
     u_counts, v_counts: list, np.array
-        Vectors of counts/abundances of OTUs for two samples. Must be equal
+        Vectors of counts/abundances of taxa for two samples. Must be equal
         length.
-    otu_ids: list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
-        same length as ``u_counts`` and ``v_counts``.
-    tree: skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+    taxa : list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
+        same length as ``u_counts`` and ``v_counts``. Required.
+    tree : skbio.TreeNode
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset. Required.
     normalized: boolean, optional
         If ``True``, apply branch length normalization, which is described in
         [1]_. Resulting distances will then be in the range ``[0, 1]``.
     validate: bool, optional
-        If `False`, validation of the input won't be performed. This step can
+        If ``False``, validation of the input won't be performed. This step can
         be slow, so if validation is run elsewhere it can be disabled here.
         However, invalid input data can lead to invalid results or error
         messages that are hard to interpret, so this step should not be
         bypassed if you're not certain that your input data are valid. See
         :mod:`skbio.diversity` for the description of what validation entails
         so you can determine if you can safely disable validation.
+    otu_ids : list, np.array
+        Alias of ``taxa`` for backward compatibility. Deprecated and to be
+        removed in a future release.
 
     Returns
     -------
@@ -221,11 +230,10 @@ def weighted_unifrac(
     inputs. First, the input tree must be rooted. In PyCogent, if an unrooted
     tree was provided that had a single trifurcating node (a newick convention
     for unrooted trees) that node was considered the root of the tree. Next,
-    all OTU IDs must be tips in the tree. PyCogent would silently ignore OTU
-    IDs that were not present the tree. To reproduce UniFrac results from
-    PyCogent with scikit-bio, ensure that your PyCogent UniFrac calculations
-    are performed on a rooted tree and that all OTU IDs are present in the
-    tree.
+    all taxa must be tips in the tree. PyCogent would silently ignore taxa that
+    were not present the tree. To reproduce UniFrac results from PyCogent with
+    scikit-bio, ensure that your PyCogent UniFrac calculations are performed on
+    a rooted tree and that all taxa are present in the tree.
 
     This implementation of weighted UniFrac is the array-based implementation
     described in [3]_.
@@ -255,43 +263,41 @@ def weighted_unifrac(
     --------
     Assume we have the following abundance data for two samples, ``u`` and
     ``v``, represented as a pair of counts vectors. These counts represent the
-    number of times specific Operational Taxonomic Units, or OTUs, were
-    observed in each of the samples.
+    number of times specific taxa were observed in each of the samples.
 
     >>> u_counts = [1, 0, 0, 4, 1, 2, 3, 0]
     >>> v_counts = [0, 1, 1, 6, 0, 1, 0, 0]
 
     Because UniFrac is a phylogenetic diversity metric, we need to know which
-    OTU each count corresponds to, which we'll provide as ``otu_ids``.
+    taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5', 'OTU6', 'OTU7',
-    ...            'OTU8']
+    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
 
-    We also need a phylogenetic tree that relates the OTUs to one another.
+    We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,'
-    ...                      '(OTU4:0.75,(OTU5:0.5,((OTU6:0.33,OTU7:0.62):0.5'
-    ...                      ',OTU8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
+    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
+    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     Compute the weighted UniFrac distance between the samples.
 
     >>> from skbio.diversity.beta import weighted_unifrac
-    >>> wu = weighted_unifrac(u_counts, v_counts, otu_ids, tree)
+    >>> wu = weighted_unifrac(u_counts, v_counts, taxa, tree)
     >>> print(round(wu, 2))
     1.54
 
     Compute the weighted UniFrac distance between the samples including
     branch length normalization so the value falls in the range ``[0.0, 1.0]``.
 
-    >>> wu = weighted_unifrac(u_counts, v_counts, otu_ids, tree,
-    ...                       normalized=True)
+    >>> wu = weighted_unifrac(u_counts, v_counts, taxa, tree, normalized=True)
     >>> print(round(wu, 2))
     0.33
 
     """
+    taxa = _check_taxa_alias(taxa, tree, otu_ids)
     (
         u_node_counts,
         v_node_counts,
@@ -301,7 +307,7 @@ def weighted_unifrac(
     ) = _setup_pairwise_unifrac(
         u_counts,
         v_counts,
-        otu_ids,
+        taxa,
         tree,
         validate,
         normalized=normalized,
@@ -326,16 +332,16 @@ def weighted_unifrac(
         )[0]
 
 
-def _validate(u_counts, v_counts, otu_ids, tree):
+def _validate(u_counts, v_counts, taxa, tree):
     _validate_counts_matrix([u_counts, v_counts], suppress_cast=True)
-    _validate_otu_ids_and_tree(counts=u_counts, otu_ids=otu_ids, tree=tree)
+    _validate_taxa_and_tree(counts=u_counts, taxa=taxa, tree=tree)
 
 
 def _setup_pairwise_unifrac(
-    u_counts, v_counts, otu_ids, tree, validate, normalized, unweighted
+    u_counts, v_counts, taxa, tree, validate, normalized, unweighted
 ):
     if validate:
-        _validate(u_counts, v_counts, otu_ids, tree)
+        _validate(u_counts, v_counts, taxa, tree)
 
     # temporarily store u_counts and v_counts in a 2-D array as that's what
     # _vectorize_counts_and_tree takes
@@ -343,7 +349,7 @@ def _setup_pairwise_unifrac(
     v_counts = np.asarray(v_counts)
     counts = np.vstack([u_counts, v_counts])
     counts_by_node, tree_index, branch_lengths = _vectorize_counts_and_tree(
-        counts, otu_ids, tree
+        counts, taxa, tree
     )
     # unpack counts vectors for single pairwise UniFrac calculation
     u_node_counts = counts_by_node[0]
@@ -489,34 +495,34 @@ def _weighted_unifrac_normalized(
     return u / c
 
 
-def _setup_multiple_unifrac(counts, otu_ids, tree, validate):
+def _setup_multiple_unifrac(counts, taxa, tree, validate):
     if validate:
-        _validate_otu_ids_and_tree(counts[0], otu_ids, tree)
+        _validate_taxa_and_tree(counts[0], taxa, tree)
 
     counts_by_node, tree_index, branch_lengths = _vectorize_counts_and_tree(
-        counts, otu_ids, tree
+        counts, taxa, tree
     )
 
     return counts_by_node, tree_index, branch_lengths
 
 
-def _setup_multiple_unweighted_unifrac(counts, otu_ids, tree, validate):
-    """Create optimized pdist-compatible unweighted UniFrac function.
+def _setup_multiple_unweighted_unifrac(counts, taxa, tree, validate):
+    r"""Create optimized pdist-compatible unweighted UniFrac function.
 
     Parameters
     ----------
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
         of observations in a given sample.
-    otu_ids: list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
+    taxa: list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
         same length as ``u_counts`` and ``v_counts``. These IDs do not need to
         be in tip order with respect to the tree.
     tree: skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset.
     validate: bool, optional
-        If `False`, validation of the input won't be performed.
+        If ``False``, validation of the input won't be performed.
 
     Returns
     -------
@@ -528,7 +534,7 @@ def _setup_multiple_unweighted_unifrac(counts, otu_ids, tree, validate):
 
     """
     counts_by_node, _, branch_lengths = _setup_multiple_unifrac(
-        counts, otu_ids, tree, validate
+        counts, taxa, tree, validate
     )
 
     f = functools.partial(_unweighted_unifrac, branch_lengths=branch_lengths)
@@ -536,25 +542,25 @@ def _setup_multiple_unweighted_unifrac(counts, otu_ids, tree, validate):
     return f, counts_by_node
 
 
-def _setup_multiple_weighted_unifrac(counts, otu_ids, tree, normalized, validate):
-    """Create optimized pdist-compatible weighted UniFrac function.
+def _setup_multiple_weighted_unifrac(counts, taxa, tree, normalized, validate):
+    r"""Create optimized pdist-compatible weighted UniFrac function.
 
     Parameters
     ----------
     counts : 2D array_like of ints or floats
         Matrix containing count/abundance data where each row contains counts
         of observations in a given sample.
-    otu_ids : list, np.array
-        Vector of OTU ids corresponding to tip names in ``tree``. Must be the
+    taxa : list, np.array
+        Vector of taxon IDs corresponding to tip names in ``tree``. Must be the
         same length as ``u_counts`` and ``v_counts``. These IDs do not need to
         be in tip order with respect to the tree.
     tree : skbio.TreeNode
-        Tree relating the OTUs in otu_ids. The set of tip names in the tree can
-        be a superset of ``otu_ids``, but not a subset.
+        Tree relating taxa. The set of tip names in the tree can be a superset
+        of ``taxa``, but not a subset.
     normalized : bool
-        If `True`, output will be normalized.
+        If ``True``, output will be normalized.
     validate: bool, optional
-        If `False`, validation of the input won't be performed.
+        If ``False``, validation of the input won't be performed.
 
     Returns
     -------
@@ -566,7 +572,7 @@ def _setup_multiple_weighted_unifrac(counts, otu_ids, tree, normalized, validate
 
     """
     counts_by_node, tree_index, branch_lengths = _setup_multiple_unifrac(
-        counts, otu_ids, tree, validate
+        counts, taxa, tree, validate
     )
     tip_indices = _get_tip_indices(tree_index)
 

--- a/skbio/diversity/beta/_unifrac.py
+++ b/skbio/diversity/beta/_unifrac.py
@@ -134,16 +134,16 @@ def unweighted_unifrac(
     Because UniFrac is a phylogenetic diversity metric, we need to know which
     taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
+    >>> taxa = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8']
 
     We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
-    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
-    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((U1:0.5,U2:0.5):0.5,U3:1.0):1.0):0.0,'
+    ...                      '(U4:0.75,(U5:0.5,((U6:0.33,U7:0.62):0.5'
+    ...                      ',U8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     We can then compute the unweighted UniFrac distance between the samples.
 
@@ -271,16 +271,16 @@ def weighted_unifrac(
     Because UniFrac is a phylogenetic diversity metric, we need to know which
     taxon each count corresponds to, which we'll provide as ``taxa``.
 
-    >>> taxa = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']
+    >>> taxa = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8']
 
     We also need a phylogenetic tree that relates the taxa to one another.
 
     >>> from io import StringIO
     >>> from skbio import TreeNode
     >>> tree = TreeNode.read(StringIO(
-    ...                      '(((((T1:0.5,T2:0.5):0.5,T3:1.0):1.0):0.0,'
-    ...                      '(T4:0.75,(T5:0.5,((T6:0.33,T7:0.62):0.5'
-    ...                      ',T8:0.5):0.5):0.5):1.25):0.0)root;'))
+    ...                      '(((((U1:0.5,U2:0.5):0.5,U3:1.0):1.0):0.0,'
+    ...                      '(U4:0.75,(U5:0.5,((U6:0.33,U7:0.62):0.5'
+    ...                      ',U8:0.5):0.5):0.5):1.25):0.0)root;'))
 
     Compute the weighted UniFrac distance between the samples.
 

--- a/skbio/diversity/beta/tests/test_unifrac.py
+++ b/skbio/diversity/beta/tests/test_unifrac.py
@@ -44,7 +44,7 @@ class UnifracTests(TestCase):
                      'root;'))
         self.oids2 = ['OTU%d' % i for i in range(1, 5)]
 
-    def test_unweighted_otus_out_of_order(self):
+    def test_unweighted_taxa_out_of_order(self):
         # UniFrac API does not assert the observations are in tip order of the
         # input tree
         shuffled_ids = self.oids1[:]
@@ -61,7 +61,7 @@ class UnifracTests(TestCase):
                     shuffled_b1[i], shuffled_b1[j], shuffled_ids, self.t1)
                 self.assertAlmostEqual(actual, expected)
 
-    def test_weighted_otus_out_of_order(self):
+    def test_weighted_taxa_out_of_order(self):
         # UniFrac API does not assert the observations are in tip order of the
         # input tree
         shuffled_ids = self.oids1[:]
@@ -196,34 +196,34 @@ class UnifracTests(TestCase):
                      '0.75,OTU2:0.75):1.25):0.0)root;'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(DuplicateNodeError, unweighted_unifrac,
-                          u_counts, v_counts, otu_ids, t)
+                          u_counts, v_counts, taxa, t)
         self.assertRaises(DuplicateNodeError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
         # unrooted tree as input
         t = TreeNode.read(StringIO('((OTU1:0.1, OTU2:0.2):0.3, OTU3:0.5,'
                                    'OTU4:0.7);'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
-        # otu_ids has duplicated ids
+        # taxa has duplicated ids
         t = TreeNode.read(
             StringIO('(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                      '0.75,OTU5:0.75):1.25):0.0)root;'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU2']
+        taxa = ['OTU1', 'OTU2', 'OTU2']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
         # len of vectors not equal
         t = TreeNode.read(
@@ -231,25 +231,25 @@ class UnifracTests(TestCase):
                      '0.75,OTU5:0.75):1.25):0.0)root;'))
         u_counts = [1, 2]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         u_counts = [1, 2, 3]
         v_counts = [1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2']
+        taxa = ['OTU1', 'OTU2']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
         # negative counts
         t = TreeNode.read(
@@ -257,29 +257,29 @@ class UnifracTests(TestCase):
                      '0.75,OTU5:0.75):1.25):0.0)root;'))
         u_counts = [1, 2, -3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         u_counts = [1, 2, 3]
         v_counts = [1, 1, -1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
         # tree with no branch lengths
         t = TreeNode.read(
             StringIO('((((OTU1,OTU2),OTU3)),(OTU4,OTU5));'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
         # tree missing some branch lengths
         t = TreeNode.read(
@@ -287,23 +287,23 @@ class UnifracTests(TestCase):
                      '0.75,OTU5:0.75):1.25):0.0)root;'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(ValueError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
-        # otu_ids not present in tree
+        # taxa not present in tree
         t = TreeNode.read(
             StringIO('(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                      '0.75,OTU5:0.75):1.25):0.0)root;'))
         u_counts = [1, 2, 3]
         v_counts = [1, 1, 1]
-        otu_ids = ['OTU1', 'OTU2', 'OTU42']
+        taxa = ['OTU1', 'OTU2', 'OTU42']
         self.assertRaises(MissingNodeError, unweighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
         self.assertRaises(MissingNodeError, weighted_unifrac, u_counts,
-                          v_counts, otu_ids, t)
+                          v_counts, taxa, t)
 
     def test_unweighted_unifrac_non_overlapping(self):
         # these communities only share the root node

--- a/skbio/diversity/tests/test_block.py
+++ b/skbio/diversity/tests/test_block.py
@@ -116,9 +116,9 @@ class ParallelBetaDiversity(TestCase):
 
     def test_block_beta_diversity(self):
         exp = beta_diversity('unweighted_unifrac', self.table1, self.sids1,
-                             tree=self.tree1, otu_ids=self.oids1)
+                             tree=self.tree1, taxa=self.oids1)
         obs = block_beta_diversity('unweighted_unifrac', self.table1,
-                                   self.sids1, otu_ids=self.oids1,
+                                   self.sids1, taxa=self.oids1,
                                    tree=self.tree1, k=2)
         npt.assert_equal(obs.data, exp.data)
         self.assertEqual(obs.ids, exp.ids)
@@ -160,11 +160,11 @@ class ParallelBetaDiversity(TestCase):
                            [0, 0, 1],
                            [0, 1, 1]])
         tree = TreeNode.read(['(a:1,b:2,c:3);'])
-        otu_ids = ['a', 'b', 'c']
+        taxa = ['a', 'b', 'c']
 
-        kw = {'tree': tree, 'otu_ids': otu_ids}
-        kw_no_a = {'tree': tree.shear(['b', 'c']), 'otu_ids': ['b', 'c']}
-        kw_no_b = {'tree': tree.shear(['a', 'c']), 'otu_ids': ['a', 'c']}
+        kw = {'tree': tree, 'taxa': taxa}
+        kw_no_a = {'tree': tree.shear(['b', 'c']), 'taxa': ['b', 'c']}
+        kw_no_b = {'tree': tree.shear(['a', 'c']), 'taxa': ['a', 'c']}
 
         # python >= 3.5 supports {foo: bar, **baz}
         exp = [dict(counts=np.array([[1, 1, 1], [1, 0, 1]]), **kw),
@@ -180,7 +180,7 @@ class ParallelBetaDiversity(TestCase):
 
         for okw, ekw in zip(obs, exp):
             npt.assert_equal(okw['counts'], ekw['counts'])
-            npt.assert_equal(okw['otu_ids'], ekw['otu_ids'])
+            npt.assert_equal(okw['taxa'], ekw['taxa'])
             self.assertEqual(str(okw['tree']), str(ekw['tree']))
 
     def test_pairs_to_compute_rids_are_cids(self):

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -68,19 +68,19 @@ class AlphaDiversityTests(TestCase):
         self.assertRaises(TypeError, alpha_diversity, 'sobs',
                           [0, 1], not_a_real_kwarg=42.0)
         self.assertRaises(TypeError, alpha_diversity, 'faith_pd',
-                          [0, 1], tree=self.tree1, otu_ids=['OTU1', 'OTU2'],
+                          [0, 1], tree=self.tree1, taxa=['OTU1', 'OTU2'],
                           not_a_real_kwarg=42.0)
         self.assertRaises(TypeError, alpha_diversity, faith_pd,
-                          [0, 1], tree=self.tree1, otu_ids=['OTU1', 'OTU2'],
+                          [0, 1], tree=self.tree1, taxa=['OTU1', 'OTU2'],
                           not_a_real_kwarg=42.0)
 
     def test_invalid_input_phylogenetic(self):
-        # otu_ids not provided
+        # taxa not provided
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd', self.table1,
                           list('ABC'), tree=self.tree1)
         # tree not provided
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd', self.table1,
-                          list('ABC'), otu_ids=self.oids1)
+                          list('ABC'), taxa=self.oids1)
 
         # tree has duplicated tip ids
         t = TreeNode.read(
@@ -88,27 +88,27 @@ class AlphaDiversityTests(TestCase):
                 '(((((OTU2:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(DuplicateNodeError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
         # unrooted tree as input
         t = TreeNode.read(io.StringIO(
             '((OTU1:0.1, OTU2:0.2):0.3, OTU3:0.5,OTU4:0.7);'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
-        # otu_ids has duplicated ids
+        # taxa has duplicated ids
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU2']
+        taxa = ['OTU1', 'OTU2', 'OTU2']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
         # count and OTU vectors are not equal length
         t = TreeNode.read(
@@ -116,44 +116,44 @@ class AlphaDiversityTests(TestCase):
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2']
+        taxa = ['OTU1', 'OTU2']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
         # tree with no branch lengths
         t = TreeNode.read(
             io.StringIO('((((OTU1,OTU2),OTU3)),(OTU4,OTU5));'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
         # tree missing some branch lengths
         t = TreeNode.read(
             io.StringIO('(((((OTU1,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                         '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
-        # some otu_ids not present in tree
+        # some taxa not present in tree
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU42']
+        taxa = ['OTU1', 'OTU2', 'OTU42']
         self.assertRaises(MissingNodeError, alpha_diversity, 'faith_pd',
-                          counts, otu_ids=otu_ids, tree=t)
+                          counts, taxa=taxa, tree=t)
 
     def test_empty(self):
         # empty vector
@@ -176,21 +176,21 @@ class AlphaDiversityTests(TestCase):
 
         # empty vector
         actual = alpha_diversity('faith_pd', np.array([], dtype=np.int64),
-                                 tree=self.tree1, otu_ids=[])
+                                 tree=self.tree1, taxa=[])
         expected = pd.Series([0.])
         assert_series_almost_equal(actual, expected)
 
         # array of empty vector
         actual = alpha_diversity('faith_pd',
                                  np.array([[]], dtype=np.int64),
-                                 tree=self.tree1, otu_ids=[])
+                                 tree=self.tree1, taxa=[])
         expected = pd.Series([0.])
         assert_series_almost_equal(actual, expected)
 
         # array of empty vectors
         actual = alpha_diversity('faith_pd',
                                  np.array([[], []], dtype=np.int64),
-                                 tree=self.tree1, otu_ids=[])
+                                 tree=self.tree1, taxa=[])
         expected = pd.Series([0., 0.])
         assert_series_almost_equal(actual, expected)
 
@@ -200,7 +200,7 @@ class AlphaDiversityTests(TestCase):
         assert_series_almost_equal(actual, expected)
 
         actual = alpha_diversity('faith_pd', np.array([1, 3, 0, 1, 0]),
-                                 tree=self.tree1, otu_ids=self.oids1)
+                                 tree=self.tree1, taxa=self.oids1)
         self.assertAlmostEqual(actual[0], 4.5)
 
     def test_input_types(self):
@@ -211,9 +211,9 @@ class AlphaDiversityTests(TestCase):
         assert_series_almost_equal(list_result, array_result)
 
         list_result = alpha_diversity('faith_pd', [1, 3, 0, 1, 0],
-                                      tree=self.tree1, otu_ids=self.oids1)
+                                      tree=self.tree1, taxa=self.oids1)
         array_result = alpha_diversity('faith_pd', np.array([1, 3, 0, 1, 0]),
-                                       tree=self.tree1, otu_ids=self.oids1)
+                                       tree=self.tree1, taxa=self.oids1)
         self.assertAlmostEqual(list_result[0], 4.5)
         assert_series_almost_equal(list_result, array_result)
 
@@ -235,46 +235,46 @@ class AlphaDiversityTests(TestCase):
         # calling it directly
         expected = []
         for e in self.table1:
-            expected.append(faith_pd(e, tree=self.tree1, otu_ids=self.oids1))
+            expected.append(faith_pd(e, tree=self.tree1, taxa=self.oids1))
         expected = pd.Series(expected)
         actual = alpha_diversity('faith_pd', self.table1, tree=self.tree1,
-                                 otu_ids=self.oids1)
+                                 taxa=self.oids1)
         assert_series_almost_equal(actual, expected)
 
         # alt input table and tree
         expected = []
         for e in self.table2:
-            expected.append(faith_pd(e, tree=self.tree2, otu_ids=self.oids2))
+            expected.append(faith_pd(e, tree=self.tree2, taxa=self.oids2))
         expected = pd.Series(expected)
         actual = alpha_diversity('faith_pd', self.table2, tree=self.tree2,
-                                 otu_ids=self.oids2)
+                                 taxa=self.oids2)
         assert_series_almost_equal(actual, expected)
 
     def test_phydiv(self):
         expected = []
         for e in self.table1:
-            expected.append(phydiv(e, tree=self.tree1, otu_ids=self.oids1))
+            expected.append(phydiv(e, tree=self.tree1, taxa=self.oids1))
         expected = pd.Series(expected)
         actual = alpha_diversity('phydiv', self.table1, tree=self.tree1,
-                                 otu_ids=self.oids1)
+                                 taxa=self.oids1)
         assert_series_almost_equal(actual, expected)
 
         expected = []
         for e in self.table1:
-            expected.append(phydiv(e, tree=self.tree1, otu_ids=self.oids1,
+            expected.append(phydiv(e, tree=self.tree1, taxa=self.oids1,
                                    rooted=False))
         expected = pd.Series(expected)
         actual = alpha_diversity('phydiv', self.table1, tree=self.tree1,
-                                 otu_ids=self.oids1, rooted=False)
+                                 taxa=self.oids1, rooted=False)
         assert_series_almost_equal(actual, expected)
 
         expected = []
         for e in self.table1:
-            expected.append(phydiv(e, tree=self.tree1, otu_ids=self.oids1,
+            expected.append(phydiv(e, tree=self.tree1, taxa=self.oids1,
                                    weight=True))
         expected = pd.Series(expected)
         actual = alpha_diversity('phydiv', self.table1, tree=self.tree1,
-                                 otu_ids=self.oids1, weight=True)
+                                 taxa=self.oids1, weight=True)
         assert_series_almost_equal(actual, expected)
 
     def test_no_ids(self):
@@ -287,9 +287,9 @@ class AlphaDiversityTests(TestCase):
         # calling optimized faith_pd gives same results as calling unoptimized
         # version
         optimized = alpha_diversity('faith_pd', self.table1, tree=self.tree1,
-                                    otu_ids=self.oids1)
+                                    taxa=self.oids1)
         unoptimized = alpha_diversity(faith_pd, self.table1, tree=self.tree1,
-                                      otu_ids=self.oids1)
+                                      taxa=self.oids1)
         assert_series_almost_equal(optimized, unoptimized)
 
 
@@ -383,27 +383,27 @@ class BetaDiversityTests(TestCase):
         with self.assertRaisesRegex(TypeError, error_msg):
             beta_diversity('unweighted_unifrac', [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0, tree=self.tree1,
-                           otu_ids=['O1', 'O2', 'O3'])
+                           taxa=['O1', 'O2', 'O3'])
         with self.assertRaisesRegex(TypeError, error_msg):
             beta_diversity('weighted_unifrac', [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0, tree=self.tree1,
-                           otu_ids=['O1', 'O2', 'O3'])
+                           taxa=['O1', 'O2', 'O3'])
         with self.assertRaisesRegex(TypeError, error_msg):
             beta_diversity(weighted_unifrac, [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0, tree=self.tree1,
-                           otu_ids=['O1', 'O2', 'O3'])
+                           taxa=['O1', 'O2', 'O3'])
 
     def test_invalid_input_phylogenetic(self):
-        # otu_ids not provided
+        # taxa not provided
         self.assertRaises(ValueError, beta_diversity, 'weighted_unifrac',
                           self.table1, list('ABC'), tree=self.tree1)
         self.assertRaises(ValueError, beta_diversity, 'unweighted_unifrac',
                           self.table1, list('ABC'), tree=self.tree1)
         # tree not provided
         self.assertRaises(ValueError, beta_diversity, 'weighted_unifrac',
-                          self.table1, list('ABC'), otu_ids=self.oids1)
+                          self.table1, list('ABC'), taxa=self.oids1)
         self.assertRaises(ValueError, beta_diversity, 'unweighted_unifrac',
-                          self.table1, list('ABC'), otu_ids=self.oids1)
+                          self.table1, list('ABC'), taxa=self.oids1)
 
         # tree has duplicated tip ids
         t = TreeNode.read(
@@ -411,35 +411,35 @@ class BetaDiversityTests(TestCase):
                 '(((((OTU2:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(DuplicateNodeError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(DuplicateNodeError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
         # unrooted tree as input
         t = TreeNode.read(io.StringIO('((OTU1:0.1, OTU2:0.2):0.3, OTU3:0.5,'
                                       'OTU4:0.7);'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
-        # otu_ids has duplicated ids
+        # taxa has duplicated ids
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU2']
+        taxa = ['OTU1', 'OTU2', 'OTU2']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
         # count and OTU vectors are not equal length
@@ -448,33 +448,33 @@ class BetaDiversityTests(TestCase):
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2']
+        taxa = ['OTU1', 'OTU2']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 2]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
         # tree with no branch lengths
         t = TreeNode.read(
             io.StringIO('((((OTU1,OTU2),OTU3)),(OTU4,OTU5));'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
         # tree missing some branch lengths
@@ -482,24 +482,24 @@ class BetaDiversityTests(TestCase):
             io.StringIO('(((((OTU1,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                         '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU3']
+        taxa = ['OTU1', 'OTU2', 'OTU3']
         self.assertRaises(ValueError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(ValueError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
-        # some otu_ids not present in tree
+        # some taxa not present in tree
         t = TreeNode.read(
             io.StringIO(
                 '(((((OTU1:0.5,OTU2:0.5):0.5,OTU3:1.0):1.0):0.0,(OTU4:'
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
-        otu_ids = ['OTU1', 'OTU2', 'OTU42']
+        taxa = ['OTU1', 'OTU2', 'OTU42']
         self.assertRaises(MissingNodeError, beta_diversity,
-                          'weighted_unifrac', counts, otu_ids=otu_ids, tree=t)
+                          'weighted_unifrac', counts, taxa=taxa, tree=t)
         self.assertRaises(MissingNodeError, beta_diversity,
-                          'unweighted_unifrac', counts, otu_ids=otu_ids,
+                          'unweighted_unifrac', counts, taxa=taxa,
                           tree=t)
 
     def test_empty(self):
@@ -512,7 +512,7 @@ class BetaDiversityTests(TestCase):
 
         actual = beta_diversity('unweighted_unifrac',
                                 np.array([[], []], dtype=np.int64),
-                                ids=['a', 'b'], tree=self.tree1, otu_ids=[])
+                                ids=['a', 'b'], tree=self.tree1, taxa=[])
         expected_dm = DistanceMatrix([[0.0, 0.0], [0.0, 0.0]], ['a', 'b'])
         self.assertEqual(actual, expected_dm)
 
@@ -587,9 +587,9 @@ class BetaDiversityTests(TestCase):
         # near-equality testing when that support is available
         # expected values calculated by hand
         dm1 = beta_diversity('unweighted_unifrac', self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1)
+                             taxa=self.oids1, tree=self.tree1)
         dm2 = beta_diversity(unweighted_unifrac, self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1)
+                             taxa=self.oids1, tree=self.tree1)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
         expected_data = [[0.0, 0.0, 0.25],
@@ -606,9 +606,9 @@ class BetaDiversityTests(TestCase):
         # near-equality testing when that support is available
         # expected values calculated by hand
         dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1)
+                             taxa=self.oids1, tree=self.tree1)
         dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1)
+                             taxa=self.oids1, tree=self.tree1)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
         expected_data = [
@@ -626,10 +626,10 @@ class BetaDiversityTests(TestCase):
         # near-equality testing when that support is available
         # expected values calculated by hand
         dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1,
+                             taxa=self.oids1, tree=self.tree1,
                              normalized=True)
         dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1,
+                             taxa=self.oids1, tree=self.tree1,
                              normalized=True)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
@@ -660,19 +660,19 @@ class BetaDiversityTests(TestCase):
         def not_a_real_pdist(counts, metric):
             return [[0.0, 42.0], [42.0, 0.0]]
         dm1 = beta_diversity('unweighted_unifrac', self.table1,
-                             otu_ids=self.oids1, tree=self.tree1,
+                             taxa=self.oids1, tree=self.tree1,
                              pairwise_func=not_a_real_pdist)
         expected = DistanceMatrix([[0.0, 42.0], [42.0, 0.0]])
         self.assertEqual(dm1, expected)
 
         dm1 = beta_diversity('weighted_unifrac', self.table1,
-                             otu_ids=self.oids1, tree=self.tree1,
+                             taxa=self.oids1, tree=self.tree1,
                              pairwise_func=not_a_real_pdist)
         expected = DistanceMatrix([[0.0, 42.0], [42.0, 0.0]])
         self.assertEqual(dm1, expected)
 
         dm1 = beta_diversity(unweighted_unifrac, self.table1,
-                             otu_ids=self.oids1, tree=self.tree1,
+                             taxa=self.oids1, tree=self.tree1,
                              pairwise_func=not_a_real_pdist)
         expected = DistanceMatrix([[0.0, 42.0], [42.0, 0.0]])
         self.assertEqual(dm1, expected)
@@ -729,7 +729,7 @@ class TestPartialBetaDiversity(TestCase):
     def test_id_pairs_as_iterable(self):
         id_pairs = iter([('B', 'C'), ])
         dm = partial_beta_diversity('unweighted_unifrac', self.table1,
-                                    self.sids1, otu_ids=self.oids1,
+                                    self.sids1, taxa=self.oids1,
                                     tree=self.tree1, id_pairs=id_pairs)
         self.assertEqual(dm.shape, (3, 3))
         expected_data = [[0.0, 0.0, 0.0],
@@ -748,7 +748,7 @@ class TestPartialBetaDiversity(TestCase):
         # near-equality testing when that support is available
         # expected values calculated by hand
         dm = partial_beta_diversity('unweighted_unifrac', self.table1,
-                                    self.sids1, otu_ids=self.oids1,
+                                    self.sids1, taxa=self.oids1,
                                     tree=self.tree1, id_pairs=[('B', 'C'), ])
         self.assertEqual(dm.shape, (3, 3))
         expected_data = [[0.0, 0.0, 0.0],
@@ -765,12 +765,12 @@ class TestPartialBetaDiversity(TestCase):
         # near-equality testing when that support is available
         # expected values calculated by hand
         dm1 = partial_beta_diversity('weighted_unifrac', self.table1,
-                                     self.sids1, otu_ids=self.oids1,
+                                     self.sids1, taxa=self.oids1,
                                      tree=self.tree1, id_pairs=[('A', 'B'),
                                                                 ('A', 'C'),
                                                                 ('B', 'C')])
         dm2 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
-                             otu_ids=self.oids1, tree=self.tree1)
+                             taxa=self.oids1, tree=self.tree1)
 
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)

--- a/skbio/diversity/tests/test_util.py
+++ b/skbio/diversity/tests/test_util.py
@@ -16,7 +16,7 @@ import numpy.testing as npt
 from skbio import TreeNode
 from skbio.diversity._util import (_validate_counts_vector,
                                    _validate_counts_matrix,
-                                   _validate_otu_ids_and_tree,
+                                   _validate_taxa_and_tree,
                                    _vectorize_counts_and_tree,
                                    _quantitative_to_qualitative_counts)
 from skbio.tree import DuplicateNodeError, MissingNodeError
@@ -128,7 +128,7 @@ class ValidationTests(TestCase):
         with self.assertRaises(ValueError):
             _validate_counts_matrix([[0, 0, 75], [0, 0, 3], [9, 8, 22, 44]])
 
-    def test_validate_otu_ids_and_tree(self):
+    def test_validate_taxa_and_tree(self):
         # basic valid input
         t = TreeNode.read(
             io.StringIO(
@@ -136,7 +136,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 1, 1]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertTrue(_validate_otu_ids_and_tree(counts, otu_ids, t) is None)
+        self.assertTrue(_validate_taxa_and_tree(counts, otu_ids, t) is None)
 
         # all tips observed
         t = TreeNode.read(
@@ -145,7 +145,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 1, 1, 1, 1]
         otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5']
-        self.assertTrue(_validate_otu_ids_and_tree(counts, otu_ids, t) is None)
+        self.assertTrue(_validate_taxa_and_tree(counts, otu_ids, t) is None)
 
         # no tips observed
         t = TreeNode.read(
@@ -154,7 +154,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = []
         otu_ids = []
-        self.assertTrue(_validate_otu_ids_and_tree(counts, otu_ids, t) is None)
+        self.assertTrue(_validate_taxa_and_tree(counts, otu_ids, t) is None)
 
         # all counts zero
         t = TreeNode.read(
@@ -163,9 +163,9 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [0, 0, 0, 0, 0]
         otu_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4', 'OTU5']
-        self.assertTrue(_validate_otu_ids_and_tree(counts, otu_ids, t) is None)
+        self.assertTrue(_validate_taxa_and_tree(counts, otu_ids, t) is None)
 
-    def test_validate_otu_ids_and_tree_invalid_input(self):
+    def test_validate_taxa_and_tree_invalid_input(self):
         # tree has duplicated tip ids
         t = TreeNode.read(
             io.StringIO(
@@ -173,7 +173,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU2:0.75):1.25):0.0)root;'))
         counts = [1, 1, 1]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertRaises(DuplicateNodeError, _validate_otu_ids_and_tree,
+        self.assertRaises(DuplicateNodeError, _validate_taxa_and_tree,
                           counts, otu_ids, t)
 
         # unrooted tree as input
@@ -181,7 +181,7 @@ class ValidationTests(TestCase):
                                       'OTU4:0.7);'))
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # otu_ids has duplicated ids
@@ -191,7 +191,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2', 'OTU2']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # len of vectors not equal
@@ -201,11 +201,11 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # tree with no branch lengths
@@ -213,7 +213,7 @@ class ValidationTests(TestCase):
             io.StringIO('((((OTU1,OTU2),OTU3)),(OTU4,OTU5));'))
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # tree missing some branch lengths
@@ -223,7 +223,7 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2', 'OTU3']
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # otu_ids not present in tree
@@ -233,14 +233,14 @@ class ValidationTests(TestCase):
                 '0.75,OTU5:0.75):1.25):0.0)root;'))
         counts = [1, 2, 3]
         otu_ids = ['OTU1', 'OTU2', 'OTU32']
-        self.assertRaises(MissingNodeError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(MissingNodeError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
         # single node tree
         t = TreeNode.read(io.StringIO('root;'))
         counts = []
         otu_ids = []
-        self.assertRaises(ValueError, _validate_otu_ids_and_tree, counts,
+        self.assertRaises(ValueError, _validate_taxa_and_tree, counts,
                           otu_ids, t)
 
     def test_vectorize_counts_and_tree(self):

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -82,7 +82,7 @@ Consider a very simple environment with only 3 species. The species
 in the environment are equally distributed and their proportions are
 equivalent:
 
->>> otus = np.array([1./3, 1./3., 1./3])
+>>> taxa = np.array([1./3, 1./3., 1./3])
 
 Suppose that an antibiotic kills off half of the population for the
 first two species, but doesn't harm the third species. Then the
@@ -92,7 +92,7 @@ perturbation vector would be as follows
 
 And the resulting perturbation would be
 
->>> perturb(otus, antibiotic)
+>>> perturb(taxa, antibiotic)
 array([ 0.25,  0.25,  0.5 ])
 
 
@@ -1304,7 +1304,7 @@ def ancom(
     >>> import pandas as pd
 
     Now let's load in a DataFrame with 6 samples and 7 features (e.g.,
-    these may be bacterial OTUs):
+    these may be bacterial taxa):
 
     >>> table = pd.DataFrame([[12, 11, 10, 10, 10, 10, 10],
     ...                       [9,  11, 12, 10, 10, 10, 10],
@@ -1571,17 +1571,17 @@ def _log_compare(mat, cats, significance_test=scipy.stats.ttest_ind):
     Parameters
     ----------
     mat: np.array
-       rows correspond to samples and columns correspond to
-       features (i.e. OTUs)
+        Matrix with rows corresponding to samples and columns corresponding to
+        features.
     cats: np.array, float
-       Vector of categories
+        Vector of categories.
     significance_test: function
-        statistical test to run
+        Statistical test to run.
 
     Returns
     -------
     log_ratio : np.array
-        log ratio pvalue matrix
+        Log ratio pvalue matrix.
 
     """
     r, c = mat.shape

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -22,7 +22,7 @@ def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
     Parameters
     ----------
     dm : skbio.DistanceMatrix
-        Input distance matrix containing distances between OTUs.
+        Input distance matrix containing distances between taxa.
     disallow_negative_branch_length : bool, optional
         Neighbor joining can result in negative branch lengths, which don't
         make sense in an evolutionary context. If `True`, negative branch
@@ -66,7 +66,7 @@ def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
     Examples
     --------
     Define a new distance matrix object describing the distances between five
-    OTUs: a, b, c, d, and e.
+    taxa: a, b, c, d, and e.
 
     >>> from skbio import DistanceMatrix
     >>> from skbio.tree import nj
@@ -80,7 +80,7 @@ def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
     >>> dm = DistanceMatrix(data, ids)
 
     Contstruct the neighbor joining tree representing the relationship between
-    those OTUs. This is returned as a TreeNode object.
+    those taxa. This is returned as a TreeNode object.
 
     >>> tree = nj(dm)
     >>> print(tree.ascii_art())

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -65,23 +65,23 @@ class TreeTests(TestCase):
         self.assertEqual(id(new_tree), id(new_tree.children[1].parent))
 
     def test_observed_node_counts(self):
-        """returns observed nodes counts given vector of otu observation counts
+        """returns observed nodes counts given vector of observed taxon counts
         """
-        # no OTUs observed
-        otu_counts = {}
+        # no taxon observed
+        taxon_counts = {}
         expected = defaultdict(int)
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
         # error on zero count(s)
-        otu_counts = {'a': 0}
+        taxon_counts = {'a': 0}
         self.assertRaises(ValueError, self.simple_t.observed_node_counts,
-                          otu_counts)
-        otu_counts = {'a': 0, 'b': 0, 'c': 0, 'd': 0}
+                          taxon_counts)
+        taxon_counts = {'a': 0, 'b': 0, 'c': 0, 'd': 0}
         self.assertRaises(ValueError, self.simple_t.observed_node_counts,
-                          otu_counts)
+                          taxon_counts)
 
-        # all OTUs observed once
-        otu_counts = {'a': 1, 'b': 1, 'c': 1, 'd': 1}
+        # all taxa observed once
+        taxon_counts = {'a': 1, 'b': 1, 'c': 1, 'd': 1}
         expected = defaultdict(int)
         expected[self.simple_t.find('root')] = 4
         expected[self.simple_t.find('i1')] = 2
@@ -90,11 +90,11 @@ class TreeTests(TestCase):
         expected[self.simple_t.find('b')] = 1
         expected[self.simple_t.find('c')] = 1
         expected[self.simple_t.find('d')] = 1
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        # some OTUs observed twice
-        otu_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 1}
+        # some taxa observed twice
+        taxon_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 1}
         expected = defaultdict(int)
         expected[self.simple_t.find('root')] = 5
         expected[self.simple_t.find('i1')] = 3
@@ -103,10 +103,10 @@ class TreeTests(TestCase):
         expected[self.simple_t.find('b')] = 1
         expected[self.simple_t.find('c')] = 1
         expected[self.simple_t.find('d')] = 1
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        otu_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 2}
+        taxon_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 2}
         expected = defaultdict(int)
         expected[self.simple_t.find('root')] = 6
         expected[self.simple_t.find('i1')] = 3
@@ -115,47 +115,47 @@ class TreeTests(TestCase):
         expected[self.simple_t.find('b')] = 1
         expected[self.simple_t.find('c')] = 1
         expected[self.simple_t.find('d')] = 2
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        # some OTUs observed, others not observed
-        otu_counts = {'a': 2, 'b': 1}
+        # some taxa observed, others not observed
+        taxon_counts = {'a': 2, 'b': 1}
         expected = defaultdict(int)
         expected[self.simple_t.find('root')] = 3
         expected[self.simple_t.find('i1')] = 3
         expected[self.simple_t.find('a')] = 2
         expected[self.simple_t.find('b')] = 1
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        otu_counts = {'d': 1}
+        taxon_counts = {'d': 1}
         expected = defaultdict(int)
         expected[self.simple_t.find('root')] = 1
         expected[self.simple_t.find('i2')] = 1
         expected[self.simple_t.find('d')] = 1
-        self.assertEqual(self.simple_t.observed_node_counts(otu_counts),
+        self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
         # error on non-tips
-        otu_counts = {'a': 2, 'e': 1}
+        taxon_counts = {'a': 2, 'e': 1}
         self.assertRaises(MissingNodeError, self.simple_t.observed_node_counts,
-                          otu_counts)
-        otu_counts = {'a': 2, 'i1': 1}
+                          taxon_counts)
+        taxon_counts = {'a': 2, 'i1': 1}
         self.assertRaises(MissingNodeError, self.simple_t.observed_node_counts,
-                          otu_counts)
+                          taxon_counts)
 
         # test with another tree
-        otu_counts = {}
+        taxon_counts = {}
         expected = defaultdict(int)
-        self.assertEqual(self.complex_tree.observed_node_counts(otu_counts),
+        self.assertEqual(self.complex_tree.observed_node_counts(taxon_counts),
                          expected)
 
-        otu_counts = {'e': 42, 'f': 1}
+        taxon_counts = {'e': 42, 'f': 1}
         expected[self.complex_tree.root()] = 43
         expected[self.complex_tree.find('int5')] = 43
         expected[self.complex_tree.find('e')] = 42
         expected[self.complex_tree.find('f')] = 1
-        self.assertEqual(self.complex_tree.observed_node_counts(otu_counts),
+        self.assertEqual(self.complex_tree.observed_node_counts(taxon_counts),
                          expected)
 
     def test_count(self):

--- a/web/devdoc/code_guide.rst
+++ b/web/devdoc/code_guide.rst
@@ -332,10 +332,10 @@ Here is an example of a ``nose`` test module structure:
         assert_almost_equal(ace(np.array([12, 3, 2, 1])), 4.6)
         assert_almost_equal(ace(np.array([12, 3, 6, 1, 10])), 5.62749672)
 
-        # Just returns the number of OTUs when all are abundant.
+        # Just returns the number of taxa when all are abundant.
         assert_almost_equal(ace(np.array([12, 12, 13, 14])), 4.0)
 
-        # Border case: only singletons and 10-tons, no abundant OTUs.
+        # Border case: only singletons and 10-tons, no abundant taxa.
         assert_almost_equal(ace([0, 1, 1, 0, 0, 10, 10, 1, 0, 0]), 9.35681818182)
 
 


### PR DESCRIPTION
This PR removes the outdated term "OTU" from both documentation and code, and replaces it with the more generic term "taxon". As a consequence, the parameter `otu_ids` now becomes `taxa`. This affects `faith_pd`, `phydiv`, `unweighted_unifrac` and `weighted_unifrac`. The parameter `otu_ids` is kept as an alias of `taxa`, such that existing code that uses these functions will not break. A deprecation warning is displayed in the documentation.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
