### PR TITLE
Fix doc rendering issues in sample_metadata

### DIFF
--- a/skbio/io/format/sample_metadata.py
+++ b/skbio/io/format/sample_metadata.py
@@ -100,6 +100,7 @@ The ID column name (i.e. ID header) must be one of the following values. The
 values listed below may not be used to name other IDs or columns in the file.
 
 Case-insensitive:
+
 - id
 
 - sampleid
@@ -116,6 +117,7 @@ Case-insensitive:
 
 Case-sensitive (these are mostly for backwards-compatibility with QIIME 1,
 biom-format, and Qiita files):
+
 - #SampleID
 
 - #Sample ID


### PR DESCRIPTION
Simple fix for incorrectly rendered bullet point lists in the `sample_metadata` documentation. Without the space added, the first item of the bullet list would render on the same line as the category for that list.

Before:
![Screenshot 2024-03-21 122742](https://github.com/scikit-bio/scikit-bio/assets/62309966/37b67bdd-3162-43d3-afda-16556046babe)

Upon merge:
![Screenshot 2024-03-21 122837](https://github.com/scikit-bio/scikit-bio/assets/62309966/984d04fd-0796-4648-9c6b-eb11856e70b4)


Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
