### PR TITLE
Fix newline character issues for windows

### DIFF
--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -1541,11 +1541,7 @@ class TestWrite(RegistryTest):
 
         with io.open(fp, mode='rb') as fh:
             # This would have been b'\xe4\xbd\xa0\xe5\xa5\xbd\n' in utf8
-            self.assertEqual(b"\xa7A\xa6n\n",
-                             fh.read()
-                             .decode(encoding="big5")
-                             .replace("\r\n", "\n")
-                             .encode(encoding="big5"))
+            self.assertEqual(b"\xa7A\xa6n\n", fh.read().replace(b"\r\n", b"\n"))
 
     def test_non_default_encoding(self):
         format1 = self.registry.create_format('format1', encoding='big5')
@@ -1562,21 +1558,14 @@ class TestWrite(RegistryTest):
         self.registry.write(obj, format='format1', into=fp)
 
         with io.open(fp, mode='rb') as fh:
-            self.assertEqual(b"\xa7A\xa6n\n",
-                             fh.read()
-                             .decode(encoding="big5")
-                             .replace("\r\n", "\n")
-                             .encode(encoding="big5"))
+            self.assertEqual(b"\xa7A\xa6n\n", fh.read().replace(b"\r\n", b"\n"))
 
         self._expected_encoding = 'utf8'
         self.registry.write(obj, format='format1', into=fp, encoding='utf8')
 
         with io.open(fp, mode='rb') as fh:
             self.assertEqual(b"\xe4\xbd\xa0\xe5\xa5\xbd\n",
-                             fh.read()
-                             .decode(encoding="utf8")
-                             .replace("\r\n", "\n")
-                             .encode(encoding="utf8"))
+                             fh.read().replace(b"\r\n", b"\n"))
 
     def test_that_newline_is_used(self):
         format1 = self.registry.create_format('format1')

--- a/skbio/io/tests/test_registry.py
+++ b/skbio/io/tests/test_registry.py
@@ -14,6 +14,7 @@ import unittest
 import warnings
 import types
 from tempfile import mkstemp
+from sys import platform
 
 from skbio.io import (FormatIdentificationWarning, UnrecognizedFormatError,
                       ArgumentOverrideWarning, io_registry, sniff,
@@ -640,10 +641,16 @@ class TestSniff(RegistryTest):
             return True, {}
 
         with io.open(get_data_path('real_file')) as fh:
-            fh.seek(2)
-            self.registry.sniff(fh)
-            self.assertEqual(fh.tell(), 2)
-            self.assertEqual('b\n', fh.readline())
+            if platform == "win32":
+                fh.seek(3)
+                self.registry.sniff(fh)
+                self.assertEqual(fh.tell(), 3)
+                self.assertEqual('b\n', fh.readline())
+            else:
+                fh.seek(2)
+                self.registry.sniff(fh)
+                self.assertEqual(fh.tell(), 2)
+                self.assertEqual('b\n', fh.readline())
 
     def test_position_not_mutated_fileish(self):
         formatx = self.registry.create_format('formatx')


### PR DESCRIPTION
This PR will fix the final newline issues on Windows. On Windows, the line separator is `\r\n` while on linux and other systems it is `\n`. The changes here fix the last of these issues for the current codebase.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
