### PR TITLE
Removed the option of not using Cython during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,13 @@ jobs:
         shell: bash -l {0}
     strategy:
       fail-fast: true
-      # macos-14 and on uses Apple silicon chips (ARM-based)
-      # macos-13 is the last version that uses Intel chips
+      # macos-14 and on uses Apple silicon chips (ARM-based).
+      # macos-13 is the last version that uses Intel chips. See:
+      # https://docs.github.com/en/actions/using-github-hosted-runners/
+      # about-github-hosted-runners/about-github-hosted-runners#standard-
+      # github-hosted-runners-for-public-repositories
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-14"]
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,20 +88,20 @@ jobs:
           name: docpack
           path: doc/build/html/
 
-  # full-scale test (including Cython) with latest Python
-  test-cython:
-    name: Test Cython (${{ needs.conf.outputs.latest_python }}, ${{ matrix.os }})
+  # full-scale test with latest Python
+  test-latest:
+    name: Test (${{ needs.conf.outputs.latest_python }}, ${{ matrix.os }})
     needs: conf
     runs-on: ${{ matrix.os }}
-    env:
-      USE_CYTHON: TRUE
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       fail-fast: true
+      # macos-14 and on uses Apple silicon chips (ARM-based)
+      # macos-13 is the last version that uses Intel chips
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-14"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
@@ -133,8 +133,8 @@ jobs:
           slug: scikit-bio/scikit-bio
 
   # test under AArch64 (ARM64) architecture
-  test-cython-aarch64:
-    name: Test Cython (${{ needs.conf.outputs.latest_python }}, qemu::aarch64-centos)
+  test-aarch64:
+    name: Test (${{ needs.conf.outputs.latest_python }}, qemu::aarch64-centos)
     needs: conf
     runs-on: ubuntu-latest
     steps:
@@ -162,8 +162,7 @@ jobs:
   test-all:
     name: Test (${{ matrix.python_version }}, ${{ matrix.os }}, ${{ fromJSON('["pypi", "conda"]')[matrix.use_conda] }})
     runs-on: ${{ matrix.os }}
-    needs: ["conf", "test-cython", "lint"]
-    # not testing Cython here, whether the Cython compiles to C is tested above
+    needs: ["conf", "test-latest", "lint"]
     defaults:
       run:
         shell: bash -l {0}
@@ -203,7 +202,7 @@ jobs:
   deploy-doc:
     name: Deploy documentation
     if: github.event_name == 'push'
-    needs: ["doc", "test-all", "test-cython-aarch64"]
+    needs: ["doc", "test-all", "test-aarch64"]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* NumPy 2.0 is now supported ([#2051](https://github.com/scikit-bio/scikit-bio/pull/2051])).
 * Added `ProteinEmbedding` class and corresponding file format ([#2008](https://github.com/scikit-bio/scikit-bio/pull/2008]))
 * Added `AlignPath` and `PairAlignPath` classes ([#2011](https://github.com/scikit-bio/scikit-bio/pull/2011))
 * Added `simpson_d` as an alias for `dominance` (Simpson's dominance index, a.k.a. Simpson's D) ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)).
@@ -15,9 +16,9 @@
 ### Performance enhancements
 
 * Subsampling now uses the optimized method from `biom` ([#2016](https://github.com/scikit-bio/scikit-bio/pull/2016))
+* Improved efficiency of counts matrix and vector validation prior to calculating community diversity metrics ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)).
 
 ### Miscellaneous
-* Improved efficiency of counts matrix and vector validation prior to calculating community diversity metrics ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)).
 * Improved treatment of empty communities (i.e., all taxa have zero counts, or there is no taxon) when calculating alpha diversity metrics. Most metrics will return `np.nan` and do not raise a warning due to zero division. Exceptions are metrics that describe observed counts, includng `sobs`, `singles`, `doubles` and `osd`, which return zero ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)). See discussions in [2014](https://github.com/scikit-bio/scikit-bio/issues/2014).
 * Return values of `pielou_e` and `heip_e` were set to 1.0 for one-taxon communities, such that NaN is avoided, while honoring the definition (evenness of taxon abundance(s)) and the rationale (ratio between observed and maximum) ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)).
 * Default logarithm base of Shannon index (`shannon`) was changed from 2 to e. This is to ensure consistency with other Shannon-based metrics (`pielou_e`), and with literature and implementations in the field. Meanwhile, parameter `base` was added to `pielou_e` such that the user can control this behavior ([#2024](https://github.com/scikit-bio/scikit-bio/pull/2024)). See discussions in [1884](https://github.com/scikit-bio/scikit-bio/issues/1884) and [2014](https://github.com/scikit-bio/scikit-bio/issues/2014).

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 	TEST_COMMAND = python -m skbio.test
 endif
 
-.PHONY: doc web lint test dev install cython
+.PHONY: doc web lint test dev install
 
 doc:
 	$(MAKE) -C doc clean html
@@ -38,9 +38,6 @@ lint:
 # not install correctly (for example).
 test:
 	cd ci && $(TEST_COMMAND)
-
-cython:
-	USE_CYTHON=TRUE python setup.py build_ext --inplace
 
 install:
 	pip install .

--- a/aarch64.Dockerfile
+++ b/aarch64.Dockerfile
@@ -3,7 +3,6 @@ RUN sudo yum update -y && \
 	sudo yum install -y make git && \
 	sudo yum clean all
 ENV MPLBACKEND=Agg
-ENV USE_CYTHON=TRUE
 ARG PYTHON_VERSION
 RUN bash -c ". /opt/conda/etc/profile.d/conda.sh && conda activate base && conda create -n testing -c conda-forge --yes python=$PYTHON_VERSION gxx_linux-aarch64"
 COPY . /work

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 import numpy as np
+from Cython.Build import cythonize
 
 
 if sys.version_info.major != 3:
@@ -141,18 +142,8 @@ description = (
 with open("README.rst") as f:
     long_description = f.read()
 
-# Dealing with Cython
-USE_CYTHON = os.environ.get("USE_CYTHON")
-if USE_CYTHON is None:
-    # use CYTHON by default
-    USE_CYTHON = True
-elif USE_CYTHON.lower() in {"false", "no"}:
-    USE_CYTHON = False
-else:
-    USE_CYTHON = True
 
-ext = ".pyx" if USE_CYTHON else ".c"
-
+# Compile SSW module
 ssw_extra_compile_args = ["-I."]
 
 if platform.system() != "Windows":
@@ -179,6 +170,9 @@ if platform.system() != "Windows":
 if platform.machine() == "i686":
     ssw_extra_compile_args.append("-msse2")
 
+
+# Cython modules (*.pyx). They will be compiled into C code (*.c) during build.
+ext = ".pyx"
 extensions = [
     Extension("skbio.metadata._intersection", ["skbio/metadata/_intersection" + ext]),
     Extension(
@@ -206,11 +200,7 @@ extensions = [
     ),
 ]
 
-if USE_CYTHON:
-    from Cython.Build import cythonize
-
-    # Always recompile the pyx files to C if USE_CYTHON is set.
-    extensions = cythonize(extensions, force=True)
+extensions = cythonize(extensions, force=True)
 
 
 setup(


### PR DESCRIPTION
Because we no longer ship .c files (#1958), the build process must always use Cython. Therefore, the environment variable `USE_CYTHON` may be deleted.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
