### PR TITLE
NumPy 2.0 backwards compatibility and Windows UniFrac support

### DIFF
--- a/skbio/diversity/_phylogenetic.pyx
+++ b/skbio/diversity/_phylogenetic.pyx
@@ -11,13 +11,12 @@ cimport numpy as np
 cimport cython
 
 DTYPE = np.int64
-ctypedef np.int64_t DTYPE_t
-
+ctypedef np.npy_intp intp_t
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _tip_distances(np.ndarray[np.double_t, ndim=1] a, object t,
-                   np.ndarray[DTYPE_t, ndim=1] tip_indices):
+                   np.ndarray[intp_t, ndim=1] tip_indices):
     """Sets each tip to its distance from the root
 
     Parameters
@@ -65,8 +64,8 @@ def _tip_distances(np.ndarray[np.double_t, ndim=1] a, object t,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef _traverse_reduce(np.ndarray[DTYPE_t, ndim=2] child_index,
-                      np.ndarray[DTYPE_t, ndim=2] a):
+cdef _traverse_reduce(np.ndarray[intp_t, ndim=2] child_index,
+                      np.ndarray[intp_t, ndim=2] a):
     """Apply a[k] = sum[i:j]
 
     Parameters
@@ -124,8 +123,8 @@ cdef _traverse_reduce(np.ndarray[DTYPE_t, ndim=2] child_index,
     """
     cdef:
         Py_ssize_t i, j, k
-        DTYPE_t node, start, end
-        DTYPE_t n_envs = a.shape[1]
+        intp_t node, start, end
+        intp_t n_envs = a.shape[1]
 
     # possible GPGPU target
     for i in range(child_index.shape[0]):
@@ -165,13 +164,13 @@ def _nodes_by_counts(np.ndarray counts,
     """
     cdef:
         np.ndarray nodes, observed_ids
-        np.ndarray[DTYPE_t, ndim=2] count_array, counts_t
-        np.ndarray[DTYPE_t, ndim=1] observed_indices, taxa_in_nodes
+        np.ndarray[intp_t, ndim=2] count_array, counts_t
+        np.ndarray[intp_t, ndim=1] observed_indices, taxa_in_nodes
         Py_ssize_t i, j
         set observed_ids_set
         object n
         dict node_lookup
-        DTYPE_t n_count_vectors, n_count_taxa
+        intp_t n_count_vectors, n_count_taxa
 
     nodes = indexed['name']
 

--- a/skbio/diversity/beta/_unifrac.py
+++ b/skbio/diversity/beta/_unifrac.py
@@ -607,7 +607,7 @@ def _setup_multiple_weighted_unifrac(counts, taxa, tree, normalized, validate):
 
 def _get_tip_indices(tree_index):
     tip_indices = np.array(
-        [n.id for n in tree_index["id_index"].values() if n.is_tip()]
+        [n.id for n in tree_index["id_index"].values() if n.is_tip()], dtype=np.intp
     )
     return tip_indices
 

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -403,7 +403,7 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations):
 
         # compute all pearsonr permutations at once
         # create first the list of permutations
-        perm_order = np.empty((permutations + 1, mat_n), dtype=int)
+        perm_order = np.empty((permutations + 1, mat_n), dtype=np.intp)
         # first row/statistic will be comp_stat
         perm_order[0, :] = np.arange(mat_n)
         for row in range(1, permutations + 1):

--- a/skbio/stats/distance/_utils.py
+++ b/skbio/stats/distance/_utils.py
@@ -112,7 +112,7 @@ def distmat_reorder_buf(in_mat, reorder_vec, out_mat, validate=False):
         Optional, if True, validate reorder_vec content, detaults to False
 
     """
-    np_reorder = np.asarray(reorder_vec, dtype=int)
+    np_reorder = np.asarray(reorder_vec, dtype=np.intp)
     if validate:
         maxsize = in_mat.shape[0]
         bad_cnt = np.where((np_reorder < 0) or (np_reorder >= maxsize))[0].size
@@ -158,7 +158,7 @@ def distmat_reorder(in_mat, reorder_vec, validate=False):
         Distance matrix
 
     """
-    np_reorder = np.asarray(reorder_vec, dtype=int)
+    np_reorder = np.asarray(reorder_vec, dtype=np.intp)
     if validate:
         maxsize = in_mat.shape[0]
         bad_cnt = np.where((np_reorder < 0) or (np_reorder >= maxsize))[0].size
@@ -203,7 +203,7 @@ def distmat_reorder_condensed(in_mat, reorder_vec, validate=False):
         Condensed distance matrix
 
     """
-    np_reorder = np.asarray(reorder_vec, dtype=int)
+    np_reorder = np.asarray(reorder_vec, dtype=np.intp)
     if validate:
         maxsize = in_mat.shape[0]
         bad_cnt = np.where((np_reorder < 0) or (np_reorder >= maxsize))[0].size

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -75,7 +75,7 @@ class InternalMantelTests(MantelTestData):
         perm_order = np.asarray([[2, 1, 0],
                                  [2, 0, 1],
                                  [0, 2, 1],
-                                 [2, 0, 1]], dtype=int)
+                                 [2, 0, 1]], dtype=np.intp)
         xmean = 2.0
         normxm = 1.4142135623730951
         ym_normalized = np.asarray([-0.80178373, 0.26726124, 0.53452248])
@@ -107,7 +107,7 @@ class InternalMantelTests(MantelTestData):
                                  [4, 3, 2, 5, 0, 1],
                                  [2, 5, 3, 1, 0, 4],
                                  [3, 5, 4, 1, 2, 0],
-                                 [4, 3, 5, 2, 0, 1]], dtype=int)
+                                 [4, 3, 5, 2, 0, 1]], dtype=np.intp)
         xmean = 0.6953921578226
         normxm = 0.3383126690576294
         ym_normalized = np.asarray([-0.4999711, 0.24980825, -0.29650504,
@@ -160,7 +160,7 @@ class InternalMantelTests(MantelTestData):
                                  [1, 2, 5, 4, 0, 3],
                                  [5, 4, 0, 1, 3, 2],
                                  [3, 0, 1, 5, 4, 2],
-                                 [5, 0, 2, 3, 1, 4]], dtype=int)
+                                 [5, 0, 2, 3, 1, 4]], dtype=np.intp)
 
         ym_normalized = ym/normym
 


### PR DESCRIPTION
This PR ensures backwards compatibility with previous versions of NumPy, given the anticipated release of 2.0. The default `int` type of NumPy will change to `np.intp` in 2.0, and is not the same as Python's `int` which was equivalent to C `long`. See [this](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#windows-default-integer) paragraph for more information.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
