### PR TITLE
Elevated and added read parameters to sample metadata

### DIFF
--- a/skbio/__init__.py
+++ b/skbio/__init__.py
@@ -20,6 +20,7 @@ from skbio.embedding import ProteinEmbedding
 from skbio.io import read, write
 from skbio.stats.ordination import OrdinationResults
 from skbio.table import Table
+from skbio.metadata import SampleMetadata
 import skbio.diversity  # noqa
 import skbio.stats.evolve  # noqa
 
@@ -39,6 +40,7 @@ __all__ = [
     "write",
     "OrdinationResults",
     "Table",
+    "SampleMetadata",
 ]
 
 __credits__ = "https://github.com/scikit-bio/scikit-bio/graphs/contributors"

--- a/skbio/io/format/sample_metadata.py
+++ b/skbio/io/format/sample_metadata.py
@@ -354,8 +354,8 @@ def _sample_metadata_sniffer(fh):
 
 
 @sample_metadata.reader(SampleMetadata)
-def _sample_metadata_read(fh):
-    return MetadataReader(fh).read(SampleMetadata)
+def _sample_metadata_read(fh, **kwargs):
+    return MetadataReader(fh).read(SampleMetadata, **kwargs)
 
 
 @sample_metadata.writer(SampleMetadata)


### PR DESCRIPTION
This PR does two things:

1) Adds `skbio.metadata.SampleMetadata` to `skbio/__init__.py`, such that the class can be imported by `from skbio import SampleMetadata`. Addresses #2055 .

2) Allows `SampleMetadata.read` to accept keyword arguments such as `default_missing_scheme`, which is useful when reading a structured metadata table. With this addition, one can do `SampleMetadata.read('metadata.tsv', default_missing_scheme='INSDC:missing')` or `skbio.io.read('metadata.tsv', into=SampleMetadata, default_missing_scheme='INSDC:missing')`

This patch makes `read` function like [`SampleMetadata.load`](https://scikit.bio/docs/latest/generated/skbio.metadata.SampleMetadata.load.html). In fact, the `load` method is not present in any other modules of skbio. It is likely an inheritance from q2. To make the skbio logic consistent, I would suggest deprecating `load` in favor of `read`. We can keep `load` as an alias to `read` for backward compatibility and compatibility with q2.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
