### PR TITLE
Resolved Warnings 

### DIFF
--- a/skbio/metadata/_testing.py
+++ b/skbio/metadata/_testing.py
@@ -462,7 +462,7 @@ class PositionalMetadataMixinTests:
         )
 
         # Mutate list (not a deep copy).
-        df["bar"][0].append(42)
+        df["bar"].iloc[0].append(42)
         assert_data_frame_almost_equal(
             obj.positional_metadata,
             pd.DataFrame({"foo": [22, 22, 0], "bar": [[42], [], []]}, index=range(3)),
@@ -875,7 +875,7 @@ class PositionalMetadataMixinTests:
         )
 
         # Mutate list (not a deep copy).
-        df["bar"][0].append(42)
+        df["bar"].iloc[0].append(42)
         assert_data_frame_almost_equal(
             obj.positional_metadata,
             pd.DataFrame({"foo": [22, 22, 0], "bar": [[42], [], []]}, index=range(3)),

--- a/skbio/metadata/io.py
+++ b/skbio/metadata/io.py
@@ -473,9 +473,14 @@ class MetadataWriter:
 
             df = md.to_dataframe(encode_missing=True)
             df.fillna("", inplace=True)
-            # df = df.map(self._format)
-            # `applymap` is for backward-compatibility with pandas<2.1.0.
-            df = getattr(df, "map", df.applymap)(self._format)
+            # since `applymap` is going to be deprecated soon
+            # and `map` may not work on older versions of pandas
+            try:
+                mapper_ = df.map
+            except AttributeError:
+                mapper_ = df.applymap
+            df = mapper_(self._format)
+
             tsv_writer.writerows(df.itertuples(index=True))
 
     def _non_default_missing(self, missing_directive):

--- a/skbio/metadata/io.py
+++ b/skbio/metadata/io.py
@@ -473,7 +473,9 @@ class MetadataWriter:
 
             df = md.to_dataframe(encode_missing=True)
             df.fillna("", inplace=True)
-            df = df.map(self._format)
+            # df = df.map(self._format)
+            # `applymap` is for backward-compatibility with pandas<2.1.0.
+            df = getattr(df, "map", df.applymap)(self._format)
             tsv_writer.writerows(df.itertuples(index=True))
 
     def _non_default_missing(self, missing_directive):

--- a/skbio/metadata/io.py
+++ b/skbio/metadata/io.py
@@ -473,7 +473,7 @@ class MetadataWriter:
 
             df = md.to_dataframe(encode_missing=True)
             df.fillna("", inplace=True)
-            df = df.applymap(self._format)
+            df = df.map(self._format)
             tsv_writer.writerows(df.itertuples(index=True))
 
     def _non_default_missing(self, missing_directive):

--- a/skbio/metadata/tests/test_io.py
+++ b/skbio/metadata/tests/test_io.py
@@ -1,6 +1,6 @@
 import collections
 import os.path
-import pkg_resources
+# import pkg_resources
 import tempfile
 import unittest
 

--- a/skbio/metadata/tests/test_io.py
+++ b/skbio/metadata/tests/test_io.py
@@ -1,6 +1,5 @@
 import collections
 import os.path
-# import pkg_resources
 import tempfile
 import unittest
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -289,7 +289,8 @@ def _compute_groups(samples, test_type, grouping):
     if test_type == "centroid":
         centroids = samples.groupby("grouping").aggregate("mean")
     elif test_type == "median":
-        centroids = samples.groupby("grouping")[samples.columns.to_list()].apply(_config_med)
+        grouping_cols = samples.columns.to_list()
+        centroids = samples.groupby("grouping")[grouping_cols].apply(_config_med)
 
     for label, df in samples.groupby("grouping"):
         groups.append(

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -289,7 +289,7 @@ def _compute_groups(samples, test_type, grouping):
     if test_type == "centroid":
         centroids = samples.groupby("grouping").aggregate("mean")
     elif test_type == "median":
-        centroids = samples.groupby("grouping").apply(_config_med)
+        centroids = samples.groupby("grouping")[samples.columns.to_list()].apply(_config_med)
 
     for label, df in samples.groupby("grouping"):
         groups.append(

--- a/skbio/stats/gradient.py
+++ b/skbio/stats/gradient.py
@@ -167,7 +167,7 @@ def _weight_by_vector(trajectories, w_vector):
             trajectories.loc[idx] = (
                 trajectories.loc[idx]
                 * optimal_gradient
-                / np.abs((w_vector[i] - w_vector[i - 1]))
+                / np.abs((w_vector.iloc[i] - w_vector.iloc[i - 1]))
             )
 
     return trajectories.astype("float64")

--- a/skbio/stats/ordination/tests/test_redundancy_analysis.py
+++ b/skbio/stats/ordination/tests/test_redundancy_analysis.py
@@ -245,7 +245,7 @@ class TestRDAResults_biplot_score(TestCase):
             eigvals=vegan_eigvals)
 
         # This scaling constant is required to make skbio comparable to vegan.
-        scaling = (rda_.eigvals[0] / rda_.eigvals[:6])
+        scaling = (rda_.eigvals.iloc[0] / rda_.eigvals.iloc[:6])
         exp.biplot_scores *= scaling
         assert_ordination_results_equal(
             rda_, exp,


### PR DESCRIPTION
This PR contains three commits which fix about 3500 warnings.  

##### original warning summary:
```
============================================================= 
3000 passed, 4093 warnings in 42.13s 
=============================================================
```
##### after:
```
============================================================= 
3000 passed, 521 warnings in 39.72s 
=============================================================
```
---

##### Warnings resolved:

1) The warning was raised because `pkg_resources` has been deprecated. After confirming that `pkg_resources` is not utilized within the codebase, I have removed the import to resolve the warning.
``` 
../skbio/metadata/tests/test_io.py:3
  /Users/aryank/Developer/scikit-bio/skbio/metadata/tests/test_io.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources     
``` 

2) The warning was raised because `DataFrame.applymap` method has been deprecated. This was a simple fix where I replaced `applymap()` with `map()` to resolve the warning.
``` 
skbio/io/format/tests/test_sample_metadata.py: 1 warning
skbio/metadata/tests/test_io.py: 45 warnings
skbio/metadata/tests/test_metadata_column.py: 1 warning
  /Users/aryank/Developer/scikit-bio/skbio/metadata/io.py:476: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
    df = df.applymap(self._format) 
```

3. The next few warnings were raised because accessing the element by using the index as a key is deprecated. This was also a simple fix where I used `iloc` method to resolve the warning. Example: 
before `df["bar"][0].append(42)` and `df["bar"].iloc[0].append(42)`
```
skbio/stats/tests/test_gradient.py: 14 warnings
  /Users/aryank/Developer/scikit-bio/skbio/stats/gradient.py:170: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    / np.abs((w_vector[i] - w_vector[i - 1]))
```

```
skbio/alignment/tests/test_tabular_msa.py::TestTabularMSAPositionalMetadata::test_constructor_makes_shallow_copy_of_positional_metadata
skbio/metadata/tests/test_mixin.py::TestPositionalMetadataMixin::test_constructor_makes_shallow_copy_of_positional_metadata
skbio/sequence/tests/test_sequence.py::TestSequencePositionalMetadata::test_constructor_makes_shallow_copy_of_positional_metadata
  /Users/aryank/Developer/scikit-bio/skbio/metadata/_testing.py:465: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    df["bar"][0].append(42)
```

```
skbio/alignment/tests/test_tabular_msa.py::TestTabularMSAPositionalMetadata::test_positional_metadata_setter_makes_shallow_copy
skbio/metadata/tests/test_mixin.py::TestPositionalMetadataMixin::test_positional_metadata_setter_makes_shallow_copy
skbio/sequence/tests/test_sequence.py::TestSequencePositionalMetadata::test_positional_metadata_setter_makes_shallow_copy
  /Users/aryank/Developer/scikit-bio/skbio/metadata/_testing.py:878: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    df["bar"][0].append(42)
```

```
skbio/stats/ordination/tests/test_redundancy_analysis.py::TestRDAResults_biplot_score::test_biplot_score /Users/aryank/Developer/scikit-bio/skbio/stats/ordination/tests/test_redundancy_analysis.py:248: FutureWarning: Series.getitem treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use ser.iloc[pos] scaling = (rda_.eigvals[0] / rda_.eigvals[:6])
```

4. This warning was a rather complex one. pandas has deprecated implicitly including groups, ie: it raises a warning whenever `include_groups=True` is passed or include_groups is not specified at all. To fix this, I explicitly selected the grouping columns by extracting the required data from `samples` variables and use it to generate a list of groups. This list is then used to select the grouping columns by specifying it after groupby. To ensure functionality remains intact, I tested this function with the example given in [scikit-bio docs](https://scikit.bio/docs/latest/generated/skbio.stats.distance.permdisp.html) and the output remains the same.
```
skbio/stats/distance/_permdisp.py: 101 warnings
skbio/stats/distance/tests/test_permdisp.py: 3401 warnings
  /Users/aryank/Developer/scikit-bio/skbio/stats/distance/_permdisp.py:292: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
    centroids = samples.groupby("grouping").apply(_config_med)
```




Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
