### PR TITLE
Resolved Warnings

### DIFF
--- a/skbio/metadata/_metadata.py
+++ b/skbio/metadata/_metadata.py
@@ -599,6 +599,7 @@ class SampleMetadata(_MetadataBase):
                 missing = _missing.series_extract_missing(series)
                 # avoid dtype changing if there's no missing values
                 if not missing.empty:
+                    series = series.astype(object)
                     series[missing.index] = missing
                 return series
 

--- a/skbio/metadata/_metadata.py
+++ b/skbio/metadata/_metadata.py
@@ -1291,7 +1291,8 @@ class CategoricalMetadataColumn(MetadataColumn):
                     % (cls.__name__, value, type(value), series.name)
                 )
 
-        norm_series = series.apply(normalize, convert_dtype=False)
+        norm_series = series.apply(normalize)
+        norm_series = norm_series.astype(object)
         norm_series.index = norm_series.index.str.strip()
         norm_series.name = norm_series.name.strip()
         return norm_series

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -1193,7 +1193,8 @@ def _calculate_power_curve(
                 mode=mode,
             )
             if vec:
-                pwr[id2] = _calculate_power(ps, a)
+                pwr[id2] = (_calculate_power(ps, a)).item()
+
             else:
                 pwr[id1, id2] = _calculate_power(ps, a)
 


### PR DESCRIPTION
This PR contains three commits which fix about 450 warnings, and brings down the number of warnings to 75.

##### original warning summary:
```
============================================================= 
3000 passed, 521 warnings in 39.72s 
=============================================================
```
##### after:
```
============================================================= 
3000 passed, 75 warnings in 38.58s
============================================================= 
```
---
##### Warnings resolved:

1)  The warning has been raised due to the deprecation of the convert_dtype parameter in the apply method. To address this issue, I have modified the code by splitting the line into two parts: the first part applies the method, and the second part converts the result to the appropriate type.
```
skbio/io/format/tests/test_sample_metadata.py: 10 warnings
skbio/metadata/tests/test_io.py: 293 warnings
skbio/metadata/tests/test_metadata.py: 88 warnings
skbio/metadata/tests/test_metadata_column.py: 13 warnings
  /Users/aryank/Developer/scikit-bio/skbio/metadata/_metadata.py:1294: FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
    norm_series = series.apply(normalize, convert_dtype=False)
```
2) This warning occurred because the code attempted to convert a single-element array with multiple dimensions to a scalar, which is now deprecated by NumPy. To address this issue, I have itemized the result before assigning it to the scalar variable.
```
skbio/stats/tests/test_power.py: 27 warnings
  /Users/aryank/Developer/scikit-bio/skbio/stats/power.py:1196: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    pwr[id2] = _calculate_power(ps, a)   
```
3) The method is attempting to assign the value `('[nan nan nan]')` to a Series, which is expected to be float64. While the current version of pandas permits this assignment, it will result in an error in future releases. To address this issue, I am explicitly casting the value to an `object` dtype.

```
skbio/metadata/tests/test_io.py::TestSave::test_all_missing_data
skbio/metadata/tests/test_io.py::TestRoundtrip::test_all_cells_padded
skbio/metadata/tests/test_io.py::TestRoundtrip::test_all_cells_padded
skbio/metadata/tests/test_io.py::TestRoundtrip::test_all_cells_padded
skbio/metadata/tests/test_io.py::TestRoundtrip::test_missing_data
  /Users/aryank/Developer/scikit-bio/skbio/metadata/_metadata.py:602: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
    series[missing.index] = missing
```

---
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
