### PR TITLE
Fix default int types for Pandas DataFrame and Series

### DIFF
--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -170,19 +170,19 @@ class AlphaDiversityTests(TestCase):
         # empty vector
         actual = alpha_diversity('sobs',
                                  np.array([], dtype=np.int64))
-        expected = pd.Series([0])
+        expected = pd.Series([0]).astype(int)
         assert_series_almost_equal(actual, expected)
 
         # array of empty vector
         actual = alpha_diversity('sobs',
                                  np.array([[]], dtype=np.int64))
-        expected = pd.Series([0])
+        expected = pd.Series([0]).astype(int)
         assert_series_almost_equal(actual, expected)
 
         # array of empty vectors
         actual = alpha_diversity('sobs',
                                  np.array([[], []], dtype=np.int64))
-        expected = pd.Series([0, 0])
+        expected = pd.Series([0, 0]).astype(int)
         assert_series_almost_equal(actual, expected)
 
         # empty vector
@@ -208,12 +208,12 @@ class AlphaDiversityTests(TestCase):
         # empty Table
         actual = alpha_diversity('sobs', Table(np.array([[]]), [], ['S1', ]))
         actual.index = pd.RangeIndex(len(actual))
-        expected = pd.Series([0])
+        expected = pd.Series([0]).astype(int)
         assert_series_almost_equal(actual, expected)
 
     def test_single_count_vector(self):
         actual = alpha_diversity('sobs', np.array([1, 0, 2]))
-        expected = pd.Series([2])
+        expected = pd.Series([2]).astype(int)
         assert_series_almost_equal(actual, expected)
 
         actual = alpha_diversity('faith_pd', np.array([1, 3, 0, 1, 0]),
@@ -255,14 +255,14 @@ class AlphaDiversityTests(TestCase):
 
     def test_sobs(self):
         # expected values hand-calculated
-        expected = pd.Series([3, 3, 3, 3], index=self.sids1)
+        expected = pd.Series([3, 3, 3, 3], index=self.sids1).astype(int)
         actual = alpha_diversity('sobs', self.table1, self.sids1)
         assert_series_almost_equal(actual, expected)
         # function passed instead of string
         actual = alpha_diversity(sobs, self.table1, self.sids1)
         assert_series_almost_equal(actual, expected)
         # alt input table
-        expected = pd.Series([2, 1, 0], index=self.sids2)
+        expected = pd.Series([2, 1, 0], index=self.sids2).astype(int)
         actual = alpha_diversity('sobs', self.table2, self.sids2)
         assert_series_almost_equal(actual, expected)
 
@@ -315,7 +315,7 @@ class AlphaDiversityTests(TestCase):
 
     def test_no_ids(self):
         # expected values hand-calculated
-        expected = pd.Series([3, 3, 3, 3])
+        expected = pd.Series([3, 3, 3, 3]).astype(int)
         actual = alpha_diversity('sobs', self.table1)
         assert_series_almost_equal(actual, expected)
 

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -170,19 +170,19 @@ class AlphaDiversityTests(TestCase):
         # empty vector
         actual = alpha_diversity('sobs',
                                  np.array([], dtype=np.int64))
-        expected = pd.Series([0]).astype(int)
+        expected = pd.Series([0], dtype=int)
         assert_series_almost_equal(actual, expected)
 
         # array of empty vector
         actual = alpha_diversity('sobs',
                                  np.array([[]], dtype=np.int64))
-        expected = pd.Series([0]).astype(int)
+        expected = pd.Series([0], dtype=int)
         assert_series_almost_equal(actual, expected)
 
         # array of empty vectors
         actual = alpha_diversity('sobs',
                                  np.array([[], []], dtype=np.int64))
-        expected = pd.Series([0, 0]).astype(int)
+        expected = pd.Series([0, 0], dtype=int)
         assert_series_almost_equal(actual, expected)
 
         # empty vector
@@ -208,12 +208,12 @@ class AlphaDiversityTests(TestCase):
         # empty Table
         actual = alpha_diversity('sobs', Table(np.array([[]]), [], ['S1', ]))
         actual.index = pd.RangeIndex(len(actual))
-        expected = pd.Series([0]).astype(int)
+        expected = pd.Series([0], dtype=int)
         assert_series_almost_equal(actual, expected)
 
     def test_single_count_vector(self):
         actual = alpha_diversity('sobs', np.array([1, 0, 2]))
-        expected = pd.Series([2]).astype(int)
+        expected = pd.Series([2], dtype=int)
         assert_series_almost_equal(actual, expected)
 
         actual = alpha_diversity('faith_pd', np.array([1, 3, 0, 1, 0]),
@@ -255,14 +255,14 @@ class AlphaDiversityTests(TestCase):
 
     def test_sobs(self):
         # expected values hand-calculated
-        expected = pd.Series([3, 3, 3, 3], index=self.sids1).astype(int)
+        expected = pd.Series([3, 3, 3, 3], index=self.sids1, dtype=int)
         actual = alpha_diversity('sobs', self.table1, self.sids1)
         assert_series_almost_equal(actual, expected)
         # function passed instead of string
         actual = alpha_diversity(sobs, self.table1, self.sids1)
         assert_series_almost_equal(actual, expected)
         # alt input table
-        expected = pd.Series([2, 1, 0], index=self.sids2).astype(int)
+        expected = pd.Series([2, 1, 0], index=self.sids2, dtype=int)
         actual = alpha_diversity('sobs', self.table2, self.sids2)
         assert_series_almost_equal(actual, expected)
 
@@ -315,7 +315,7 @@ class AlphaDiversityTests(TestCase):
 
     def test_no_ids(self):
         # expected values hand-calculated
-        expected = pd.Series([3, 3, 3, 3]).astype(int)
+        expected = pd.Series([3, 3, 3, 3], dtype=int)
         actual = alpha_diversity('sobs', self.table1)
         assert_series_almost_equal(actual, expected)
 

--- a/skbio/io/format/fasta.py
+++ b/skbio/io/format/fasta.py
@@ -955,7 +955,7 @@ def _parse_quality_scores(chunks):
 
     qual_str = " ".join(chunks)
     try:
-        quality = np.asarray(qual_str.split(), dtype=int)
+        quality = np.asarray(qual_str.split(), dtype=np.int64)
     except ValueError:
         raise QUALFormatError(
             "Could not convert quality scores to integers:\n%s" % str(qual_str)

--- a/skbio/io/format/tests/test_taxdump.py
+++ b/skbio/io/format/tests/test_taxdump.py
@@ -69,7 +69,8 @@ class TestTaxdumpReader(unittest.TestCase):
                  'inherited_MGC_flag', 'GenBank_hidden_flag',
                  'hidden_subtree_root_flag', 'comments']).set_index('tax_id')
         exp['comments'] = exp['comments'].astype('O')
-        assert_data_frame_almost_equal(obs, _data_frame_to_default_int_type(exp))
+        _data_frame_to_default_int_type(exp)
+        assert_data_frame_almost_equal(obs, exp)
 
     def test_names_default(self):
         # subset of a real NCBI taxonomy names.dmp file
@@ -131,7 +132,8 @@ class TestTaxdumpReader(unittest.TestCase):
             [1038927, 562,    'no rank'],
             [2580236, 488338, 'species']],
             columns=['tax_id', 'parent_tax_id', 'rank']).set_index('tax_id')
-        assert_data_frame_almost_equal(obs, _data_frame_to_default_int_type(exp))
+        _data_frame_to_default_int_type(exp)
+        assert_data_frame_almost_equal(obs, exp)
 
     def test_custom_scheme(self):
         fs = StringIO('\n'.join(map('\t|\t'.join, [

--- a/skbio/io/format/tests/test_taxdump.py
+++ b/skbio/io/format/tests/test_taxdump.py
@@ -13,6 +13,7 @@ import pandas as pd
 import numpy as np
 
 from skbio.util import get_data_path, assert_data_frame_almost_equal
+from skbio.util._testing import _data_frame_to_default_int_type
 from skbio.io.format.taxdump import _taxdump_to_data_frame
 
 
@@ -68,7 +69,7 @@ class TestTaxdumpReader(unittest.TestCase):
                  'inherited_MGC_flag', 'GenBank_hidden_flag',
                  'hidden_subtree_root_flag', 'comments']).set_index('tax_id')
         exp['comments'] = exp['comments'].astype('O')
-        assert_data_frame_almost_equal(obs, exp)
+        assert_data_frame_almost_equal(obs, _data_frame_to_default_int_type(exp))
 
     def test_names_default(self):
         # subset of a real NCBI taxonomy names.dmp file
@@ -130,7 +131,7 @@ class TestTaxdumpReader(unittest.TestCase):
             [1038927, 562,    'no rank'],
             [2580236, 488338, 'species']],
             columns=['tax_id', 'parent_tax_id', 'rank']).set_index('tax_id')
-        assert_data_frame_almost_equal(obs, exp)
+        assert_data_frame_almost_equal(obs, _data_frame_to_default_int_type(exp))
 
     def test_custom_scheme(self):
         fs = StringIO('\n'.join(map('\t|\t'.join, [

--- a/skbio/stats/distance/tests/test_bioenv.py
+++ b/skbio/stats/distance/tests/test_bioenv.py
@@ -75,26 +75,31 @@ class BIOENVTests(TestCase):
         self.df_vegan.set_index('#SampleID', inplace=True)
 
         # Load expected results.
-        self.exp_results = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path('exp_results.txt'),
-                        sep='\t',
-                        index_col=0)
-            )
-        self.exp_results_single_column = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path('exp_results_single_column.txt'),
-                        sep='\t',
-                        index_col=0)
-            )
-        self.exp_results_different_column_order = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path('exp_results_different_column_order.txt'),
-                        sep='\t',
-                        index_col=0)
-            )
-        self.exp_results_vegan = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path('bioenv_exp_results_vegan.txt'),
-                        sep='\t',
-                        index_col=0)
-            )
+        self.exp_results = pd.read_csv(get_data_path('exp_results.txt'),
+                                       sep='\t',
+                                       index_col=0)
+        _data_frame_to_default_int_type(self.exp_results)
+
+        self.exp_results_single_column = pd.read_csv(
+            get_data_path('exp_results_single_column.txt'),
+            sep='\t',
+            index_col=0
+        )
+        _data_frame_to_default_int_type(self.exp_results_single_column)
+
+        self.exp_results_different_column_order = pd.read_csv(
+            get_data_path('exp_results_different_column_order.txt'),
+            sep='\t',
+            index_col=0
+        )
+        _data_frame_to_default_int_type(self.exp_results_different_column_order)
+
+        self.exp_results_vegan = pd.read_csv(
+            get_data_path('bioenv_exp_results_vegan.txt'),
+            sep='\t',
+            index_col=0
+        )
+        _data_frame_to_default_int_type(self.exp_results_vegan)
 
     def test_bioenv_all_columns_implicit(self):
         # Test with all columns in data frame (implicitly).

--- a/skbio/stats/distance/tests/test_bioenv.py
+++ b/skbio/stats/distance/tests/test_bioenv.py
@@ -15,6 +15,7 @@ from skbio import DistanceMatrix
 from skbio.stats.distance import bioenv
 from skbio.stats.distance._bioenv import _scale
 from skbio.util import get_data_path, assert_data_frame_almost_equal
+from skbio.util._testing import _data_frame_to_default_int_type
 
 
 class BIOENVTests(TestCase):
@@ -74,17 +75,26 @@ class BIOENVTests(TestCase):
         self.df_vegan.set_index('#SampleID', inplace=True)
 
         # Load expected results.
-        self.exp_results = pd.read_csv(get_data_path('exp_results.txt'),
-                                       sep='\t', index_col=0)
-        self.exp_results_single_column = pd.read_csv(
-            get_data_path('exp_results_single_column.txt'), sep='\t',
-            index_col=0)
-        self.exp_results_different_column_order = pd.read_csv(
-            get_data_path('exp_results_different_column_order.txt'), sep='\t',
-            index_col=0)
-        self.exp_results_vegan = pd.read_csv(
-            get_data_path('bioenv_exp_results_vegan.txt'), sep='\t',
-            index_col=0)
+        self.exp_results = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path('exp_results.txt'),
+                        sep='\t',
+                        index_col=0)
+            )
+        self.exp_results_single_column = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path('exp_results_single_column.txt'),
+                        sep='\t',
+                        index_col=0)
+            )
+        self.exp_results_different_column_order = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path('exp_results_different_column_order.txt'),
+                        sep='\t',
+                        index_col=0)
+            )
+        self.exp_results_vegan = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path('bioenv_exp_results_vegan.txt'),
+                        sep='\t',
+                        index_col=0)
+            )
 
     def test_bioenv_all_columns_implicit(self):
         # Test with all columns in data frame (implicitly).
@@ -146,7 +156,11 @@ class BIOENVTests(TestCase):
         # same distances yields *very* similar results. Thus, the discrepancy
         # seems to stem from differences when computing ranks/ties.
         obs = bioenv(self.dm_vegan, self.df_vegan)
-        assert_data_frame_almost_equal(obs, self.exp_results_vegan, rtol=1e-3)
+        assert_data_frame_almost_equal(
+            obs,
+            self.exp_results_vegan,
+            rtol=1e-3
+            )
 
     def test_bioenv_no_distance_matrix(self):
         with self.assertRaises(TypeError):

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -552,7 +552,7 @@ class PairwiseMantelTests(MantelTestData):
         # input as array_like
         obs = pwmantel((self.minx, self.miny, self.minz),
                        alternative='greater')
-        assert_data_frame_almost_equal(obs, self.exp_results_minimal) #
+        assert_data_frame_almost_equal(obs, self.exp_results_minimal)
 
     def test_minimal_compatible_input_with_labels(self):
         np.random.seed(0)
@@ -561,17 +561,17 @@ class PairwiseMantelTests(MantelTestData):
                        labels=('minx', 'miny', 'minz'))
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_minimal_with_labels) #
+            self.exp_results_minimal_with_labels)
 
     def test_duplicate_dms(self):
         obs = pwmantel((self.minx_dm, self.minx_dm, self.minx_dm),
                        alternative='less')
-        assert_data_frame_almost_equal(obs, self.exp_results_duplicate_dms) #
+        assert_data_frame_almost_equal(obs, self.exp_results_duplicate_dms)
 
     def test_na_p_value(self):
         obs = pwmantel((self.miny_dm, self.minx_dm), method='spearman',
                        permutations=0)
-        assert_data_frame_almost_equal(obs, self.exp_results_na_p_value) #
+        assert_data_frame_almost_equal(obs, self.exp_results_na_p_value)
 
     def test_reordered_distance_matrices(self):
         # Matrices have matching IDs but they all have different ordering.
@@ -584,7 +584,7 @@ class PairwiseMantelTests(MantelTestData):
         obs = pwmantel((x, y, z), alternative='greater')
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices) #
+            self.exp_results_reordered_distance_matrices)
 
     def test_strict(self):
         # Matrices have some matching and nonmatching IDs, with different
@@ -599,7 +599,7 @@ class PairwiseMantelTests(MantelTestData):
         obs = pwmantel((x, y, z), alternative='greater', strict=False)
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices) #
+            self.exp_results_reordered_distance_matrices)
 
     def test_id_lookup(self):
         # Matrices have mismatched IDs but a lookup is provided.
@@ -623,7 +623,7 @@ class PairwiseMantelTests(MantelTestData):
                        lookup=lookup)
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices) #
+            self.exp_results_reordered_distance_matrices)
 
         # Make sure the inputs aren't modified.
         self.assertEqual(x, x_copy)

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -495,28 +495,40 @@ class PairwiseMantelTests(MantelTestData):
 
         self.min_dms = (self.minx_dm, self.miny_dm, self.minz_dm)
 
-        self.exp_results_minimal = _data_frame_to_default_int_type(pd.read_csv(
-            get_data_path('pwmantel_exp_results_minimal.txt'), sep='\t',
-            index_col=(0, 1)))
+        self.exp_results_minimal = pd.read_csv(
+            get_data_path('pwmantel_exp_results_minimal.txt'),
+            sep='\t',
+            index_col=(0, 1)
+        )
+        _data_frame_to_default_int_type(self.exp_results_minimal)
 
-        self.exp_results_minimal_with_labels = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path('pwmantel_exp_results_minimal_with_labels.txt'),
-                                      sep='\t',
-                                      index_col=(0, 1)))
+        self.exp_results_minimal_with_labels = pd.read_csv(
+            get_data_path('pwmantel_exp_results_minimal_with_labels.txt'),
+            sep='\t',
+            index_col=(0, 1)
+        )
+        _data_frame_to_default_int_type(self.exp_results_minimal_with_labels)
 
-        self.exp_results_duplicate_dms = _data_frame_to_default_int_type(pd.read_csv(
+        self.exp_results_duplicate_dms = pd.read_csv(
             get_data_path('pwmantel_exp_results_duplicate_dms.txt'),
-            sep='\t', index_col=(0, 1)))
+            sep='\t',
+            index_col=(0, 1)
+        )
+        _data_frame_to_default_int_type(self.exp_results_duplicate_dms)
 
-        self.exp_results_na_p_value = _data_frame_to_default_int_type(pd.read_csv(
+        self.exp_results_na_p_value = pd.read_csv(
             get_data_path('pwmantel_exp_results_na_p_value.txt'),
-            sep='\t', index_col=(0, 1)))
+            sep='\t',
+            index_col=(0, 1)
+        )
+        _data_frame_to_default_int_type(self.exp_results_na_p_value)
 
-        self.exp_results_reordered_distance_matrices = _data_frame_to_default_int_type(
-            pd.read_csv(get_data_path(
-                        'pwmantel_exp_results_reordered_distance_matrices.txt'),
-                        sep='\t',
-                        index_col=(0, 1)))
+        self.exp_results_reordered_distance_matrices = pd.read_csv(
+            get_data_path('pwmantel_exp_results_reordered_distance_matrices.txt'),
+            sep='\t',
+            index_col=(0, 1)
+        )
+        _data_frame_to_default_int_type(self.exp_results_reordered_distance_matrices)
 
         self.exp_results_dm_dm2 = pd.read_csv(
             get_data_path('pwmantel_exp_results_dm_dm2.txt'),

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -25,6 +25,7 @@ from skbio.stats.distance._mantel import _mantel_stats_spearman
 from skbio.stats.distance._cutils import mantel_perm_pearsonr_cy
 from skbio.stats.distance._utils import distmat_reorder_condensed
 from skbio.util import get_data_path, assert_data_frame_almost_equal
+from skbio.util._testing import _data_frame_to_default_int_type
 
 
 class MantelTestData(TestCase):
@@ -494,26 +495,28 @@ class PairwiseMantelTests(MantelTestData):
 
         self.min_dms = (self.minx_dm, self.miny_dm, self.minz_dm)
 
-        self.exp_results_minimal = pd.read_csv(
+        self.exp_results_minimal = _data_frame_to_default_int_type(pd.read_csv(
             get_data_path('pwmantel_exp_results_minimal.txt'), sep='\t',
-            index_col=(0, 1))
+            index_col=(0, 1)))
 
-        self.exp_results_minimal_with_labels = pd.read_csv(
-            get_data_path('pwmantel_exp_results_minimal_with_labels.txt'),
-            sep='\t', index_col=(0, 1))
+        self.exp_results_minimal_with_labels = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path('pwmantel_exp_results_minimal_with_labels.txt'),
+                                      sep='\t',
+                                      index_col=(0, 1)))
 
-        self.exp_results_duplicate_dms = pd.read_csv(
+        self.exp_results_duplicate_dms = _data_frame_to_default_int_type(pd.read_csv(
             get_data_path('pwmantel_exp_results_duplicate_dms.txt'),
-            sep='\t', index_col=(0, 1))
+            sep='\t', index_col=(0, 1)))
 
-        self.exp_results_na_p_value = pd.read_csv(
+        self.exp_results_na_p_value = _data_frame_to_default_int_type(pd.read_csv(
             get_data_path('pwmantel_exp_results_na_p_value.txt'),
-            sep='\t', index_col=(0, 1))
+            sep='\t', index_col=(0, 1)))
 
-        self.exp_results_reordered_distance_matrices = pd.read_csv(
-            get_data_path('pwmantel_exp_results_reordered_distance_matrices'
-                          '.txt'),
-            sep='\t', index_col=(0, 1))
+        self.exp_results_reordered_distance_matrices = _data_frame_to_default_int_type(
+            pd.read_csv(get_data_path(
+                        'pwmantel_exp_results_reordered_distance_matrices.txt'),
+                        sep='\t',
+                        index_col=(0, 1)))
 
         self.exp_results_dm_dm2 = pd.read_csv(
             get_data_path('pwmantel_exp_results_dm_dm2.txt'),
@@ -549,7 +552,7 @@ class PairwiseMantelTests(MantelTestData):
         # input as array_like
         obs = pwmantel((self.minx, self.miny, self.minz),
                        alternative='greater')
-        assert_data_frame_almost_equal(obs, self.exp_results_minimal)
+        assert_data_frame_almost_equal(obs, self.exp_results_minimal) #
 
     def test_minimal_compatible_input_with_labels(self):
         np.random.seed(0)
@@ -558,17 +561,17 @@ class PairwiseMantelTests(MantelTestData):
                        labels=('minx', 'miny', 'minz'))
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_minimal_with_labels)
+            self.exp_results_minimal_with_labels) #
 
     def test_duplicate_dms(self):
         obs = pwmantel((self.minx_dm, self.minx_dm, self.minx_dm),
                        alternative='less')
-        assert_data_frame_almost_equal(obs, self.exp_results_duplicate_dms)
+        assert_data_frame_almost_equal(obs, self.exp_results_duplicate_dms) #
 
     def test_na_p_value(self):
         obs = pwmantel((self.miny_dm, self.minx_dm), method='spearman',
                        permutations=0)
-        assert_data_frame_almost_equal(obs, self.exp_results_na_p_value)
+        assert_data_frame_almost_equal(obs, self.exp_results_na_p_value) #
 
     def test_reordered_distance_matrices(self):
         # Matrices have matching IDs but they all have different ordering.
@@ -581,7 +584,7 @@ class PairwiseMantelTests(MantelTestData):
         obs = pwmantel((x, y, z), alternative='greater')
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices)
+            self.exp_results_reordered_distance_matrices) #
 
     def test_strict(self):
         # Matrices have some matching and nonmatching IDs, with different
@@ -596,7 +599,7 @@ class PairwiseMantelTests(MantelTestData):
         obs = pwmantel((x, y, z), alternative='greater', strict=False)
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices)
+            self.exp_results_reordered_distance_matrices) #
 
     def test_id_lookup(self):
         # Matrices have mismatched IDs but a lookup is provided.
@@ -620,7 +623,7 @@ class PairwiseMantelTests(MantelTestData):
                        lookup=lookup)
         assert_data_frame_almost_equal(
             obs,
-            self.exp_results_reordered_distance_matrices)
+            self.exp_results_reordered_distance_matrices) #
 
         # Make sure the inputs aren't modified.
         self.assertEqual(x, x_copy)

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -349,6 +349,23 @@ def assert_data_frame_almost_equal(left, right, rtol=1e-5):
     assert_index_equal(left.index, right.index)
 
 
+def _data_frame_to_default_int_type(df):
+    """Convert integer columns in a data frame into the platform-default integer type.
+
+    Pandas DataFrame defaults to int64 when reading integers, rather than respecting
+    the platform default (Linux and MacOS: int64, Windows: int32). This causes issues
+    in comparing observed and expected data frames in Windows. This function repairs
+    the issue by converting int64 columns of a data frame into int32 in Windows.
+
+    See: https://github.com/unionai-oss/pandera/issues/726
+
+    """
+    for col in df.select_dtypes("int").columns:
+        df[col] = df[col].astype(int)
+
+    return df
+
+
 def assert_series_almost_equal(left, right):
     # pass all kwargs to ensure this function has consistent behavior even if
     # `assert_series_equal`'s defaults change

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -363,8 +363,6 @@ def _data_frame_to_default_int_type(df):
     for col in df.select_dtypes("int").columns:
         df[col] = df[col].astype(int)
 
-    return df
-
 
 def assert_series_almost_equal(left, right):
     # pass all kwargs to ensure this function has consistent behavior even if


### PR DESCRIPTION
This PR fixes underlying issues with the way Pandas handles `int`s on Windows.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
