### PR TITLE
House keeping works for the composition module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@
 
 * Added biom-format Table import and updated corresponding requirement files ([#1907](https://github.com/scikit-bio/scikit-bio/pull/1907)).
 * Added biom-format 2.1.0 IO support ([#1984](https://github.com/scikit-bio/scikit-bio/pull/1984)).
-* Added ``Table`` support to `alpha_diversity` and `beta_diversity` drivers ([#1984](https://github.com/scikit-bio/scikit-bio/pull/1984)).
+* Added `Table` support to `alpha_diversity` and `beta_diversity` drivers ([#1984](https://github.com/scikit-bio/scikit-bio/pull/1984)).
 * Implemented a mechanism to automatically build documentation and/or homepage and deploy them to the website ([#1934](https://github.com/scikit-bio/scikit-bio/pull/1934)).
+* Added the Benjamini-Hochberg method as an option for FDR correction (in addition to the existing Holm-Bonferroni method) for `ancom` and `dirmult_ttest` ([#1988](https://github.com/scikit-bio/scikit-bio/pull/1988)).
+* Added function `dirmult_ttest`, which performs differential abundance test using a Dirichilet multinomial distribution. This function mirrors the method provided by ALDEx2 ([#1956](https://github.com/scikit-bio/scikit-bio/pull/1956)).
 * Added method `Sequence.to_indices` to convert a sequence into a vector of indices of characters in an alphabet (can be from a substitution matrix) or unique characters observed in the sequence. Supports gap masking and wildcard substitution ([#1917](https://github.com/scikit-bio/scikit-bio/pull/1917)).
 * Added class `SubstitutionMatrix` to support subsitution matrices for nucleotides, amino acids are more general cases ([#1913](https://github.com/scikit-bio/scikit-bio/pull/1913)).
 * Added alpha diversity metric `sobs`, which is the observed species richness (S_{obs}) of a sample. `sobs` will replace `observed_otus`, which uses the historical term "OTU". Also added metric `observed_features` to be compatible with the QIIME 2 terminology. All three metrics are equivalent ([#1902](https://github.com/scikit-bio/scikit-bio/pull/1902)).
@@ -25,7 +27,7 @@
 * SciPy 1.11+ is now supported ([#1887](https://github.com/scikit-bio/scikit-bio/pull/1887)).
 * Removed IPython as a dependency. Scikit-bio continues to support displaying plots in IPython, but it no longer requires importing IPython functionality ([#1901](https://github.com/scikit-bio/scikit-bio/pull/1901)).
 * Made Matplotlib an optional dependency. Scikit-bio no longer requires Matplotlib except for plotting, during which it attempts to import Matplotlib if it is present in the system, and raises an error if not ([#1901](https://github.com/scikit-bio/scikit-bio/pull/1901)).
-* Ported the qiime2 metadata object into skbio. ([#1929](https://github.com/scikit-bio/scikit-bio/pull/1929))
+* Ported the QIIME 2 metadata object into skbio. ([#1929](https://github.com/scikit-bio/scikit-bio/pull/1929))
 * Python 3.12+ is now supported, thank you @actapia ([#1930](https://github.com/scikit-bio/scikit-bio/pull/1930))
 * Introduced native character conversion ([#1971])(https://github.com/scikit-bio/scikit-bio/pull/1971)
 
@@ -44,9 +46,10 @@
 
 ### Miscellaneous
 
-* Replaced the historical term "OTU" with the more generic term "taxon" (plural: "taxa"). As a consequence, the parameter "otu_ids" in phylogenetic alpha and beta diversity metrics was replaced by "taxa". Meanwhile,
-the old parameter "otu_ids" is still kept as an alias of "taxa" for backward compatibility. However it will be removed in a future release.
+* Replaced the historical term "OTU" with the more generic term "taxon" (plural: "taxa"). As a consequence, the parameter "otu_ids" in phylogenetic alpha and beta diversity metrics was replaced by "taxa". Meanwhile, the old parameter "otu_ids" is still kept as an alias of "taxa" for backward compatibility. However it will be removed in a future release.
 * Revised contributor's guidelines.
+* Renamed function `multiplicative_replacement` as `multi_replace` for conciseness ([#1988](https://github.com/scikit-bio/scikit-bio/pull/1988)).
+* Renamed parameter `multiple_comparisons_correction` as `p_adjust` of function `ancom` for conciseness ([#1988](https://github.com/scikit-bio/scikit-bio/pull/1988)).
 * Enabled code coverage reporting via Codecov. See [#1954](https://github.com/scikit-bio/scikit-bio/pull/1954).
 * Renamed the default branch from "master" to "main". See [#1953](https://github.com/scikit-bio/scikit-bio/pull/1953).
 * Enabled subclassing of DNA, RNA and Protein classes to allow secondary development.

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -1292,6 +1292,11 @@ def ancom(
         accept at least two vectors of floats and returns a test statistic and
         a *p*-value. Functions under ``scipy.stats`` can be directly specified
         by name. The default is one-way ANOVA ("f_oneway").
+
+        .. versionchanged:: 0.6.0
+
+            Accepts test names in addition to functions.
+
     percentiles : iterable of floats, optional
         Percentile abundances to return for each feature in each group. By
         default, will return the minimum, 25th percentile, median, 75th
@@ -1330,6 +1335,9 @@ def ancom(
     --------
     ``multiple_comparisons_correction`` is deprecated as of ``0.6.0``. It has
     been renamed to ``p_adjust``.
+
+    ``significance_test=None` is deprecated as of ``0.6.0``. The default value
+    is now "f_oneway".
 
     Notes
     -----
@@ -1490,7 +1498,7 @@ def ancom(
     if not 0 < theta < 1:
         raise ValueError("`theta`=%f is not within 0 and 1." % theta)
 
-    # deprecated parameter
+    # @deprecated
     if multiple_comparisons_correction != "holm-bonferroni":
         _warn_deprecated(ancom, "0.6.0")
         p_adjust = multiple_comparisons_correction
@@ -1538,6 +1546,7 @@ def ancom(
             "single group)."
         )
 
+    # @deprecated
     if significance_test is None:
         significance_test = "f_oneway"
 

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -92,6 +92,7 @@ from scipy.stats import t, gmean
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import find_duplicates
 from skbio.util._misc import get_rng
+from skbio.util._warning import _warn_deprecated
 
 
 def closure(mat):
@@ -238,14 +239,7 @@ def multiplicative_replacement(mat, delta=None):
     multi_replace
 
     """
-    # @deprecated
-    if not hasattr(multi_replace, "warned"):
-        simplefilter("once", DeprecationWarning)
-        warn(
-            "multiplicative_replacement is deprecated as of 0.6.0.", DeprecationWarning
-        )
-        multi_replace.warned = True
-
+    _warn_deprecated(multiplicative_replacement, "0.6.0")
     return multi_replace(mat, delta)
 
 
@@ -1288,6 +1282,11 @@ def ancom(
         Boniferroni ("holm" or "holm-bonferroni") (default) or Benjamini-
         Hochberg ("bh", "fdr_bh" or "benjamini-hochberg"). Case-insensitive. If
         None, no correction will be performed.
+
+        .. versionchanged:: 0.6.0
+
+            Replaces ``multiple_comparisons_correction`` for conciseness.
+
     significance_test : str or callable, optional
         A function to test for significance between classes. It must be able to
         accept at least two vectors of floats and returns a test statistic and
@@ -1334,7 +1333,7 @@ def ancom(
 
     Notes
     -----
-    The developers of ANCOM recommend the following significance tests ([2]_,
+    The developers of ANCOM recommend the following significance tests ([1]_,
     Supplementary File 1, top of page 11):
 
     - If there are two groups, use the standard parametric *t*-test
@@ -1493,13 +1492,7 @@ def ancom(
 
     # deprecated parameter
     if multiple_comparisons_correction != "holm-bonferroni":
-        if not hasattr(ancom, "warned"):
-            simplefilter("once", DeprecationWarning)
-            warn(
-                "multiple_comparisons_correction is deprecated as of 0.6.0.",
-                DeprecationWarning,
-            )
-            ancom.warned = True
+        _warn_deprecated(ancom, "0.6.0")
         p_adjust = multiple_comparisons_correction
 
     p_adjust = _dispatch_p_adjust(p_adjust)

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -517,7 +517,7 @@ def ilr(mat, basis=None, check=True):
     r"""Perform isometric log ratio transformation.
 
     This function transforms compositions from Aitchison simplex to the real
-    space. The :math: ilr` transform is both an isometry, and an isomorphism
+    space. The :math:`ilr` transform is both an isometry, and an isomorphism
     defined on the following spaces:
 
     .. math::
@@ -1336,7 +1336,7 @@ def ancom(
     ``multiple_comparisons_correction`` is deprecated as of ``0.6.0``. It has
     been renamed to ``p_adjust``.
 
-    ``significance_test=None` is deprecated as of ``0.6.0``. The default value
+    ``significance_test=None`` is deprecated as of ``0.6.0``. The default value
     is now "f_oneway".
 
     Notes

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -5,34 +5,32 @@ r"""Composition Statistics (:mod:`skbio.stats.composition`)
 
 This module provides functions for compositional data analysis.
 
-Many 'omics datasets are inherently compositional - meaning that they
-are best interpreted as proportions or percentages rather than
-absolute counts.
+Many omics datasets are inherently compositional -- meaning that they are best
+interpreted as proportions or percentages rather than absolute counts.
 
-Formally, :math:`x` is a composition if :math:`\sum_{i=0}^D x_{i} = c`
-and :math:`x_{i} > 0`, :math:`1 \leq i \leq D` and :math:`c` is a real
-valued constant and there are :math:`D` components for each
-composition. In this module :math:`c=1`. Compositional data can be
-analyzed using Aitchison geometry. [1]_
+Formally, sample :math:`x` is a composition if :math:`\sum_{i=0}^D x_{i} = c`
+and :math:`x_{i} > 0`, :math:`1 \leq i \leq D` and :math:`c` is a real-valued
+constant and there are :math:`D` components (features) for this composition.
+In this module :math:`c=1`. Compositional data can be analyzed using
+**Aitchison geometry** [1]_.
 
-However, in this framework, standard real Euclidean operations such as
-addition and multiplication no longer apply. Only operations such as
-perturbation and power can be used to manipulate this data.
+However, in this framework, standard real Euclidean operations such as addition
+and multiplication no longer apply. Only operations such as perturbation and
+power can be used to manipulate this data.
 
 This module allows two styles of manipulation of compositional data.
-Compositional data can be analyzed using perturbation and power
-operations, which can be useful for simulation studies. The
-alternative strategy is to transform compositional data into the real
-space.  Right now, the centre log ratio transform (clr) and
-the isometric log ratio transform (ilr) [2]_ can be used to accomplish
-this. This transform can be useful for performing standard statistical
-tools such as parametric hypothesis testing, regressions and more.
+Compositional data can be analyzed using perturbation and power operations,
+which can be useful for simulation studies. The alternative strategy is to
+transform compositional data into the real space. Right now, the centre log
+ratio transform (clr) and the isometric log ratio transform (ilr) [2]_ can be
+used to accomplish this. This transform can be useful for performing standard
+statistical methods such as parametric hypothesis testing, regression and more.
 
-The major caveat of using this framework is dealing with zeros.  In
-the Aitchison geometry, only compositions with nonzero components can
-be considered. The multiplicative replacement technique [3]_ can be
-used to substitute these zeros with small pseudocounts without
-introducing major distortions to the data.
+The major caveat of using this framework is dealing with zeros. In Aitchison
+geometry, only compositions with non-zero components can be considered.
+The multiplicative replacement technique [3]_ can be used to substitute these
+zeros with small pseudocounts without introducing major distortions to the
+data.
 
 Functions
 ---------
@@ -41,6 +39,7 @@ Functions
    :toctree:
 
    closure
+   multi_replace
    multiplicative_replacement
    perturb
    perturb_inv
@@ -60,7 +59,6 @@ Functions
    sbp_basis
    dirmult_ttest
 
-
 References
 ----------
 .. [1] V. Pawlowsky-Glahn, J. J. Egozcue, R. Tolosana-Delgado (2015),
@@ -73,29 +71,6 @@ References
    Compositional Data Sets Using Nonparametric Imputation",
    Mathematical Geology, 35.3 (2003)
 
-
-Examples
---------
->>> import numpy as np
-
-Consider a very simple environment with only 3 species. The species
-in the environment are equally distributed and their proportions are
-equivalent:
-
->>> taxa = np.array([1./3, 1./3., 1./3])
-
-Suppose that an antibiotic kills off half of the population for the
-first two species, but doesn't harm the third species. Then the
-perturbation vector would be as follows
-
->>> antibiotic = np.array([1./2, 1./2, 1])
-
-And the resulting perturbation would be
-
->>> perturb(taxa, antibiotic)
-array([ 0.25,  0.25,  0.5 ])
-
-
 """  # noqa: D205, D415
 
 # ----------------------------------------------------------------------------
@@ -106,14 +81,17 @@ array([ 0.25,  0.25,  0.5 ])
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from warnings import warn, simplefilter
+
 import numpy as np
 import pandas as pd
 import scipy.stats
-import skbio.util
-from skbio.stats.distance import DistanceMatrix
-from skbio.util._misc import get_rng
 from scipy.sparse import coo_matrix
-from scipy.stats import t
+from scipy.stats import t, gmean
+
+from skbio.stats.distance import DistanceMatrix
+from skbio.util import find_duplicates
+from skbio.util._misc import get_rng
 
 
 def closure(mat):
@@ -121,25 +99,23 @@ def closure(mat):
 
     Parameters
     ----------
-    mat : array_like
-       a matrix of proportions where
-       rows = compositions
-       columns = components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    array_like, np.float64
-       A matrix of proportions where all of the values
-       are nonzero and each composition (row) adds up to 1
+    ndarray of shape (n_compositions, n_components)
+        The matrix where all of the values are non-zero and each composition
+        (row) adds up to 1.
 
     Raises
     ------
     ValueError
-       Raises an error if any values are negative.
+        If any values are negative.
     ValueError
-       Raises an error if the matrix has more than 2 dimension.
+        If the matrix has more than two dimensions.
     ValueError
-       Raises an error if there is a row that has all zeros.
+        If there is a row that has all zeros.
 
     Examples
     --------
@@ -162,37 +138,32 @@ def closure(mat):
     return mat.squeeze()
 
 
-def multiplicative_replacement(mat, delta=None):
+def multi_replace(mat, delta=None):
     r"""Replace all zeros with small non-zero values.
 
-    It uses the multiplicative replacement strategy [1]_ ,
-    replacing zeros with a small positive :math:`\delta`
-    and ensuring that the compositions still add up to 1.
-
+    It uses the multiplicative replacement strategy [1]_, replacing zeros with
+    a small positive :math:`\delta` and ensuring that the compositions still
+    add up to 1.
 
     Parameters
     ----------
-    mat: array_like
-       a matrix of proportions where
-       rows = compositions and
-       columns = components
-    delta: float, optional
-       a small number to be used to replace zeros
-       If delta is not specified, then the default delta is
-       :math:`\delta = \frac{1}{N^2}` where :math:`N`
-       is the number of components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    delta : float, optional
+        A small number to be used to replace zeros. If not specified, the
+        default value is :math:`\delta = \frac{1}{N^2}` where :math:`N` is the
+        number of components.
 
     Returns
     -------
-    numpy.ndarray, np.float64
-       A matrix of proportions where all of the values
-       are nonzero and each composition (row) adds up to 1
+    ndarray of shape (n_compositions, n_components)
+        The matrix where all of the values are non-zero and each composition
+        (row) adds up to 1.
 
     Raises
     ------
     ValueError
-       Raises an error if negative proportions are created due to a large
-       `delta`.
+        If negative proportions are created due to a large ``delta``.
 
     Notes
     -----
@@ -203,13 +174,12 @@ def multiplicative_replacement(mat, delta=None):
     .. [1] J. A. Martin-Fernandez. "Dealing With Zeros and Missing Values in
            Compositional Data Sets Using Nonparametric Imputation"
 
-
     Examples
     --------
     >>> import numpy as np
-    >>> from skbio.stats.composition import multiplicative_replacement
-    >>> X = np.array([[.2,.4,.4, 0],[0,.5,.5,0]])
-    >>> multiplicative_replacement(X)
+    >>> from skbio.stats.composition import multi_replace
+    >>> X = np.array([[.2, .4, .4, 0],[0, .5, .5, 0]])
+    >>> multi_replace(X)
     array([[ 0.1875,  0.375 ,  0.375 ,  0.0625],
            [ 0.0625,  0.4375,  0.4375,  0.0625]])
 
@@ -233,15 +203,61 @@ def multiplicative_replacement(mat, delta=None):
     return mat.squeeze()
 
 
+def multiplicative_replacement(mat, delta=None):
+    r"""Replace all zeros with small non-zero values.
+
+    This function is an alias for ``multi_replace``.
+
+    Parameters
+    ----------
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    delta : float, optional
+        A small number to be used to replace zeros. If not specified, the
+        default value is :math:`\delta = \frac{1}{N^2}` where :math:`N` is the
+        number of components.
+
+    Returns
+    -------
+    ndarray of shape (n_compositions, n_components)
+        The matrix where all of the values are non-zero and each composition
+        (row) adds up to 1.
+
+    Raises
+    ------
+    ValueError
+        If negative proportions are created due to a large ``delta``.
+
+    Warnings
+    --------
+    ``multiplicative_replacement`` is deprecated as of ``0.6.0`` in favor of
+    ``multi_replace``.
+
+    See Also
+    --------
+    multi_replace
+
+    """
+    # @deprecated
+    if not hasattr(multi_replace, "warned"):
+        simplefilter("once", DeprecationWarning)
+        warn(
+            "multiplicative_replacement is deprecated as of 0.6.0.", DeprecationWarning
+        )
+        multi_replace.warned = True
+
+    return multi_replace(mat, delta)
+
+
 def perturb(x, y):
     r"""Perform the perturbation operation.
 
-    This operation is defined as
+    This operation is defined as:
 
     .. math::
         x \oplus y = C[x_1 y_1, \ldots, x_D y_D]
 
-    :math:`C[x]` is the closure operation defined as
+    :math:`C[x]` is the closure operation defined as:
 
     .. math::
         C[x] = \left[\frac{x_1}{\sum_{i=1}^{D} x_i},\ldots,
@@ -252,29 +268,37 @@ def perturb(x, y):
 
     Parameters
     ----------
-    x : array_like, float
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
-    y : array_like, float
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
+    x : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    y : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    numpy.ndarray, np.float64
-       A matrix of proportions where all of the values
-       are nonzero and each composition (row) adds up to 1
+    ndarray of shape (n_compositions, n_components)
+       A matrix of proportions where all of the values are non-zero and each
+       composition (row) adds up to 1.
 
     Examples
     --------
     >>> import numpy as np
     >>> from skbio.stats.composition import perturb
-    >>> x = np.array([.1,.3,.4, .2])
-    >>> y = np.array([1./6,1./6,1./3,1./3])
-    >>> perturb(x,y)
-    array([ 0.0625,  0.1875,  0.5   ,  0.25  ])
+
+    Consider a very simple environment with only three species. The species in
+    the environment are evenly distributed and their proportions are equal:
+
+    >>> before = np.array([1/3, 1/3, 1/3])
+
+    Suppose that an antibiotic kills off half of the population for the first
+    two species, but doesn't harm the third species. Then the perturbation
+    vector would be as follows:
+
+    >>> after = np.array([1/2, 1/2, 1])
+
+    And the resulting perturbation would be:
+
+    >>> perturb(before, after)
+    array([ 0.25,  0.25,  0.5 ])
 
     """
     x, y = closure(x), closure(y)
@@ -284,45 +308,40 @@ def perturb(x, y):
 def perturb_inv(x, y):
     r"""Perform the inverse perturbation operation.
 
-    This operation is defined as
+    This operation is defined as:
 
     .. math::
         x \ominus y = C[x_1 y_1^{-1}, \ldots, x_D y_D^{-1}]
 
-    :math:`C[x]` is the closure operation defined as
+    :math:`C[x]` is the closure operation defined as:
 
     .. math::
         C[x] = \left[\frac{x_1}{\sum_{i=1}^{D} x_i},\ldots,
                      \frac{x_D}{\sum_{i=1}^{D} x_i} \right]
 
-
-    for some :math:`D` dimensional real vector :math:`x` and
-    :math:`D` is the number of components for every composition.
+    for some :math:`D` dimensional real vector :math:`x` and :math:`D` is the
+    number of components for every composition.
 
     Parameters
     ----------
-    x : array_like
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
-    y : array_like
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
+    x : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    y : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    numpy.ndarray, np.float64
-       A matrix of proportions where all of the values
-       are nonzero and each composition (row) adds up to 1
+    ndarray of shape (n_compositions, n_components)
+        A matrix of proportions where all of the values are non-zero and each
+        composition (row) adds up to 1.
 
     Examples
     --------
     >>> import numpy as np
     >>> from skbio.stats.composition import perturb_inv
-    >>> x = np.array([.1,.3,.4, .2])
-    >>> y = np.array([1./6,1./6,1./3,1./3])
-    >>> perturb_inv(x,y)
+    >>> x = np.array([.1, .3, .4, .2])
+    >>> y = np.array([1/6, 1/6, 1/3, 1/3])
+    >>> perturb_inv(x, y)
     array([ 0.14285714,  0.42857143,  0.28571429,  0.14285714])
 
     """
@@ -333,12 +352,12 @@ def perturb_inv(x, y):
 def power(x, a):
     r"""Perform the power operation.
 
-    This operation is defined as follows
+    This operation is defined as follows:
 
     .. math::
         `x \odot a = C[x_1^a, \ldots, x_D^a]
 
-    :math:`C[x]` is the closure operation defined as
+    :math:`C[x]` is the closure operation defined as:
 
     .. math::
         C[x] = \left[\frac{x_1}{\sum_{i=1}^{D} x_i},\ldots,
@@ -349,24 +368,22 @@ def power(x, a):
 
     Parameters
     ----------
-    x : array_like, float
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
+    x : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
     a : float
-        a scalar float
+        A scalar exponent.
 
     Returns
     -------
-    numpy.ndarray, np.float64
-       A matrix of proportions where all of the values
-       are nonzero and each composition (row) adds up to 1
+    ndarray of shape (n_compositions, n_components)
+       The matrix where all of the values are non-zero and each composition
+       (row) adds up to 1.
 
     Examples
     --------
     >>> import numpy as np
     >>> from skbio.stats.composition import power
-    >>> x = np.array([.1,.3,.4, .2])
+    >>> x = np.array([.1, .3, .4, .2])
     >>> power(x, .1)
     array([ 0.23059566,  0.25737316,  0.26488486,  0.24714631])
 
@@ -378,7 +395,7 @@ def power(x, a):
 def inner(x, y):
     r"""Calculate the Aitchson inner product.
 
-    This inner product is defined as follows
+    This inner product is defined as follows:
 
     .. math::
         \langle x, y \rangle_a =
@@ -387,19 +404,15 @@ def inner(x, y):
 
     Parameters
     ----------
-    x : array_like
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
-    y : array_like
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
+    x : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    y : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    numpy.ndarray
-         inner product result
+    ndarray or scalar of shape (n_compositions, n_compositions)
+        Inner product result.
 
     Examples
     --------
@@ -420,11 +433,12 @@ def inner(x, y):
 def clr(mat):
     r"""Perform centre log ratio transformation.
 
-    This function transforms compositions from Aitchison geometry to
-    the real space. The :math:`clr` transform is both an isometry and an
-    isomorphism defined on the following spaces
+    This function transforms compositions from Aitchison geometry to the real
+    space. The :math:`clr` transform is both an isometry and an isomorphism
+    defined on the following spaces:
 
-    :math:`clr: S^D \rightarrow U`
+    .. math::
+        clr: S^D \rightarrow U
 
     where :math:`U=
     \{x :\sum\limits_{i=1}^D x = 0 \; \forall x \in \mathbb{R}^D\}`
@@ -439,15 +453,13 @@ def clr(mat):
 
     Parameters
     ----------
-    mat : array_like, float
-       a matrix of proportions where
-       rows = compositions and
-       columns = components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    numpy.ndarray
-         clr transformed matrix
+    ndarray of shape (n_compositions, n_components)
+        Clr-transformed matrix.
 
     Examples
     --------
@@ -467,31 +479,30 @@ def clr(mat):
 def clr_inv(mat):
     r"""Perform inverse centre log ratio transformation.
 
-    This function transforms compositions from the real space to
-    Aitchison geometry. The :math:`clr^{-1}` transform is both an isometry,
-    and an isomorphism defined on the following spaces
+    This function transforms compositions from the real space to Aitchison
+    geometry. The :math:`clr^{-1}` transform is both an isometry, and an
+    isomorphism defined on the following spaces:
 
-    :math:`clr^{-1}: U \rightarrow S^D`
+    .. math::
+        clr^{-1}: U \rightarrow S^D
 
     where :math:`U=
     \{x :\sum\limits_{i=1}^D x = 0 \; \forall x \in \mathbb{R}^D\}`
 
-    This transformation is defined as follows
+    This transformation is defined as follows:
 
     .. math::
         clr^{-1}(x) = C[\exp( x_1, \ldots, x_D)]
 
     Parameters
     ----------
-    mat : array_like, float
-       a matrix of real values where
-       rows = transformed compositions and
-       columns = components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of clr-transformed data.
 
     Returns
     -------
-    numpy.ndarray
-         inverse clr transformed matrix
+    ndarray of shape (n_compositions, n_components)
+        Inverse clr-transformed matrix.
 
     Examples
     --------
@@ -511,13 +522,14 @@ def clr_inv(mat):
 def ilr(mat, basis=None, check=True):
     r"""Perform isometric log ratio transformation.
 
-    This function transforms compositions from Aitchison simplex to
-    the real space. The :math: ilr` transform is both an isometry,
-    and an isomorphism defined on the following spaces
+    This function transforms compositions from Aitchison simplex to the real
+    space. The :math: ilr` transform is both an isometry, and an isomorphism
+    defined on the following spaces:
 
-    :math:`ilr: S^D \rightarrow \mathbb{R}^{D-1}`
+    .. math::
+        ilr: S^D \rightarrow \mathbb{R}^{D-1}
 
-    The ilr transformation is defined as follows
+    The ilr transformation is defined as follows:
 
     .. math::
         ilr(x) =
@@ -526,22 +538,22 @@ def ilr(mat, basis=None, check=True):
     where :math:`[e_1,\ldots,e_{D-1}]` is an orthonormal basis in the simplex.
 
     If an orthornormal basis isn't specified, the J. J. Egozcue orthonormal
-    basis derived from Gram-Schmidt orthogonalization will be used by
-    default.
+    basis derived from Gram-Schmidt orthogonalization will be used by default.
 
     Parameters
     ----------
-    mat: numpy.ndarray
-       a matrix of proportions where
-       rows = compositions and
-       columns = components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    basis : ndarray or sparse matrix, optional
+        Orthonormal basis for Aitchison simplex. Defaults to J. J. Egozcue
+        orthonormal basis.
+    check : bool
+        Check to see if basis is orthonormal.
 
-    basis: numpy.ndarray or scipy.sparse.matrix, optional
-        orthonormal basis for Aitchison simplex
-        defaults to J.J.Egozcue orthonormal basis.
-
-    check: bool
-        Specifies if the basis is orthonormal.
+    Returns
+    -------
+    ndarray of shape (n_compositions, n_components - 1)
+        Ilr-transformed matrix.
 
     Examples
     --------
@@ -553,10 +565,10 @@ def ilr(mat, basis=None, check=True):
 
     Notes
     -----
-    If the `basis` parameter is specified, it is expected to be a basis in the
-    Aitchison simplex.  If there are `D-1` elements specified in `mat`, then
-    the dimensions of the basis needs be `D-1 x D`, where rows represent
-    basis vectors, and the columns represent proportions.
+    If the ``basis`` parameter is specified, it is expected to be a basis in
+    the Aitchison simplex. If there are :math:`D - 1` elements specified in
+    ``mat``, then the dimensions of the basis needs be :math:`(D-1) \times D`,
+    where rows represent basis vectors, and the columns represent proportions.
 
     """
     mat = closure(mat)
@@ -578,13 +590,14 @@ def ilr(mat, basis=None, check=True):
 def ilr_inv(mat, basis=None, check=True):
     r"""Perform inverse isometric log ratio transform.
 
-    This function transforms compositions from the real space to
-    Aitchison geometry. The :math:`ilr^{-1}` transform is both an isometry,
-    and an isomorphism defined on the following spaces
+    This function transforms compositions from the real space to Aitchison
+    geometry. The :math:`ilr^{-1}` transform is both an isometry, and an
+    isomorphism defined on the following spaces:
 
-    :math:`ilr^{-1}: \mathbb{R}^{D-1} \rightarrow S^D`
+    .. math::
+        ilr^{-1}: \mathbb{R}^{D-1} \rightarrow S^D
 
-    The inverse ilr transformation is defined as follows
+    The inverse ilr transformation is defined as follows:
 
     .. math::
         ilr^{-1}(x) = \bigoplus\limits_{i=1}^{D-1} x \odot e_i
@@ -595,21 +608,20 @@ def ilr_inv(mat, basis=None, check=True):
     basis derived from Gram-Schmidt orthogonalization will be used by
     default.
 
-
     Parameters
     ----------
-    mat: numpy.ndarray, float
-       a matrix of transformed proportions where
-       rows = compositions and
-       columns = components
+    mat : array_like of shape (n_compositions, n_components - 1)
+        A matrix of ilr-transformed data.
+    basis : ndarray or sparse matrix, optional
+        Orthonormal basis for Aitchison simplex. Defaults to J. J. Egozcue
+        orthonormal basis.
+    check : bool
+        Check to see if basis is orthonormal.
 
-    basis: numpy.ndarray, float, optional
-        orthonormal basis for Aitchison simplex
-        defaults to J.J.Egozcue orthonormal basis
-
-    check: bool
-        Specifies if the basis is orthonormal.
-
+    Returns
+    -------
+    ndarray of shape (n_compositions, n_components)
+        Inverse ilr-transformed matrix.
 
     Examples
     --------
@@ -621,10 +633,10 @@ def ilr_inv(mat, basis=None, check=True):
 
     Notes
     -----
-    If the `basis` parameter is specified, it is expected to be a basis in the
-    Aitchison simplex.  If there are `D-1` elements specified in `mat`, then
-    the dimensions of the basis needs be `D-1 x D`, where rows represent
-    basis vectors, and the columns represent proportions.
+    If the ``basis`` parameter is specified, it is expected to be a basis in
+    the Aitchison simplex. If there are :math:`D - 1` elements specified in
+    ``mat``, then the dimensions of the basis needs be :math:`(D-1) \times D`,
+    where rows represent basis vectors, and the columns represent proportions.
 
     """
     mat = np.atleast_2d(mat)
@@ -651,11 +663,12 @@ def alr(mat, denominator_idx=0):
 
     This function transforms compositions from a D-part Aitchison simplex to
     a non-isometric real space of D-1 dimensions. The argument
-    `denominator_col` defines the index of the column used as the common
-    denominator. The :math: `alr` transformed data are amenable to multivariate
+    ``denominator_col`` defines the index of the column used as the common
+    denominator. The :math:`alr` transformed data are amenable to multivariate
     analysis as long as statistics don't involve distances.
 
-    :math:`alr: S^D \rightarrow \mathbb{R}^{D-1}`
+    .. math::
+        alr: S^D \rightarrow \mathbb{R}^{D-1}
 
     The alr transformation is defined as follows
 
@@ -667,21 +680,18 @@ def alr(mat, denominator_idx=0):
 
     Parameters
     ----------
-    mat: numpy.ndarray
-       a matrix of proportions where
-       rows = compositions and
-       columns = components
-
-    denominator_idx: int
-       the index of the column (2D-matrix) or position (vector) of
-       `mat` which should be used as the reference composition. By default
-       `denominator_idx=0` to specify the first column or position.
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    denominator_idx : int
+        The index of the column (2-D matrix) or position (vector) of ``mat``
+        which should be used as the reference composition. Default is 0 which
+        specifies the first column or position.
 
     Returns
     -------
-    numpy.ndarray
-         alr-transformed data projected in a non-isometric real space
-         of D-1 dimensions for a D-parts composition
+    ndarray of shape (n_compositions, n_components - 1)
+        Alr-transformed data projected in a non-isometric real space of
+        :math:`D - 1` dimensions for a *D*-parts composition.
 
     Examples
     --------
@@ -713,9 +723,10 @@ def alr_inv(mat, denominator_idx=0):
     This function transforms compositions from the non-isometric real space of
     alrs to Aitchison geometry.
 
-    :math:`alr^{-1}: \mathbb{R}^{D-1} \rightarrow S^D`
+    .. math::
+        alr^{-1}: \mathbb{R}^{D-1} \rightarrow S^D
 
-    The inverse alr transformation is defined as follows
+    The inverse alr transformation is defined as follows:
 
     .. math::
          alr^{-1}(x) = C[exp([y_1, y_2, ..., y_{D-1}, 0])]
@@ -731,17 +742,17 @@ def alr_inv(mat, denominator_idx=0):
 
     Parameters
     ----------
-    mat: numpy.ndarray
-       a matrix of alr-transformed data
-    denominator_idx: int
-       the index of the column (2D-composition) or position (1D-composition) of
-       the output where the common denominator should be placed. By default
-       `denominator_idx=0` to specify the first column or position.
+    mat : array_like of shape (n_compositions, n_components - 1)
+        A matrix of alr-transformed data.
+    denominator_idx : int
+        The index of the column (2-D matrix) or position (vector) of ``mat``
+        which should be used as the reference composition. Default is 0 which
+        specifies the first column or position.
 
     Returns
     -------
-    numpy.ndarray
-         Inverse alr transformed matrix or vector where rows sum to 1.
+    ndarray of shape (n_compositions, n_components)
+        Inverse alr-transformed matrix or vector where rows sum to 1.
 
     Examples
     --------
@@ -779,41 +790,39 @@ def centralize(mat):
 
     Parameters
     ----------
-    mat : array_like, float
-       a matrix of proportions where
-       rows = compositions and
-       columns = components
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
 
     Returns
     -------
-    numpy.ndarray
-         centered composition matrix
+    ndarray of shape (n_compositions, n_components)
+        Centered composition matrix.
 
     Examples
     --------
     >>> import numpy as np
     >>> from skbio.stats.composition import centralize
-    >>> X = np.array([[.1,.3,.4, .2],[.2,.2,.2,.4]])
+    >>> X = np.array([[.1, .3, .4, .2], [.2, .2, .2, .4]])
     >>> centralize(X)
     array([[ 0.17445763,  0.30216948,  0.34891526,  0.17445763],
            [ 0.32495488,  0.18761279,  0.16247744,  0.32495488]])
 
     """
     mat = closure(mat)
-    cen = scipy.stats.gmean(mat, axis=0)
+    cen = gmean(mat, axis=0)
     return perturb_inv(mat, cen)
 
 
-def _vlr(x: np.array, y: np.array, ddof: int):
+def _vlr(x, y, ddof):
     r"""Calculate variance log ratio.
 
     Parameters
     ----------
-    x : array_like, float
-        A 1-dimensional vector of proportions.
-    y : array_like, float
-        A 1-dimensional vector of proportions.
-    ddof: int
+    x : array_like of shape (n_components,)
+        A vector of proportions.
+    y : array_like of shape (n_components,)
+        A vector of proportions.
+    ddof : int
         Degrees of freedom.
 
     Returns
@@ -830,16 +839,16 @@ def _vlr(x: np.array, y: np.array, ddof: int):
     return np.var(x - y, ddof=ddof)
 
 
-def _robust_vlr(x: np.ndarray, y: np.ndarray, ddof: int):
+def _robust_vlr(x, y, ddof):
     r"""Calculate variance log ratio while masking zeros.
 
     Parameters
     ----------
-    x : array_like, float
-        A 1-dimensional vector of proportions.
-    y : array_like, float
-        A 1-dimensional vector of proportions.
-    ddof: int
+    x : array_like of shape (n_components,)
+        A vector of proportions.
+    y : array_like of shape (n_components,)
+        A vector of proportions.
+    ddof : int
         Degrees of freedom.
 
     Returns
@@ -860,19 +869,19 @@ def _robust_vlr(x: np.ndarray, y: np.ndarray, ddof: int):
     return np.ma.var(x - y, ddof=ddof)
 
 
-def vlr(x: np.ndarray, y: np.ndarray, ddof: int = 1, robust: bool = False):
+def vlr(x, y, ddof=1, robust=False):
     r"""Calculate variance log ratio.
 
     Parameters
     ----------
-    x : array_like, float
-        A 1-dimensional vector of proportions.
-    y : array_like, float
-        A 1-dimensional vector of proportions.
-    ddof: int
+    x : array_like of shape (n_components,)
+        A vector of proportions.
+    y : array_like of shape (n_components,)
+        A vector of proportions.
+    ddof : int
         Degrees of freedom.
-    robust: bool
-        Mask zeros at the cost of performance.
+    robust : bool
+        Whether to mask zeros at the cost of performance.
 
     Returns
     -------
@@ -898,9 +907,9 @@ def vlr(x: np.ndarray, y: np.ndarray, ddof: int = 1, robust: bool = False):
     --------
     >>> import numpy as np
     >>> from skbio.stats.composition import vlr
-    >>> x = np.exp([1,2,3])
-    >>> y = np.exp([2,3,4])
-    >>> vlr(x,y)  # no zeros
+    >>> x = np.exp([1, 2, 3])
+    >>> y = np.exp([2, 3, 4])
+    >>> vlr(x, y)  # no zeros
     0.0
 
     """
@@ -922,23 +931,19 @@ def vlr(x: np.ndarray, y: np.ndarray, ddof: int = 1, robust: bool = False):
         return _vlr(**kwargs)
 
 
-def _pairwise_vlr(mat: np.ndarray, ddof: int):
+def _pairwise_vlr(mat, ddof):
     r"""Perform pairwise variance log ratio transformation.
 
     Parameters
     ----------
-    mat : array_like, float
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
-    ids : array_like, str
-        Component names.
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
     ddof : int
         Degrees of freedom.
 
     Returns
     -------
-    skbio.DistanceMatrix
+    ndarray of shape (n_compositions, n_compositions)
         Distance matrix of variance log ratio values.
 
     """
@@ -952,23 +957,19 @@ def _pairwise_vlr(mat: np.ndarray, ddof: int):
     return vlr_data
 
 
-def pairwise_vlr(
-    mat, ids=None, ddof: int = 1, robust: bool = False, validate: bool = True
-):
+def pairwise_vlr(mat, ids=None, ddof=1, robust=False, validate=True):
     r"""Perform pairwise variance log ratio transformation.
 
     Parameters
     ----------
-    mat : array_like, float
-        a matrix of proportions where
-        rows = compositions and
-        columns = components
-    ids : array_like, str
+    mat : array_like of shape (n_compositions, n_components)
+        A matrix of proportions.
+    ids : array_like of str of shape (n_components,)
         Component names.
     ddof : int
         Degrees of freedom.
     robust : bool
-        Mask zeros at the cost of performance.
+        Whether to mask zeros at the cost of performance.
     validate : bool
         Whether to validate the distance matrix after construction.
 
@@ -1017,7 +1018,7 @@ def pairwise_vlr(
         "ddof": ddof,
     }
 
-    # Variance Log Ratio
+    # Variance log ratio
     if robust:
         raise NotImplementedError("Pairwise version of robust VLR not implemented.")
     else:
@@ -1034,30 +1035,30 @@ def pairwise_vlr(
 
 
 def tree_basis(tree):
-    r"""Calculate sparse representation of an ilr basis from a tree.
+    r"""Calculate the sparse representation of an ilr basis from a tree.
 
     This computes an orthonormal basis specified from a bifurcating tree.
 
     Parameters
     ----------
     tree : skbio.TreeNode
-        Input bifurcating tree.  Must be strictly bifurcating
-        (i.e. every internal node needs to have exactly 2 children).
-        This is used to specify the ilr basis.
+        Input bifurcating tree. Must be strictly bifurcating (i.e. every
+        internal node needs to have exactly two children). This is used to
+        specify the ilr basis.
 
     Returns
     -------
     scipy.sparse.coo_matrix
-       The ilr basis required to perform the ilr_inv transform.
-       This is also known as the sequential binary partition.
-       Note that this matrix is represented in clr coordinates.
-    nodes : list, str
-        List of tree nodes indicating the ordering in the basis.
+        The ilr basis required to perform the ilr_inv transform. This is also
+        known as the sequential binary partition. Note that this matrix is
+        represented in clr coordinates.
+    list of str
+        List of tree node names indicating the ordering in the basis.
 
     Raises
     ------
     ValueError
-        The tree doesn't contain two branches.
+        If the tree doesn't contain two branches.
 
     Examples
     --------
@@ -1074,10 +1075,12 @@ def tree_basis(tree):
     # within any given node in a tree.
     NUMERATOR = 1
     DENOMINATOR = 0
+
     # this is inspired by @wasade in
     # https://github.com/biocore/gneiss/pull/8
     t = tree.copy()
     D = len(list(tree.tips()))
+
     # calculate number of tips under each node
     for n in t.postorder(include_self=True):
         if n.is_tip():
@@ -1148,24 +1151,105 @@ def tree_basis(tree):
     return basis, nodes
 
 
+def _holm_bonferroni(p):
+    """Perform Holm-Bonferroni correction.
+
+    Perform Holm-Bonferroni correction ([1]_) for *p*-values to account for
+    multiple comparisons.
+
+    Parameters
+    ----------
+    p : ndarray of shape (n_tests,)
+        Original *p*-values.
+
+    Returns
+    -------
+    ndarray of shape (n_tests,)
+        Corrected *p*-values.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method
+
+    """
+    K = len(p)
+    sort_index = -np.ones(K, dtype=np.int64)
+    sorted_p = np.sort(p)
+    sorted_p_adj = sorted_p * (K - np.arange(K))
+    for j in range(K):
+        idx = (p == sorted_p[j]) & (sort_index < 0)
+        num_ties = len(sort_index[idx])
+        sort_index[idx] = np.arange(j, (j + num_ties), dtype=np.int64)
+
+    sorted_holm_p = [min([max(sorted_p_adj[:k]), 1]) for k in range(1, K + 1)]
+    holm_p = [sorted_holm_p[sort_index[k]] for k in range(K)]
+    return holm_p
+
+
+def _benjamini_hochberg(p):
+    """Perform Benjamini-Hochberg correction.
+
+    Perform Benjamini-Hochberg correction ([1]_) for *p*-values to account for
+    multiple comparisons.
+
+    Parameters
+    ----------
+    p : ndarray of shape (n_tests,)
+        Original *p*-values.
+
+    Returns
+    -------
+    ndarray of shape (n_tests,)
+        Corrected *p*-values.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Benjamini%E2%80%93Hochberg_procedure
+
+    """
+    # Derived from @Vladimir's answer at:
+    # https://stackoverflow.com/questions/7450957/
+    p = np.asarray(p)
+    K = len(p)
+    order = p.argsort()[::-1]
+    bh_p = p[order] * K / np.arange(K, 0, -1)
+    bh_p = np.minimum(1, np.minimum.accumulate(bh_p))
+    return bh_p[order.argsort()]
+
+
+def _dispatch_p_adjust(name):
+    """Refer to a *p*-value correction function by the method's name."""
+    if name is None:
+        return
+    name_ = name.lower()
+    if name_ in ("holm", "holm-bonferroni"):
+        return _holm_bonferroni
+    elif name_ in ("bh", "fdr_bh", "benjamini-hochberg"):
+        return _benjamini_hochberg
+    else:
+        raise ValueError(f"{name} is not an available FDR correction method.")
+
+
 def ancom(
     table,
     grouping,
     alpha=0.05,
     tau=0.02,
     theta=0.1,
-    multiple_comparisons_correction="holm-bonferroni",
-    significance_test=None,
+    p_adjust="holm",
+    significance_test="f_oneway",
     percentiles=(0.0, 25.0, 50.0, 75.0, 100.0),
+    multiple_comparisons_correction="holm-bonferroni",
 ):
     r"""Perform a differential abundance test using ANCOM.
 
-    This is done by calculating pairwise log ratios between all features
-    and performing a significance test to determine if there is a significant
-    difference in feature ratios with respect to the variable of interest.
+    Analysis of composition of microbiomes (ANCOM) is done by calculating
+    pairwise log ratios between all features and performing a significance
+    test to determine if there is a significant difference in feature ratios
+    with respect to the variable of interest.
 
     In an experiment with only two treatments, this tests the following
-    hypothesis for feature :math:`i`
+    hypothesis for feature :math:`i`:
 
     .. math::
 
@@ -1178,53 +1262,55 @@ def ancom(
     Parameters
     ----------
     table : pd.DataFrame
-        A 2D matrix of strictly positive values (i.e. counts or proportions)
+        A 2-D matrix of strictly positive values (i.e. counts or proportions)
         where the rows correspond to samples and the columns correspond to
         features.
     grouping : pd.Series
-        Vector indicating the assignment of samples to groups.  For example,
+        Vector indicating the assignment of samples to groups. For example,
         these could be strings or integers denoting which group a sample
-        belongs to.  It must be the same length as the samples in `table`.
+        belongs to. It must be the same length as the samples in `table`.
         The index must be the same on `table` and `grouping` but need not be
         in the same order.
     alpha : float, optional
-        Significance level for each of the statistical tests.
-        This can can be anywhere between 0 and 1 exclusive.
+        Significance level for each of the statistical tests. This can can be
+        anywhere between 0 and 1 exclusive.
     tau : float, optional
-        A constant used to determine an appropriate cutoff.
-        A value close to zero indicates a conservative cutoff.
-        This can can be anywhere between 0 and 1 exclusive.
+        A constant used to determine an appropriate cutoff. A value close to
+        zero indicates a conservative cutoff. This can can be anywhere between
+        0 and 1 exclusive.
     theta : float, optional
-        Lower bound for the proportion for the W-statistic.
-        If all W-statistics are lower than theta, then no features
-        will be detected to be differentially significant.
-        This can can be anywhere between 0 and 1 exclusive.
-    multiple_comparisons_correction : {None, 'holm-bonferroni'}, optional
-        The multiple comparison correction procedure to run.  If None,
-        then no multiple comparison correction procedure will be run.
-        If 'holm-boniferroni' is specified, then the Holm-Boniferroni
-        procedure [1]_ will be run.
-    significance_test : function, optional
-        A statistical significance function to test for significance between
-        classes.  This function must be able to accept at least two 1D
-        array_like arguments of floats and returns a test statistic and a
-        p-value. By default ``scipy.stats.f_oneway`` is used.
+        Lower bound for the proportion for the *W*-statistic. If all *W*-
+        statistics are lower than theta, then no features will be detected to
+        be significantly different. This can can be anywhere between 0 and 1
+        exclusive.
+    p_adjust : str or None, optional
+        Method to correct *p*-values for multiple comparisons. Options are Holm-
+        Boniferroni ("holm" or "holm-bonferroni") (default) or Benjamini-
+        Hochberg ("bh", "fdr_bh" or "benjamini-hochberg"). Case-insensitive. If
+        None, no correction will be performed.
+    significance_test : str or callable, optional
+        A function to test for significance between classes. It must be able to
+        accept at least two vectors of floats and returns a test statistic and
+        a *p*-value. Functions under ``scipy.stats`` can be directly specified
+        by name. The default is one-way ANOVA ("f_oneway").
     percentiles : iterable of floats, optional
         Percentile abundances to return for each feature in each group. By
         default, will return the minimum, 25th percentile, median, 75th
         percentile, and maximum abundances for each feature in each group.
+    multiple_comparisons_correction : str or None, optional
+        Alias for ``p_adjust``. For backward compatibility. Deprecated.
 
     Returns
     -------
     pd.DataFrame
-        A table of features, their W-statistics and whether the null hypothesis
-        is rejected.
+        A table of features, their *W*-statistics and whether the null
+        hypothesis is rejected.
 
-        `"W"` is the W-statistic, or number of features that a single feature
-        is tested to be significantly different against.
+        - ``W``: *W*-statistic, or the number of features that the current
+          feature is tested to be significantly different against.
 
-        `"Reject null hypothesis"` indicates if feature is differentially
-        abundant across groups (`True`) or not (`False`).
+        - ``Reject null hypothesis``: Whether the feature is differentially
+          abundant across groups (``True``) or not (``False``).
 
     pd.DataFrame
         A table of features and their percentile abundances in each group. If
@@ -1235,55 +1321,62 @@ def ancom(
 
     See Also
     --------
-    multiplicative_replacement
+    multi_replace
     scipy.stats.ttest_ind
     scipy.stats.f_oneway
     scipy.stats.wilcoxon
     scipy.stats.kruskal
 
+    Warnings
+    --------
+    ``multiple_comparisons_correction`` is deprecated as of ``0.6.0``. It has
+    been renamed to ``p_adjust``.
+
     Notes
     -----
-    The developers of this method recommend the following significance tests
-    ([2]_, Supplementary File 1, top of page 11): if there are 2 groups, use
-    the standard parametric t-test (``scipy.stats.ttest_ind``) or
-    non-parametric Mann-Whitney rank test (``scipy.stats.mannwhitneyu``).
-    For paired samples, use the parametric paired t-test
-    (``scipy.stats.ttest_rel``) or nonparametric Wilcoxon signed-rank test
-    (``scipy.stats.wilcoxon``). If there are more than 2 groups, use
-    parametric one-way ANOVA (``scipy.stats.f_oneway``) or nonparametric
-    Kruskal-Wallis (``scipy.stats.kruskal``). If there are multiple
-    measurements obtained from the individuals, use a Friedman test
-    (``scipy.stats.friedmanchisquare``).  Because one-way ANOVA is
-    equivalent to the standard t-test when the number of groups is two, we
-    default to ``scipy.stats.f_oneway`` here, which can be used when there
-    are two or more groups. Users should refer to the documentation of these
-    tests in SciPy to understand the assumptions made by each test.
+    The developers of ANCOM recommend the following significance tests ([2]_,
+    Supplementary File 1, top of page 11):
+
+    - If there are two groups, use the standard parametric *t*-test
+      (``ttest_ind``) or the non-parametric Mann-Whitney rank test
+      (``mannwhitneyu``).
+
+    - For paired samples, use the parametric paired *t*-test (``ttest_rel``) or
+      the non-parametric Wilcoxon signed-rank test (``wilcoxon``).
+
+    - If there are more than two groups, use the parametric one-way ANOVA
+      (``f_oneway``) or the non-parametric Kruskal-Wallis test (``kruskal``).
+
+    - If there are multiple measurements obtained from the individuals, use a
+      Friedman test (``friedmanchisquare``).
+
+    Because one-way ANOVA is equivalent to the standard *t*-test when the
+    number of groups is two, we default to ``f_oneway`` here, which can be used
+    when there are two or more groups.
+
+    Users should refer to the documentation of these tests in SciPy to
+    understand the assumptions made by each test.
 
     This method cannot handle any zero counts as input, since the logarithm
     of zero cannot be computed.  While this is an unsolved problem, many
-    studies, including [2]_, have shown promising results by adding
-    pseudocounts to all values in the matrix. In [2]_, a pseudocount of 0.001
+    studies, including [1]_, have shown promising results by adding
+    pseudocounts to all values in the matrix. In [1]_, a pseudocount of 0.001
     was used, though the authors note that a pseudocount of 1.0 may also be
-    useful. Zero counts can also be addressed using the
-    ``multiplicative_replacement`` method.
+    useful. Zero counts can also be addressed using the ``multi_replace`` method.
 
     References
     ----------
-    .. [1] Holm, S. "A simple sequentially rejective multiple test procedure".
-       Scandinavian Journal of Statistics (1979), 6.
-    .. [2] Mandal et al. "Analysis of composition of microbiomes: a novel
+    .. [1] Mandal et al. "Analysis of composition of microbiomes: a novel
        method for studying microbial composition", Microbial Ecology in Health
        & Disease, (2015), 26.
 
     Examples
     --------
-    First import all of the necessary modules:
-
     >>> from skbio.stats.composition import ancom
     >>> import pandas as pd
 
-    Now let's load in a DataFrame with 6 samples and 7 features (e.g.,
-    these may be bacterial taxa):
+    Let's load in a DataFrame with six samples and seven features (e.g., these
+    may be bacterial taxa):
 
     >>> table = pd.DataFrame([[12, 11, 10, 10, 10, 10, 10],
     ...                       [9,  11, 12, 10, 10, 10, 10],
@@ -1319,14 +1412,14 @@ def ancom(
     b7    1
     Name: W, dtype: int64
 
-    The W-statistic is the number of features that a single feature is tested
-    to be significantly different against.  In this scenario, `b2` was detected
-    to have significantly different abundances compared to four of the other
-    features. To summarize the results from the W-statistic, let's take a look
-    at the results from the hypothesis test. The `Reject null hypothesis`
-    column in the table indicates whether the null hypothesis was rejected,
-    and that a feature was therefore observed to be differentially abundant
-    across the groups.
+    The *W*-statistic is the number of features that a single feature is tested
+    to be significantly different against. In this scenario, ``b2`` was
+    detected to have significantly different abundances compared to four of the
+    other features. To summarize the results from the *W*-statistic, let's take
+    a look at the results from the hypothesis test. The ``Reject null
+    hypothesis`` column in the table indicates whether the null hypothesis was
+    rejected, and that a feature was therefore observed to be differentially
+    abundant across the groups.
 
     >>> ancom_df['Reject null hypothesis']
     b1    False
@@ -1338,13 +1431,13 @@ def ancom(
     b7    False
     Name: Reject null hypothesis, dtype: bool
 
-    From this we can conclude that only `b2` was significantly different in
+    From this we can conclude that only ``b2`` was significantly different in
     abundance between the treatment and the placebo. We still don't know, for
-    example, in which group `b2` was more abundant. We therefore may next be
-    interested in comparing the abundance of `b2` across the two groups.
+    example, in which group ``b2`` was more abundant. We therefore may next be
+    interested in comparing the abundance of ``b2`` across the two groups.
     We can do that using the second DataFrame that was returned. Here we
-    compare the median (50th percentile) abundance of `b2` in the treatment and
-    placebo groups:
+    compare the median (50th percentile) abundance of ``b2`` in the treatment
+    and placebo groups:
 
     >>> percentile_df[50.0].loc['b2']
     Group
@@ -1369,7 +1462,7 @@ def ancom(
     100.0       treatment    11.0
     Name: b2, dtype: float64
 
-    Taken together, these data tell us that `b2` is present in significantly
+    Taken together, these data tell us that ``b2`` is present in significantly
     higher abundance in the placebo group samples than in the treatment group
     samples.
 
@@ -1386,7 +1479,7 @@ def ancom(
     if np.any(table <= 0):
         raise ValueError(
             "Cannot handle zeros or negative values in `table`. "
-            "Use pseudocounts or ``multiplicative_replacement``."
+            "Use pseudocounts or ``multi_replace``."
         )
 
     if not 0 < alpha < 1:
@@ -1398,12 +1491,18 @@ def ancom(
     if not 0 < theta < 1:
         raise ValueError("`theta`=%f is not within 0 and 1." % theta)
 
-    if multiple_comparisons_correction is not None:
-        if multiple_comparisons_correction != "holm-bonferroni":
-            raise ValueError(
-                "%r is not an available option for "
-                "`multiple_comparisons_correction`." % multiple_comparisons_correction
+    # deprecated parameter
+    if multiple_comparisons_correction != "holm-bonferroni":
+        if not hasattr(ancom, "warned"):
+            simplefilter("once", DeprecationWarning)
+            warn(
+                "multiple_comparisons_correction is deprecated as of 0.6.0.",
+                DeprecationWarning,
             )
+            ancom.warned = True
+        p_adjust = multiple_comparisons_correction
+
+    p_adjust = _dispatch_p_adjust(p_adjust)
 
     if (grouping.isnull()).any():
         raise ValueError("Cannot handle missing values in `grouping`.")
@@ -1419,7 +1518,7 @@ def ancom(
                 "was provided." % percentile
             )
 
-    duplicates = skbio.util.find_duplicates(percentiles)
+    duplicates = find_duplicates(percentiles)
     if duplicates:
         formatted_duplicates = ", ".join(repr(e) for e in duplicates)
         raise ValueError(
@@ -1447,7 +1546,7 @@ def ancom(
         )
 
     if significance_test is None:
-        significance_test = scipy.stats.f_oneway
+        significance_test = "f_oneway"
 
     table_index_len = len(table.index)
     grouping_index_len = len(grouping.index)
@@ -1461,8 +1560,9 @@ def ancom(
     logratio_mat = _logratio_mat + _logratio_mat.T
 
     # Multiple comparisons
-    if multiple_comparisons_correction == "holm-bonferroni":
-        logratio_mat = np.apply_along_axis(_holm_bonferroni, 1, logratio_mat)
+    if p_adjust is not None:
+        logratio_mat = np.apply_along_axis(p_adjust, 1, logratio_mat)
+
     np.fill_diagonal(logratio_mat, 1)
     W = (logratio_mat < alpha).sum(axis=1)
     c_start = W.max() / n_feat
@@ -1510,86 +1610,66 @@ def ancom(
         return ancom_df, percentile_df
 
 
-def _holm_bonferroni(p):
-    """Perform Holm-Bonferroni correction.
-
-    Perform Holm-Bonferroni correction for pvalues to account for multiple comparisons.
-
-    Parameters
-    ----------
-    p: numpy.array
-        array of pvalues
-
-    Returns
-    -------
-    numpy.array
-        corrected pvalues
-
-    """
-    K = len(p)
-    sort_index = -np.ones(K, dtype=np.int64)
-    sorted_p = np.sort(p)
-    sorted_p_adj = sorted_p * (K - np.arange(K))
-    for j in range(K):
-        idx = (p == sorted_p[j]) & (sort_index < 0)
-        num_ties = len(sort_index[idx])
-        sort_index[idx] = np.arange(j, (j + num_ties), dtype=np.int64)
-
-    sorted_holm_p = [min([max(sorted_p_adj[:k]), 1]) for k in range(1, K + 1)]
-    holm_p = [sorted_holm_p[sort_index[k]] for k in range(K)]
-    return holm_p
-
-
-def _log_compare(mat, cats, significance_test=scipy.stats.ttest_ind):
+def _log_compare(mat, cats, test="ttest_ind"):
     """Calculate pairwise log ratios and perform a significance test.
 
     Calculate pairwise log ratios between all features and perform a
-    significance test (i.e. t-test) to determine if there is a significant
+    significance test (i.e. *t*-test) to determine if there is a significant
     difference in feature ratios with respect to the variable of interest.
 
     Parameters
     ----------
-    mat: np.array
-        Matrix with rows corresponding to samples and columns corresponding to
-        features.
-    cats: np.array, float
-        Vector of categories.
-    significance_test: function
+    mat : array_like of shape (n_samples, n_features)
+        A matrix of proportions.
+    cats : array_like of shape (n_samples,)
+        A vector of categories.
+    test : str or callable
         Statistical test to run.
 
     Returns
     -------
-    log_ratio : np.array
-        Log ratio pvalue matrix.
+    log_ratio : ndarray
+        Log ratio *p*-value matrix.
+
+    Raises
+    ------
+    ValueError
+        If specified test name is not a function under ``scipy.stats``.
 
     """
-    r, c = mat.shape
+    c = mat.shape[1]
     log_ratio = np.zeros((c, c))
     log_mat = np.log(mat)
     cs = np.unique(cats)
 
+    if isinstance(test, str):
+        try:
+            test = getattr(scipy.stats, test)
+        except AttributeError:
+            raise ValueError(f'Function "{test}" does not exist under scipy.stats.')
+
     def func(x):
-        return significance_test(*[x[cats == k] for k in cs])
+        return test(*[x[cats == k] for k in cs])
 
     for i in range(c - 1):
         ratio = (log_mat[:, i].T - log_mat[:, i + 1 :].T).T
-        m, p = np.apply_along_axis(func, axis=0, arr=ratio)
+        _, p = np.apply_along_axis(func, axis=0, arr=ratio)
         log_ratio[i, i + 1 :] = np.squeeze(np.array(p.T))
     return log_ratio
 
 
 def _gram_schmidt_basis(n):
-    """Build clr transformed basis derived from gram schmidt orthogonalization.
+    """Build clr-transformed basis derived from Gram-Schmidt orthogonalization.
 
     Parameters
     ----------
     n : int
-        Dimension of the Aitchison simplex
+        Dimension of the Aitchison simplex.
 
     Returns
     -------
-    basis : np.array
-        Dimension (n-1) x n basis matrix
+    basis : array_like of shape (n - 1, n)
+        Basis matrix.
 
     """
     basis = np.zeros((n, n - 1))
@@ -1603,37 +1683,40 @@ def _gram_schmidt_basis(n):
 def sbp_basis(sbp):
     r"""Build an orthogonal basis from a sequential binary partition (SBP).
 
-    As explained in [1]_, the SBP is a hierarchical collection of binary
-    divisions of compositional parts. The child groups are divided again until
-    all groups contain a single part. The SBP can be encoded in a
-    :math:`(D - 1) \times D` matrix where, for each row, parts can be grouped
-    by -1 and +1 tags, and 0 for excluded parts. The `sbp_basis` method was
-    originally derived from function `gsi.buildilrBase()` found in the R
-    package `compositions` [2]_. The ith balance is computed as follows
+    A SBP is a hierarchical collection of binary divisions of compositional
+    parts ([1]_). The child groups are divided again until all groups contain a
+    single part. The SBP can be encoded in a :math:`(D - 1) \times D` matrix
+    where, for each row, parts can be grouped by -1 and +1 tags, and 0 for
+    excluded parts. The *i*-th balance is computed as follows:
 
     .. math::
         b_i = \sqrt{ \frac{r_i s_i}{r_i+s_i} }
         \ln \left( \frac{g(x_{r_i})}{g(x_{s_i})} \right)
 
-    where :math:`b_i` is the ith balance corresponding to the ith row in the
-    SBP, :math:`r_i` and :math:`s_i` and the number of respectively `+1` and
-    `-1` labels in the ith row of the SBP and where :math:`g(x) =
+    where :math:`b_i` is the *i*-th balance corresponding to the *i*-th row in
+    the SBP, :math:`r_i` and :math:`s_i` and the number of respectively ``+1``
+    and ``-1`` labels in the *i*-th row of the SBP and where :math:`g(x) =
     (\prod\limits_{i=1}^{D} x_i)^{1/D}` is the geometric mean of :math:`x`.
 
     Parameters
     ----------
-    sbp: np.array, int
+    sbp : array_like of shape (n_partitions, n_features)
         A contrast matrix, also known as a sequential binary partition, where
         every row represents a partition between two groups of features. A part
-        labelled `+1` would correspond to that feature being in the numerator
-        of the given row partition, a part labelled `-1` would correspond to
-        features being in the denominator of that given row partition, and `0`
-        would correspond to features excluded in the row partition.
+        labelled ``+1`` would correspond to that feature being in the numerator
+        of the given row partition, a part labelled ``-1`` would correspond to
+        features being in the denominator of that given row partition, and
+        ``0`` would correspond to features excluded in the row partition.
 
     Returns
     -------
-    numpy.array
-        An orthonormal basis in the Aitchison simplex
+    ndarray of shape (n_partitions, n_features)
+        An orthonormal basis in the Aitchison simplex.
+
+    Notes
+    -----
+    The ``sbp_basis`` method was derived from the ``gsi.buildilrBase()``
+    function implemented in the R package "compositions" [2]_.
 
     Examples
     --------
@@ -1655,7 +1738,7 @@ def sbp_basis(sbp):
        Hernandes, A., Lapointe, L., Hébert-Gentile, V., Naess, K.,
        Marchand, S., Lafond, J., Mattos, D., Barlow, P., Natale, W., 2013.
        The plant ionome revisited by the nutrient balance concept.
-       Front. Plant Sci. 4, 39, http://dx.doi.org/10.3389/fpls.2013.00039.
+       Front. Plant Sci. 4, 39.
     .. [2] van den Boogaart, K. Gerald, Tolosana-Delgado, Raimon and Bren,
        Matevz, 2014. `compositions`: Compositional Data Analysis. R package
        version 1.40-1. https://CRAN.R-project.org/package=compositions.
@@ -1672,28 +1755,51 @@ def sbp_basis(sbp):
 
 
 def _check_orthogonality(basis):
-    """Check to see if basis is truly orthonormal in the Aitchison simplex.
+    r"""Check to see if basis is truly orthonormal in the Aitchison simplex.
 
     Parameters
     ----------
-    basis: numpy.ndarray
-        basis in the Aitchison simplex of dimension d-1 x d
+    basis : ndarray
+        Basis in the Aitchison simplex of dimension :math:`(D - 1) \times D`.
 
     """
     basis = np.atleast_2d(basis)
     if not np.allclose(basis @ basis.T, np.identity(len(basis)), rtol=1e-4, atol=1e-6):
-        raise ValueError("Basis is not orthonormal")
+        raise ValueError("Basis is not orthonormal.")
 
 
-def _welch_ttest(x1, x2):
+def _welch_ttest(a, b):
+    r"""Perform Welch's *t*-test on two samples of unequal variances.
+
+    Parameters
+    ----------
+    a, b : 1-D array_like
+        Samples to test.
+
+    Returns
+    -------
+    pd.DataFrame
+        Test result. Columns are: T statistic, df, pvalue, Difference, CI(2.5),
+        CI(97.5).
+
+    See Also
+    --------
+    scipy.stats.ttest_ind
+
+    Notes
+    -----
+    Compared with ``scipy.stats.ttest_ind`` with ``equal_var=False``, this
+    function additionally returns confidence intervals.
+
+    """
     # See https://stats.stackexchange.com/a/475345
-    n1 = x1.size
-    n2 = x2.size
-    m1 = np.mean(x1)
-    m2 = np.mean(x2)
+    n1 = len(a)
+    n2 = len(b)
+    m1 = np.mean(a)
+    m2 = np.mean(b)
 
-    v1 = np.var(x1, ddof=1)
-    v2 = np.var(x2, ddof=1)
+    v1 = np.var(a, ddof=1)
+    v2 = np.var(b, ddof=1)
 
     pooled_se = np.sqrt(v1 / n1 + v2 / n2)
     delta = m1 - m2
@@ -1703,7 +1809,7 @@ def _welch_ttest(x1, x2):
         v1**2 / (n1**2 * (n1 - 1)) + v2**2 / (n2**2 * (n2 - 1))
     )
 
-    # two side t-test
+    # two-sided t-test
     p = 2 * t.cdf(-abs(tstat), df)
 
     # upper and lower bounds
@@ -1720,11 +1826,12 @@ def dirmult_ttest(
     grouping,
     treatment,
     reference,
-    pseudocount = 0.5,
-    draws = 128,
+    pseudocount=0.5,
+    draws=128,
+    p_adjust="holm",
     seed=None,
 ):
-    r"""*T*-test using Dirichlet Multinomial Distribution.
+    r"""*T*-test using Dirichlet-multinomial distribution.
 
     The Dirichlet-multinomial distribution is a compound distribution that
     combines a Dirichlet distribution over the probabilities of a multinomial
@@ -1736,9 +1843,10 @@ def dirmult_ttest(
     feature. The fold change is computed as the difference between the
     samples of the two groups. *t*-tests are then performed on the posterior
     samples, drawn from each Dirichlet-multinomial distribution. The
-    log-fold changes as well as their credible intervals, the pvalues a
-    FDR corrected pvalues using Holm-Bonferroni [1]_ are reported.
-    This process mirrors the approach performed by ALDEx2.
+    log-fold changes as well as their credible intervals, the *p*-values and
+    the multiple comparison corrected *p*-values are reported.
+
+    This process mirrors the approach performed by the R package "ALDEx2" [1]_.
 
     Parameters
     ----------
@@ -1762,6 +1870,11 @@ def dirmult_ttest(
         The number of draws from the Dirichilet-multinomial posterior distribution
         More draws provide higher uncertainty surrounding the estimated
         log-fold changes and *p*-values.
+    p_adjust : str or None, optional
+        Method to correct *p*-values for multiple comparisons. Options are Holm-
+        Boniferroni ("holm" or "holm-bonferroni") (default) or Benjamini-
+        Hochberg ("bh", "fdr_bh" or "benjamini-hochberg"). Case-insensitive. If
+        None, no correction will be performed.
     seed : int or np.random.Generator, optional
         A user-provided random seed or random generator instance.
 
@@ -1791,14 +1904,12 @@ def dirmult_ttest(
         reported ``CI(97.5)`` is the 97.5% quantile of all of the log2-fold
         changes computed from each of the posterior draws.
 
-        ``pvalue`` is the pvalue of the *t*-test. The reported ``*p*-value`` is the
-        average of all of the pvalues computed from the t-tests calculated
+        ``pvalue`` is the *p*-value of the *t*-test. The reported values are the
+        average of all of the *p*-values computed from the *t*-tests calculated
         across all of the posterior draws.
 
-        ``qvalue`` is the pvalue of the t-test after performing multiple
-        hypothesis correction. The reported ``*q*-value`` is computed after
-        performing holm-bonferroni multiple hypothesis correction on the
-        reported ``*p*-value``.
+        ``qvalue`` is the *p*-value of the *t*-test after performing multiple
+        comparison correction.
 
         ``Reject null hypothesis`` indicates if feature is differentially
         abundant across groups (``True``) or not (``False``). In order for a
@@ -1806,22 +1917,20 @@ def dirmult_ttest(
         (i.e. <0.05) and the confidence intervals reported by ``CI(2.5)`` and
         ``CI(97.5)`` must not overlap with zero.
 
-
     See Also
     --------
     scipy.stats.ttest_ind
 
     Notes
     -----
-    FDR-corrected pvalues use Benjamini-Hochberg for pvalue adjustment for
-    multiple corrections. The confidence intervals are computed using the
-    mininum 2.5% and maximum 97.5% bounds computed across all of the posterior draws.
+    The confidence intervals are computed using the mininum 2.5% and maximum
+    97.5% bounds computed across all of the posterior draws.
 
     The reference frame here is the geometric mean. Extracting absolute log
     fold changes from this test assumes that the average feature abundance
     between the ``treatment`` and the ``reference`` groups are the same. If this
     assumption is violated, then the log-fold changes will be biased, and the
-    pvalues will not be reliable. However, the bias is the same across each
+    *p*-values will not be reliable. However, the bias is the same across each
     feature, as a result the ordering of the log-fold changes can still be useful.
 
     One benefit of using the Dirichlet-multinomial distribution is that the
@@ -1831,9 +1940,7 @@ def dirmult_ttest(
 
     References
     ----------
-    .. [1] Holm, S. "A simple sequentially rejective multiple test procedure".
-       Scandinavian Journal of Statistics (1979), 6.
-    .. [2] Fernandes et al. "Unifying the analysis of
+    .. [1] Fernandes et al. "Unifying the analysis of
        high-throughput sequencing datasets: characterizing RNA-seq,
        16S rRNA gene sequencing and selective growth experiments by
        compositional data analysis." Microbiome (2014).
@@ -1886,6 +1993,8 @@ def dirmult_ttest(
     if (table.isnull()).any().any():
         raise ValueError("Cannot handle missing values in `table`.")
 
+    p_adjust = _dispatch_p_adjust(p_adjust)
+
     table_index_len = len(table.index)
     grouping_index_len = len(grouping.index)
     mat, cats = table.align(grouping, axis=0, join="inner")
@@ -1935,8 +2044,11 @@ def dirmult_ttest(
     res["CI(2.5)"] = res["CI(2.5)"] / np.log(2)
     res["CI(97.5)"] = res["CI(97.5)"] / np.log(2)
 
-    mres = _holm_bonferroni(res["pvalue"])
-    qval = mres
+    # multiple comparison
+    if p_adjust is not None:
+        qval = p_adjust(res["pvalue"])
+    else:
+        qval = res["pvalue"].values
 
     # test to see if confidence interval includes 0.
     sig = np.logical_or(
@@ -1944,11 +2056,11 @@ def dirmult_ttest(
         np.logical_and(res["CI(2.5)"] < 0, res["CI(97.5)"] < 0),
     )
 
-    reject = np.logical_and(mres[0], sig)
+    reject = np.logical_and(qval[0], sig)
 
     res = res.rename(columns={"Difference": "Log2(FC)"})
     res["qvalue"] = qval
-    res['"Reject null hypothesis"'] = reject
+    res["Reject null hypothesis"] = reject
 
     col_order = [
         "T statistic",
@@ -1958,6 +2070,6 @@ def dirmult_ttest(
         "CI(97.5)",
         "pvalue",
         "qvalue",
-        '"Reject null hypothesis"',
+        "Reject null hypothesis",
     ]
     return res[col_order]

--- a/skbio/stats/tests/test_composition.py
+++ b/skbio/stats/tests/test_composition.py
@@ -1429,6 +1429,11 @@ class DirMultTTestTests(TestCase):
         pdt.assert_index_equal(result.index,
                                pd.Index(['feature1', 'feature2', 'feature3']))
 
+    def test_dirmult_ttest_no_p_adjust(self):
+        result = dirmult_ttest(self.table, self.grouping, self.treatment, self.reference,
+                               p_adjust=None)
+        pdt.assert_series_equal(result['pvalue'], result['qvalue'], check_names=False)
+
     def test_dirmult_ttest_invalid_table_type(self):
         with self.assertRaises(TypeError):
             dirmult_ttest("invalid_table", self.grouping, self.treatment, self.reference)

--- a/skbio/stats/tests/test_composition.py
+++ b/skbio/stats/tests/test_composition.py
@@ -365,7 +365,7 @@ class CompositionTests(TestCase):
                             rtol=1e-04, atol=1e-06)
 
         # no check
-        npt.assert_array_almost_equal(ilr_inv(ilr(mat)), mat, check=False)
+        npt.assert_array_almost_equal(ilr_inv(ilr(mat), check=False), mat)
 
         with self.assertRaises(ValueError):
             ilr_inv(self.cdata1, basis=self.cdata1)

--- a/skbio/stats/tests/test_composition.py
+++ b/skbio/stats/tests/test_composition.py
@@ -6,27 +6,24 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import functools
 from unittest import TestCase, main
+import copy
+
 import numpy as np
 import numpy.testing as npt
-import pandas.testing as pdt
 from numpy.random import normal
 import pandas as pd
-import scipy
-import copy
+import pandas.testing as pdt
+from scipy.sparse import coo_matrix
+
 from skbio import TreeNode
 from skbio.util import assert_data_frame_almost_equal
 from skbio.stats.distance import DistanceMatrixError
-from skbio.stats.composition import (closure, multiplicative_replacement,
-                                     perturb, perturb_inv, power, inner,
-                                     clr, clr_inv, ilr, ilr_inv, alr, alr_inv,
-                                     sbp_basis, _gram_schmidt_basis,
-                                     centralize, _holm_bonferroni, ancom,
-                                     vlr, pairwise_vlr, tree_basis,
-                                     dirmult_ttest)
-
-from scipy.sparse import coo_matrix
+from skbio.stats.composition import (
+    closure, multi_replace, multiplicative_replacement, perturb, perturb_inv, power,
+    inner, clr, clr_inv, ilr, ilr_inv, alr, alr_inv, sbp_basis, _gram_schmidt_basis,
+    centralize, _holm_bonferroni, _benjamini_hochberg, _dispatch_p_adjust, ancom,
+    vlr, pairwise_vlr, tree_basis, dirmult_ttest)
 
 
 def assert_coo_allclose(res, exp, rtol=1e-7, atol=1e-7):
@@ -205,8 +202,8 @@ class CompositionTests(TestCase):
                             np.array([[2, 2, 6],
                                       [4, 4, 2]]))
 
-    def test_multiplicative_replacement(self):
-        amat = multiplicative_replacement(closure(self.cdata3))
+    def test_multi_replace(self):
+        amat = multi_replace(closure(self.cdata3))
         npt.assert_allclose(amat,
                             np.array([[0.087273, 0.174545, 0.261818,
                                        0.04, 0.436364],
@@ -215,13 +212,13 @@ class CompositionTests(TestCase):
                                        0.266667, 0.333333]]),
                             rtol=1e-5, atol=1e-5)
 
-        amat = multiplicative_replacement(closure(self.cdata4))
+        amat = multi_replace(closure(self.cdata4))
         npt.assert_allclose(amat,
                             np.array([0.087273, 0.174545, 0.261818,
                                       0.04, 0.436364]),
                             rtol=1e-5, atol=1e-5)
 
-        amat = multiplicative_replacement(closure(self.cdata6))
+        amat = multi_replace(closure(self.cdata6))
         npt.assert_allclose(amat,
                             np.array([[0.087273, 0.174545, 0.261818,
                                        0.04, 0.436364],
@@ -231,17 +228,21 @@ class CompositionTests(TestCase):
                             rtol=1e-5, atol=1e-5)
 
         with self.assertRaises(ValueError):
-            multiplicative_replacement(self.bad1)
+            multi_replace(self.bad1)
         with self.assertRaises(ValueError):
-            multiplicative_replacement(self.bad2)
+            multi_replace(self.bad2)
 
         # make sure that inplace modification is not occurring
-        multiplicative_replacement(self.cdata4)
+        multi_replace(self.cdata4)
         npt.assert_allclose(self.cdata4, np.array([1, 2, 3, 0, 5]))
 
-    def multiplicative_replacement_warning(self):
+    def multi_replace_warning(self):
         with self.assertRaises(ValueError):
-            multiplicative_replacement([0, 1, 2], delta=1)
+            multi_replace([0, 1, 2], delta=1)
+
+    def test_multiplicative_replacement(self):
+        mat = closure(self.cdata3)
+        npt.assert_allclose(multiplicative_replacement(mat), multi_replace(mat))
 
     def test_clr(self):
         cmat = clr(closure(self.cdata1))
@@ -783,9 +784,7 @@ class AncomTests(TestCase):
         original_table = copy.deepcopy(test_table)
         test_cats = pd.Series(self.cats1)
         original_cats = copy.deepcopy(test_cats)
-        result = ancom(test_table,
-                       test_cats,
-                       multiple_comparisons_correction=None)
+        result = ancom(test_table, test_cats, p_adjust=None)
         # Test to make sure that the input table hasn't be altered
         assert_data_frame_almost_equal(original_table, test_table)
         # Test to make sure that the input table hasn't be altered
@@ -989,9 +988,7 @@ class AncomTests(TestCase):
         original_table = copy.deepcopy(test_table)
         test_cats = pd.Series(self.cats1)
         original_cats = copy.deepcopy(test_cats)
-        result = ancom(test_table,
-                       test_cats,
-                       multiple_comparisons_correction=None)
+        result = ancom(test_table, test_cats, p_adjust=None)
         # Test to make sure that the input table hasn't be altered
         assert_data_frame_almost_equal(original_table, test_table)
         # Test to make sure that the input table hasn't be altered
@@ -1021,9 +1018,7 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_noncontiguous(self):
-        result = ancom(self.table5,
-                       self.cats5,
-                       multiple_comparisons_correction=None)
+        result = ancom(self.table5, self.cats5, p_adjust=None)
         exp = pd.DataFrame(
             {'W': np.array([6, 2, 2, 2, 2, 6, 2]),
              'Reject null hypothesis': np.array([True, False, False, False,
@@ -1032,9 +1027,7 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_unbalanced(self):
-        result = ancom(self.table6,
-                       self.cats6,
-                       multiple_comparisons_correction=None)
+        result = ancom(self.table6, self.cats6, p_adjust=None)
         exp = pd.DataFrame(
             {'W': np.array([5, 3, 3, 2, 2, 5, 2]),
              'Reject null hypothesis': np.array([True, False, False, False,
@@ -1043,9 +1036,7 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_letter_categories(self):
-        result = ancom(self.table7,
-                       self.cats7,
-                       multiple_comparisons_correction=None)
+        result = ancom(self.table7, self.cats7, p_adjust=None)
         exp = pd.DataFrame(
             {'W': np.array([5, 3, 3, 2, 2, 5, 2]),
              'Reject null hypothesis': np.array([True, False, False, False,
@@ -1054,22 +1045,26 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_multiple_comparisons(self):
-        significance_test = functools.partial(scipy.stats.mannwhitneyu,
-                                              alternative='two-sided')
-        result = ancom(self.table1,
-                       self.cats1,
-                       multiple_comparisons_correction='holm-bonferroni',
-                       significance_test=significance_test)
         exp = pd.DataFrame(
-            {'W': np.array([0]*7),
-             'Reject null hypothesis': np.array([False]*7, dtype=bool)})
+            {'W': np.array([0] * 7),
+             'Reject null hypothesis': np.array([False] * 7, dtype=bool)})
+        for method in 'holm', 'bh':
+            result = ancom(self.table1, self.cats1, p_adjust=method,
+                           significance_test='mannwhitneyu')
+            assert_data_frame_almost_equal(result[0], exp)
+
+    def test_ancom_multiple_comparisons_deprecated(self):
+        exp = pd.DataFrame(
+            {'W': np.array([0] * 7),
+             'Reject null hypothesis': np.array([False] * 7, dtype=bool)})
+        result = ancom(self.table1, self.cats1,
+                       significance_test='mannwhitneyu',
+                       multiple_comparisons_correction=None)
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_alternative_test(self):
-        result = ancom(self.table1,
-                       self.cats1,
-                       multiple_comparisons_correction=None,
-                       significance_test=scipy.stats.ttest_ind)
+        result = ancom(self.table1, self.cats1, p_adjust=None,
+                       significance_test="ttest_ind")
         exp = pd.DataFrame(
             {'W': np.array([5, 5, 2, 2, 2, 2, 2]),
              'Reject null hypothesis': np.array([True,  True, False, False,
@@ -1077,11 +1072,15 @@ class AncomTests(TestCase):
                                                 dtype=bool)})
         assert_data_frame_almost_equal(result[0], exp)
 
+    def test_ancom_incorrect_test(self):
+        with self.assertRaises(ValueError) as cm:
+            ancom(self.table1, self.cats1, significance_test="not_a_test")
+        msg = 'Function "not_a_test" does not exist under scipy.stats.'
+        self.assertEqual(str(cm.exception), msg)
+
     def test_ancom_normal_data(self):
-        result = ancom(self.table2,
-                       self.cats2,
-                       multiple_comparisons_correction=None,
-                       significance_test=scipy.stats.ttest_ind)
+        result = ancom(self.table2, self.cats2, p_adjust=None,
+                       significance_test="ttest_ind")
         exp = pd.DataFrame(
             {'W': np.array([8, 8, 3, 3, 8, 3, 3, 3, 3]),
              'Reject null hypothesis': np.array([True, True, False, False,
@@ -1100,9 +1099,7 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_no_signal(self):
-        result = ancom(self.table3,
-                       self.cats3,
-                       multiple_comparisons_correction=None)
+        result = ancom(self.table3, self.cats3, p_adjust=None)
         exp = pd.DataFrame(
             {'W': np.array([0]*7),
              'Reject null hypothesis': np.array([False]*7, dtype=bool)})
@@ -1132,12 +1129,9 @@ class AncomTests(TestCase):
                                                  False, False, False, False,
                                                  False, False], dtype=bool)})
 
-        result1 = ancom(self.table4, self.cats4,
-                        multiple_comparisons_correction=None, tau=0.25)
-        result2 = ancom(self.table9, self.cats9,
-                        multiple_comparisons_correction=None, tau=0.02)
-        result3 = ancom(self.table10, self.cats10,
-                        multiple_comparisons_correction=None, tau=0.02)
+        result1 = ancom(self.table4, self.cats4, p_adjust=None, tau=0.25)
+        result2 = ancom(self.table9, self.cats9, p_adjust=None, tau=0.02)
+        result3 = ancom(self.table10, self.cats10, p_adjust=None, tau=0.02)
 
         assert_data_frame_almost_equal(result1[0], exp1)
         assert_data_frame_almost_equal(result2[0], exp2)
@@ -1153,8 +1147,7 @@ class AncomTests(TestCase):
         assert_data_frame_almost_equal(result[0], exp)
 
     def test_ancom_alpha(self):
-        result = ancom(self.table1, self.cats1,
-                       multiple_comparisons_correction=None, alpha=0.5)
+        result = ancom(self.table1, self.cats1, p_adjust=None, alpha=0.5)
         exp = pd.DataFrame(
             {'W': np.array([6, 6, 4, 5, 5, 4, 2]),
              'Reject null hypothesis': np.array([True, True, False, True,
@@ -1170,16 +1163,15 @@ class AncomTests(TestCase):
 
     def test_ancom_fail_zeros(self):
         with self.assertRaises(ValueError):
-            ancom(self.bad1, self.cats2, multiple_comparisons_correction=None)
+            ancom(self.bad1, self.cats2, p_adjust=None)
 
     def test_ancom_fail_negative(self):
         with self.assertRaises(ValueError):
-            ancom(self.bad2, self.cats2, multiple_comparisons_correction=None)
+            ancom(self.bad2, self.cats2, p_adjust=None)
 
-    def test_ancom_fail_not_implemented_multiple_comparisons_correction(self):
+    def test_ancom_fail_not_implemented_p_adjust(self):
         with self.assertRaises(ValueError):
-            ancom(self.table2, self.cats2,
-                  multiple_comparisons_correction='fdr')
+            ancom(self.table2, self.cats2, p_adjust='fdr')
 
     def test_ancom_fail_missing(self):
         with self.assertRaises(ValueError):
@@ -1225,17 +1217,33 @@ class AncomTests(TestCase):
     def test_ancom_fail_multiple_groups(self):
         with self.assertRaises((TypeError, np.AxisError)):
             ancom(self.table4, self.cats4,
-                  significance_test=scipy.stats.ttest_ind)
+                  significance_test="ttest_ind")
 
+
+class FDRTests(TestCase):
     def test_holm_bonferroni(self):
         p = [0.005, 0.011, 0.02, 0.04, 0.13]
-        corrected_p = p * np.arange(1, 6)[::-1]
-        guessed_p = _holm_bonferroni(p)
-        for a, b in zip(corrected_p, guessed_p):
+        obs = _holm_bonferroni(p)
+        exp = p * np.arange(1, 6)[::-1]
+        for a, b in zip(obs, exp):
             self.assertAlmostEqual(a, b)
 
+    def test_benjamini_hochberg(self):
+        p = [0.005, 0.011, 0.02, 0.04, 0.13]
+        obs = _benjamini_hochberg(p)
+        exp = [0.025, 0.0275, 0.03333333, 0.05, 0.13]
+        for a, b in zip(obs, exp):
+            self.assertAlmostEqual(a, b)
 
-class TestVLR(TestCase):
+    def test_dispatch_p_adjust(self):
+        self.assertIsNone(_dispatch_p_adjust(None))
+        self.assertEqual(_dispatch_p_adjust(
+            "holm-bonferroni").__name__, "_holm_bonferroni")
+        self.assertEqual(_dispatch_p_adjust(
+            "benjamini-hochberg").__name__, "_benjamini_hochberg")
+
+
+class VLRTests(TestCase):
     def setUp(self):
         self.mat = np.array([[1, 1, 2], [3, 5, 8], [13, 21, 55]])
         self.mat_neg = np.array([[-1, 1, 2], [3, -5, 8], [13, 21, -55]])
@@ -1306,7 +1314,7 @@ class TestVLR(TestCase):
         self.assertAlmostEqual(output, 0.2857382286903922)
 
 
-class TestDirMultTTest(TestCase):
+class DirMultTTestTests(TestCase):
     def setUp(self):
         np.random.seed(0)
         # Create sample data for testing


### PR DESCRIPTION
This PR touches up the `skbio.stats.composition` module to improve its usability.

Main changes (following discussion with @mortonjt):

- Abbreviated `multiplicative_replacement` as `multi_replace` for simplicity. The old function is kept as an alias for backward compatibility.
- Implemented the Benjamini-Hochberg method for FDR correction, in addition to the existing Holm-Bonferroni method.
- Added a parameter `p_adjust` for both `ancom` and `dirmult_ttest`.
  - The word `p_adjust` is consistent with R, statsmodels, and QIIME2's ANCOM-BC plugin.
  - The value of `p_adjust` can be None, "holm", "holm-bonferroni", "bh", "fdr_bh", "benjamini-hochberg" (case insensitive). This is to ensure compatibility with statsmodels' `multipletests`, which we may adopt in the future.
  - The original parameter `multiple_comparisons_correction` of `ancom` is too long, so I renamed it as `p_adjust`. The old name is kept for backward compatibility.

Notes:
- I left the default FDR correction method as Holm-Bonferroni (Holm) for both `ancom` and `dirmult_ttest`. However, I acknowledge that ALDEx2 defaults to Benjamini-Hochberg (BH). ANCOM also defaults to BH ([source code](https://github.com/FrederickHuangLin/ANCOM-Code-Archive/blob/a1c47296b5e8e518387b4885699587274c2ab6b1/programs/ancom.R#L129)), whereas ANCOM-BC defaults to Holm. I left them Holm because I fear that my edits could break the code. @mortonjt 

Minor changes:
- Standardized docstrings throughout the module.
- For `ancom`, the user now can specify a statistical test by name (like "ttest_ind") in addition to a callable.

Issues noticed (@mortonjt please check):
- In the test code, the [`multiplicative_replacement_warning`](https://github.com/scikit-bio/scikit-bio/blob/3fb72e437841e01690a02d44a35c290953ff12d1/skbio/stats/tests/test_composition.py#L242) function was skipped because it doesn't starts with `test_`. I manually ran it and found that it failed. That is, a large delta value doesn't cause multiplicative replacement to generate negative proportions ([source code](https://github.com/scikit-bio/scikit-bio/blob/3fb72e437841e01690a02d44a35c290953ff12d1/skbio/stats/composition.py#L228)). I tried very large delta values but it consistently failed. Is there something overlooked in the function?
- The function `vlr`'s docstring doesn't have formula and description as other transformation functions do. Also, `vlr` does not seem to support 2D matrices as input, while other transformations do.

Thoughts:
- The functions [`sbp_basis`](https://github.com/scikit-bio/scikit-bio/blob/3fb72e437841e01690a02d44a35c290953ff12d1/skbio/stats/composition.py#L1603C5-L1603C14) and [`_gram_schmidt_basis`](https://github.com/scikit-bio/scikit-bio/blob/3fb72e437841e01690a02d44a35c290953ff12d1/skbio/stats/composition.py#L1581) use a slow `for` loop and can be optimized using NumPy's vectorization. Can be a practice project for a junior developer.
- The `draws` parameter of `dirmult_ttest` may be too informal. This parameter defines the number of Monte Carlo samplings. In ALDEx2, it is called `mc.samples`. In SciPy it is called `n_resamples` ([link](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.monte_carlo_test.html)).
- "significance_test" is bit long. But I don't have a better idea.
- "Reject null hypothesis" is bit long. How about "Reject null"?
- "Treatment" vs "Reference" sounds too specific. But I don't have a better idea.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
