### PR TITLE
Fix doctests on Windows

### DIFF
--- a/skbio/alignment/_path.py
+++ b/skbio/alignment/_path.py
@@ -424,10 +424,10 @@ class AlignPath(SkbioObject):
         >>> path = AlignPath(lengths=[1, 2, 2, 1],
         ...                  states=[0, 5, 2, 6],
         ...                  starts=[0, 0, 0])
-        >>> path.to_coordinates()
+        >>> path.to_coordinates() # doctest: +ELLIPSIS
         array([[0, 1, 1, 3, 4],
                [0, 1, 3, 3, 3],
-               [0, 1, 1, 3, 3]])
+               [0, 1, 1, 3, 3]]...
 
         """
         lens = self._lengths * (1 - self.to_bits())

--- a/skbio/diversity/__init__.py
+++ b/skbio/diversity/__init__.py
@@ -222,14 +222,14 @@ Create a matrix containing 6 samples (rows) and 7 taxa (columns):
 
    >>> from skbio.diversity import alpha_diversity
    >>> adiv_sobs = alpha_diversity('sobs', data, ids)
-   >>> adiv_sobs
+   >>> adiv_sobs # doctest: +ELLIPSIS
    A    5
    B    5
    C    4
    D    4
    E    5
    F    3
-   dtype: int64
+   dtype: ...
 
    Next we'll compute Faith's PD on the same samples. Since this is a
    phylogenetic diversity metric, we'll first create a tree and an ordered

--- a/skbio/sequence/_nucleotide_mixin.py
+++ b/skbio/sequence/_nucleotide_mixin.py
@@ -135,8 +135,8 @@ class NucleotideMixin(metaclass=ABCMeta):
             GC-content: 16.67%
         -----------------------------
         0 AATGAA
-        >>> rc.positional_metadata['quality'].values
-        array([5, 4, 3, 2, 1, 0])
+        >>> rc.positional_metadata['quality'].values # doctest: +ELLIPSIS
+        array([5, 4, 3, 2, 1, 0]...
 
         """
         result = self._complement_lookup[self._bytes]
@@ -206,8 +206,8 @@ class NucleotideMixin(metaclass=ABCMeta):
             GC-content: 16.67%
         -----------------------------
         0 AATGAA
-        >>> seq.positional_metadata['quality'].values
-        array([5, 4, 3, 2, 1, 0])
+        >>> seq.positional_metadata['quality'].values # doctest: +ELLIPSIS
+        array([5, 4, 3, 2, 1, 0]...
 
 
         """

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -1409,7 +1409,7 @@ def ancom(
     feature in each group.
 
     >>> ancom_df, percentile_df = ancom(table, grouping)
-    >>> ancom_df['W']
+    >>> ancom_df['W'] # doctest: +ELLIPSIS
     b1    0
     b2    4
     b3    0
@@ -1417,7 +1417,7 @@ def ancom(
     b5    1
     b6    0
     b7    1
-    Name: W, dtype: int64
+    Name: W, dtype: ...
 
     The *W*-statistic is the number of features that a single feature is tested
     to be significantly different against. In this scenario, ``b2`` was

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -63,8 +63,8 @@ step.
 >>> import numpy as np
 >>> np.random.seed(20)
 >>> ind = np.random.randint(0, 20, 15)
->>> ind
-array([ 3, 15,  9, 11,  7,  2,  0,  8, 19, 16,  6,  6, 16,  9,  5])
+>>> ind # doctest: +ELLIPSIS
+array([ 3, 15,  9, 11,  7,  2,  0,  8, 19, 16,  6,  6, 16,  9,  5]...
 >>> dep = (3 * ind + 5 + np.random.randn(15) * 5).round(3)
 >>> dep
 array([ 15.617,  47.533,  28.04 ,  33.788,  19.602,  12.229,   4.779,

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -19,7 +19,7 @@ from scipy.spatial.distance import correlation
 
 from skbio._base import SkbioObject
 from skbio.stats.distance import DistanceMatrix
-from ._exception import (
+from skbio.tree._exception import (
     NoLengthError,
     DuplicateNodeError,
     NoParentError,
@@ -2085,11 +2085,11 @@ class TreeNode(SkbioObject):
         >>> res = t.to_array()
         >>> sorted(res.keys())
         ['child_index', 'id', 'id_index', 'length', 'name']
-        >>> res['child_index']
+        >>> res['child_index'] # doctest: +ELLIPSIS
         array([[4, 0, 2],
                [5, 3, 3],
                [6, 4, 5],
-               [7, 6, 6]])
+               [7, 6, 6]]...
         >>> for k, v in res['id_index'].items():
         ...     print(k, v)
         ...


### PR DESCRIPTION
This PR fixes doctests for Windows compatibility. Simple implementation of `doctest: +ELLIPSIS` was used to ignore `dtype` differences across platforms.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
