### PR TITLE
Improved tree rooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* Added method `TreeNode.insert`, which insert a node intot the branch connecting self and its parent.
 * Added support for Microsoft Windows operating system. ([#2071](https://github.com/scikit-bio/scikit-bio/pull/2071), [#2068](https://github.com/scikit-bio/scikit-bio/pull/2068),
 [#2067](https://github.com/scikit-bio/scikit-bio/pull/2067), [#2061](https://github.com/scikit-bio/scikit-bio/pull/2061), [#2046](https://github.com/scikit-bio/scikit-bio/pull/2046),
 [#2040](https://github.com/scikit-bio/scikit-bio/pull/2040), [#2036](https://github.com/scikit-bio/scikit-bio/pull/2036), [#2034](https://github.com/scikit-bio/scikit-bio/pull/2034),
@@ -13,7 +14,9 @@
 
 ### Performance enhancements
 
-* `TreeNode.unrooted_copy` now preserves names of the original nodes, in addition to topology and branch lengths. The new root is no longer named as "root" ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* `Treenode.copy` and `TreeNode.unrooted_copy` can perform shallow copy of a tree in addition to deep copy.
+* `TreeNode.unrooted_copy` now preserves names of the original nodes, in addition to topology and branch lengths. The new root is no longer named as "root".
+This affects `TreeNode.root_at` and `TreeNode.root_at_midpoint` ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
 
 
 ## Version 0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Performance enhancements
 
+* The time and memory efficiency of `TreeNode` has been significantly improved by making its caching mechanism lazy ([#2082](https://github.com/scikit-bio/scikit-bio/pull/2082)).
 * `Treenode.copy` and `TreeNode.unrooted_copy` can now perform shallow copy of a tree in addition to deep copy.
 * `TreeNode.unrooted_copy` can now copy all attributes of the nodes, in addition to name and length ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
 * Paremter `above` was added to `TreeNode.root_at`, such that the user can root the tree within the branch connecting the given node and its parent, thereby creating a rooted tree ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
@@ -27,11 +28,12 @@ during the rerooting operation. The default behavior is preserved but is subject
 ### Bug fixes
 
 * Cleared the internal node references after performing midpoint rooting (`TreeNode.root_at_midpoint`), such that a deep copy of the resulting tree will not result in infinite recursion ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
-* Fixed the Zenodo link in the README to always point to the most recent version.
+* Fixed the Zenodo link in the README to always point to the most recent version ([#2078](https://github.com/scikit-bio/scikit-bio/pull/2078)).
 
 ### Deprecated functionality
 
 * Methods `deepcopy` and `unrooted_deepcopy` of `Treenode` are deprecated. Use `copy` and `unrooted_copy` instead.
+
 
 ## Version 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 [#2032](https://github.com/scikit-bio/scikit-bio/pull/2032), [#2005](https://github.com/scikit-bio/scikit-bio/pull/2005)) 
 * Added `nni` function for phylogenetic tree rearrangement using nearest neighbor interchange (NNI) ([#2050](https://github.com/scikit-bio/scikit-bio/pull/2050))
 
+### Performance enhancements
+
+* `TreeNode.unrooted_copy` now preserves names of the original nodes, in addition to topology and branch lengths. The new root is no longer named as "root" ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+
+
 ## Version 0.6.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Features
 
-* Added method `TreeNode.insert`, which insert a node intot the branch connecting self and its parent.
+* Added method `TreeNode.unrooted_move`, which resembles `TreeNode.unrooted_copy` but rearranges the tree in place, thus avoid making copies of the nodes.
+* Added method `TreeNode.root_by_outgroup`, which reroots a tree according to a given outgroup.
+* Added method `TreeNode.insert`, which inserts a node intot the branch connecting self and its parent.
 * Added support for Microsoft Windows operating system. ([#2071](https://github.com/scikit-bio/scikit-bio/pull/2071), [#2068](https://github.com/scikit-bio/scikit-bio/pull/2068),
 [#2067](https://github.com/scikit-bio/scikit-bio/pull/2067), [#2061](https://github.com/scikit-bio/scikit-bio/pull/2061), [#2046](https://github.com/scikit-bio/scikit-bio/pull/2046),
 [#2040](https://github.com/scikit-bio/scikit-bio/pull/2040), [#2036](https://github.com/scikit-bio/scikit-bio/pull/2036), [#2034](https://github.com/scikit-bio/scikit-bio/pull/2034),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,33 @@
 
 ### Features
 
-* Added method `TreeNode.unrooted_move`, which resembles `TreeNode.unrooted_copy` but rearranges the tree in place, thus avoid making copies of the nodes.
-* Added method `TreeNode.root_by_outgroup`, which reroots a tree according to a given outgroup.
-* Added method `TreeNode.insert`, which inserts a node intot the branch connecting self and its parent.
 * Added support for Microsoft Windows operating system. ([#2071](https://github.com/scikit-bio/scikit-bio/pull/2071), [#2068](https://github.com/scikit-bio/scikit-bio/pull/2068),
 [#2067](https://github.com/scikit-bio/scikit-bio/pull/2067), [#2061](https://github.com/scikit-bio/scikit-bio/pull/2061), [#2046](https://github.com/scikit-bio/scikit-bio/pull/2046),
 [#2040](https://github.com/scikit-bio/scikit-bio/pull/2040), [#2036](https://github.com/scikit-bio/scikit-bio/pull/2036), [#2034](https://github.com/scikit-bio/scikit-bio/pull/2034),
 [#2032](https://github.com/scikit-bio/scikit-bio/pull/2032), [#2005](https://github.com/scikit-bio/scikit-bio/pull/2005))
 * Added alpha diversity metrics: Hill number (`hill`), Renyi entropy (`renyi`) and Tsallis entropy (`tsallis`) ([#2074](https://github.com/scikit-bio/scikit-bio/pull/2074)).
 * Added `nni` function for phylogenetic tree rearrangement using nearest neighbor interchange (NNI) ([#2050](https://github.com/scikit-bio/scikit-bio/pull/2050)).
+* Added method `TreeNode.unrooted_move`, which resembles `TreeNode.unrooted_copy` but rearranges the tree in place, thus avoid making copies of the nodes ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Added method `TreeNode.root_by_outgroup`, which reroots a tree according to a given outgroup ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Added method `TreeNode.unroot`, which converts a rooted tree into unrooted by trifucating its root ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Added method `TreeNode.insert`, which inserts a node into the branch connecting self and its parent ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
 
 ### Performance enhancements
 
-* `Treenode.copy` and `TreeNode.unrooted_copy` can perform shallow copy of a tree in addition to deep copy.
-* `TreeNode.unrooted_copy` now preserves names of the original nodes, in addition to topology and branch lengths. The new root is no longer named as "root".
-This affects `TreeNode.root_at` and `TreeNode.root_at_midpoint` ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* `Treenode.copy` and `TreeNode.unrooted_copy` can now perform shallow copy of a tree in addition to deep copy.
+* `TreeNode.unrooted_copy` can now copy all attributes of the nodes, in addition to name and length ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Paremter `above` was added to `TreeNode.root_at`, such that the user can root the tree within the branch connecting the given node and its parent, thereby creating a rooted tree ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Parameter `branch_attrs` was added to the `unrooted_copy`, `root_at`, and `root_at_midpoint` methods of `TreeNode`, such that the user can customize which node attributes should be considered as branch attributes and treated accordingly
+during the rerooting operation. The default behavior is preserved but is subject ot change in version 0.7.0 ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+* Parameter `root_name` was added to the `unrooted_copy`, `root_at`, and `root_at_midpoint` methods of `TreeNode`, such that the user can customize (or omit) the name to be given to the root node. The default behavior is preserved but is subject ot change in version 0.7.0 ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+
+### Bug fixes
+
+* Cleared the internal node references after performing midpoint rooting (`TreeNode.root_at_midpoint`), such that a deep copy of the resulting tree will not result in infinite recursion ([#2073](https://github.com/scikit-bio/scikit-bio/pull/2073)).
+
+### Deprecated functionality
+
+* Methods `deepcopy` and `unrooted_deepcopy` of `Treenode` are deprecated. Use `copy` and `unrooted_copy` instead.
 
 
 ## Version 0.6.1

--- a/skbio/diversity/alpha/_base.py
+++ b/skbio/diversity/alpha/_base.py
@@ -1123,8 +1123,8 @@ def renyi(counts, order=2, base=None):
     --------
     hill
     inv_simpson
-    renyi
     shannon
+    tsallis
 
     Notes
     -----

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -697,10 +697,7 @@ class TreeNode(SkbioObject):
         root_name="root",
         deep=False,
     ):
-        r"""Walk the tree unrooted-style and returns a copy.
-
-        Perform a copy of self and return a new copy of the tree as an
-        unrooted copy. This is useful for defining a new root of the tree.
+        r"""Walk the tree unrooted-style and return a copy.
 
         Parameters
         ----------
@@ -754,7 +751,12 @@ class TreeNode(SkbioObject):
 
         Notes
         -----
-        This method is recursive.
+        This method recursively walks a tree from a given node in an unrooted
+        style (i.e., directions of branches are not assumed), and copies each
+        node it visits, such that the copy of the given node becomes the root
+        node of a new tree and the copies of all other nodes are re-positioned
+        accordingly, whereas the topology of the new tree will be identical to
+        the existing one.
 
         Examples
         --------
@@ -1200,8 +1202,12 @@ class TreeNode(SkbioObject):
         ----------
         node : TreeNode or str, optional
             The node to root at. Can either be a node object or the name of the
-            node. If not provided, will root at self. If a root is provided,
+            node. If not provided, will root at self. If a root node provided,
             will return the original tree.
+
+            .. versionchanged:: 0.6.2
+
+                Becomes optional.
 
         above : bool, float, or int, optional
             Whether and where to insert a new root node. If ``False``

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1326,9 +1326,6 @@ class TreeNode(SkbioObject):
                 )
                 func.warned = True
 
-        msg = "Use unrooted_copy instead."
-        _warn_deprecated(self.__class__.unrooted_deepcopy, "0.6.2", msg)
-
         tree = self.root()
         if node is None:
             node = self

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -549,7 +549,7 @@ class TreeNode(SkbioObject):
         <BLANKLINE>
 
         """
-        tcopy = self.deepcopy()
+        tcopy = self.copy()
         all_tips = {n.name for n in tcopy.tips()}
         ids = set(names)
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -895,6 +895,10 @@ class TreeNode(SkbioObject):
         tree such that the given node becomes the root node and all other nodes
         are re-positioned accordingly, whereas the topology remains the same.
 
+        This method manipulates the tree in place. There is no return value.
+        The new tree should be referred to by the node where the operation
+        started, as it has become the new root node.
+
         Examples
         --------
         >>> from skbio import TreeNode
@@ -929,17 +933,17 @@ class TreeNode(SkbioObject):
                 setattr(self, attr, getattr(parent, attr, None))
 
     def count(self, tips=False):
-        """Get the count of nodes in the tree.
+        r"""Get the count of nodes in the tree.
 
         Parameters
         ----------
         tips : bool
-            If `True`, only return the count of the number of tips
+            If ``True``, only return the count of tips.
 
         Returns
         -------
         int
-            The number of nodes or tips
+            The number of nodes.
 
         Examples
         --------

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1024,6 +1024,43 @@ class TreeTests(TestCase):
         npt.assert_equal(child_3, np.array([[4, 0, 2], [5, 3, 3], [8, 4, 5],
                                             [9, 6, 7], [10, 8, 9]]))
 
+    def test_unroot(self):
+        """Convert a root tree into unrooted."""
+        t = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        t.unroot()
+        exp = "((a,b)c,d,e)f;\n"
+        self.assertEqual(str(t), exp)
+
+        # with branch lengths
+        t = TreeNode.read(["((a:2.0,b:1.5)c:0.5,(d:1.0,e:1.2)f:0.3)g;"])
+        t.unroot()
+        exp = "((a:2.0,b:1.5)c:0.8,d:1.0,e:1.2)f;\n"
+        self.assertEqual(str(t), exp)
+
+        # other child has no branch length
+        t = TreeNode.read(["((a,b)c,(d,e)f:1.0)g;"])
+        t.unroot()
+        exp = "((a,b)c:1.0,d,e)f;\n"
+        self.assertEqual(str(t), exp)
+
+        # second child is a tip
+        t = TreeNode.read(["((a,b)c,d)e;"])
+        t.unroot()
+        exp = "(d,a,b)c;\n"
+        self.assertEqual(str(t), exp)
+
+        # both children are tips
+        t = TreeNode.read(["(a,b)c;"])
+        t.unroot()
+        exp = "(a)b;\n"
+        self.assertEqual(str(t), exp)
+
+        # tree is already unrooted
+        t = TreeNode.read(["(a,b,(d,e)f)c;"])
+        t.unroot()
+        exp = "(a,b,(d,e)f)c;\n"
+        self.assertEqual(str(t), exp)
+
     def test_root_at(self):
         """Root tree at given node"""
         t = TreeNode.read(["(((a,b)c,(d,e)f)g,h)i;"])
@@ -1046,6 +1083,23 @@ class TreeTests(TestCase):
         # root at root (no change)
         obs = str(t.root_at("i", branch_attrs=[]))
         self.assertEqual(obs, str(t))
+
+        # root at branch above node
+        obs = str(t.root_at("c", above=True, branch_attrs=[]))
+        exp = "((a,b)c,((d,e)f,(h)i)g)root;\n"
+        self.assertEqual(obs, exp)
+
+        # root at midpoint of branch
+        t = TreeNode.read(["(((a,b)c:1.0,(d,e)f)g,h)i;"])
+        obs = str(t.root_at("c", above=True, branch_attrs=[]))
+        exp = "((a,b)c:0.5,((d,e)f,(h)i)g:0.5)root;\n"
+        self.assertEqual(obs, exp)
+
+        # root at specific position
+        t = TreeNode.read(["(((a,b)c:1.0,(d,e)f)g,h)i;"])
+        obs = str(t.root_at("c", above=0.4, branch_attrs=[]))
+        exp = "((a,b)c:0.4,((d,e)f,(h)i)g:0.6)root;\n"
+        self.assertEqual(obs, exp)
 
     def test_root_at_midpoint(self):
         """Root tree at the midpoint"""

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -209,7 +209,7 @@ class TreeTests(TestCase):
 
     def test_deepcopy(self):
         self.simple_t.dummy = [1, [2, 3], 4]
-        cp = self.simple_t.deepcopy()
+        cp = self.simple_t.copy()
         cp.dummy[1].append(0)
         self.assertListEqual(self.simple_t.dummy[1], [2, 3])
 

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -287,6 +287,21 @@ class TreeTests(TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             t.find("c").insert(TreeNode("x"), 20)
 
+        # with branch support
+        t = TreeNode.read(["(((a,b)90)d);"])
+        t.assign_supports()
+        t.lca(["a", "b"]).insert(TreeNode("x"))
+        self.assertEqual(t.find("x").support, 90)
+
+        # with custom branch attribute
+        t = TreeNode.read(["(((a,b)c)d);"])
+        n = t.find("c")
+        n.battr = 1  # branch attribute
+        n.nattr = 2  # node attribute
+        n.insert(TreeNode("x"), branch_attrs=["battr"])
+        self.assertEqual(t.find("x").battr, 1)
+        self.assertFalse(hasattr(t.find("x"), "nattr"))
+
     def test_iter(self):
         """iter wraps children"""
         exp = ["i1", "i2"]

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -6,7 +6,6 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import io
 from unittest import TestCase, main
 from collections import defaultdict
 
@@ -30,15 +29,15 @@ class TreeTests(TestCase):
     def setUp(self):
         """Prep the self"""
         self.simple_t = TreeNode.read(["((a,b)i1,(c,d)i2)root;"])
-        nodes = dict([(x, TreeNode(x)) for x in 'abcdefgh'])
-        nodes['a'].append(nodes['b'])
-        nodes['b'].append(nodes['c'])
-        nodes['c'].append(nodes['d'])
-        nodes['c'].append(nodes['e'])
-        nodes['c'].append(nodes['f'])
-        nodes['f'].append(nodes['g'])
-        nodes['a'].append(nodes['h'])
-        self.TreeRoot = nodes['a']
+        nodes = dict([(x, TreeNode(x)) for x in "abcdefgh"])
+        nodes["a"].append(nodes["b"])
+        nodes["b"].append(nodes["c"])
+        nodes["c"].append(nodes["d"])
+        nodes["c"].append(nodes["e"])
+        nodes["c"].append(nodes["f"])
+        nodes["f"].append(nodes["g"])
+        nodes["a"].append(nodes["h"])
+        self.TreeRoot = nodes["a"]
 
         def rev_f(items):
             items.reverse()
@@ -50,14 +49,14 @@ class TreeTests(TestCase):
 
         self.rev_f = rev_f
         self.rotate_f = rotate_f
-        self.complex_tree = TreeNode.read(io.StringIO(
-            "(((a,b)int1,(x,y,(w,z)int2,(c,d)int3)int4),(e,f)int5);"))
+        self.complex_tree = TreeNode.read([
+            "(((a,b)int1,(x,y,(w,z)int2,(c,d)int3)int4),(e,f)int5);"])
 
     def test_bug_issue_1416(self):
-        tree = TreeNode.read(['(((a,b,f,g),c),d);'])
-        new_tree = tree.shear(['a', 'b', 'c', 'f'])
+        tree = TreeNode.read(["(((a,b,f,g),c),d);"])
+        new_tree = tree.shear(["a", "b", "c", "f"])
 
-        exp = {'a', 'b', 'c', 'f'}
+        exp = {"a", "b", "c", "f"}
         obs = {n.name for n in new_tree.tips()}
 
         self.assertEqual(obs, exp)
@@ -73,74 +72,74 @@ class TreeTests(TestCase):
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
         # error on zero count(s)
-        taxon_counts = {'a': 0}
+        taxon_counts = {"a": 0}
         self.assertRaises(ValueError, self.simple_t.observed_node_counts,
                           taxon_counts)
-        taxon_counts = {'a': 0, 'b': 0, 'c': 0, 'd': 0}
+        taxon_counts = {"a": 0, "b": 0, "c": 0, "d": 0}
         self.assertRaises(ValueError, self.simple_t.observed_node_counts,
                           taxon_counts)
 
         # all taxa observed once
-        taxon_counts = {'a': 1, 'b': 1, 'c': 1, 'd': 1}
+        taxon_counts = {"a": 1, "b": 1, "c": 1, "d": 1}
         expected = defaultdict(int)
-        expected[self.simple_t.find('root')] = 4
-        expected[self.simple_t.find('i1')] = 2
-        expected[self.simple_t.find('i2')] = 2
-        expected[self.simple_t.find('a')] = 1
-        expected[self.simple_t.find('b')] = 1
-        expected[self.simple_t.find('c')] = 1
-        expected[self.simple_t.find('d')] = 1
+        expected[self.simple_t.find("root")] = 4
+        expected[self.simple_t.find("i1")] = 2
+        expected[self.simple_t.find("i2")] = 2
+        expected[self.simple_t.find("a")] = 1
+        expected[self.simple_t.find("b")] = 1
+        expected[self.simple_t.find("c")] = 1
+        expected[self.simple_t.find("d")] = 1
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
         # some taxa observed twice
-        taxon_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 1}
+        taxon_counts = {"a": 2, "b": 1, "c": 1, "d": 1}
         expected = defaultdict(int)
-        expected[self.simple_t.find('root')] = 5
-        expected[self.simple_t.find('i1')] = 3
-        expected[self.simple_t.find('i2')] = 2
-        expected[self.simple_t.find('a')] = 2
-        expected[self.simple_t.find('b')] = 1
-        expected[self.simple_t.find('c')] = 1
-        expected[self.simple_t.find('d')] = 1
+        expected[self.simple_t.find("root")] = 5
+        expected[self.simple_t.find("i1")] = 3
+        expected[self.simple_t.find("i2")] = 2
+        expected[self.simple_t.find("a")] = 2
+        expected[self.simple_t.find("b")] = 1
+        expected[self.simple_t.find("c")] = 1
+        expected[self.simple_t.find("d")] = 1
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        taxon_counts = {'a': 2, 'b': 1, 'c': 1, 'd': 2}
+        taxon_counts = {"a": 2, "b": 1, "c": 1, "d": 2}
         expected = defaultdict(int)
-        expected[self.simple_t.find('root')] = 6
-        expected[self.simple_t.find('i1')] = 3
-        expected[self.simple_t.find('i2')] = 3
-        expected[self.simple_t.find('a')] = 2
-        expected[self.simple_t.find('b')] = 1
-        expected[self.simple_t.find('c')] = 1
-        expected[self.simple_t.find('d')] = 2
+        expected[self.simple_t.find("root")] = 6
+        expected[self.simple_t.find("i1")] = 3
+        expected[self.simple_t.find("i2")] = 3
+        expected[self.simple_t.find("a")] = 2
+        expected[self.simple_t.find("b")] = 1
+        expected[self.simple_t.find("c")] = 1
+        expected[self.simple_t.find("d")] = 2
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
         # some taxa observed, others not observed
-        taxon_counts = {'a': 2, 'b': 1}
+        taxon_counts = {"a": 2, "b": 1}
         expected = defaultdict(int)
-        expected[self.simple_t.find('root')] = 3
-        expected[self.simple_t.find('i1')] = 3
-        expected[self.simple_t.find('a')] = 2
-        expected[self.simple_t.find('b')] = 1
+        expected[self.simple_t.find("root")] = 3
+        expected[self.simple_t.find("i1")] = 3
+        expected[self.simple_t.find("a")] = 2
+        expected[self.simple_t.find("b")] = 1
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
-        taxon_counts = {'d': 1}
+        taxon_counts = {"d": 1}
         expected = defaultdict(int)
-        expected[self.simple_t.find('root')] = 1
-        expected[self.simple_t.find('i2')] = 1
-        expected[self.simple_t.find('d')] = 1
+        expected[self.simple_t.find("root")] = 1
+        expected[self.simple_t.find("i2")] = 1
+        expected[self.simple_t.find("d")] = 1
         self.assertEqual(self.simple_t.observed_node_counts(taxon_counts),
                          expected)
 
         # error on non-tips
-        taxon_counts = {'a': 2, 'e': 1}
+        taxon_counts = {"a": 2, "e": 1}
         self.assertRaises(MissingNodeError, self.simple_t.observed_node_counts,
                           taxon_counts)
-        taxon_counts = {'a': 2, 'i1': 1}
+        taxon_counts = {"a": 2, "i1": 1}
         self.assertRaises(MissingNodeError, self.simple_t.observed_node_counts,
                           taxon_counts)
 
@@ -150,11 +149,11 @@ class TreeTests(TestCase):
         self.assertEqual(self.complex_tree.observed_node_counts(taxon_counts),
                          expected)
 
-        taxon_counts = {'e': 42, 'f': 1}
+        taxon_counts = {"e": 42, "f": 1}
         expected[self.complex_tree.root()] = 43
-        expected[self.complex_tree.find('int5')] = 43
-        expected[self.complex_tree.find('e')] = 42
-        expected[self.complex_tree.find('f')] = 1
+        expected[self.complex_tree.find("int5")] = 43
+        expected[self.complex_tree.find("e")] = 42
+        expected[self.complex_tree.find("f")] = 1
         self.assertEqual(self.complex_tree.observed_node_counts(taxon_counts),
                          expected)
 
@@ -200,94 +199,137 @@ class TreeTests(TestCase):
 
     def test_append(self):
         """Append a node to a tree"""
-        second_tree = TreeNode.read(io.StringIO("(x,y)z;"))
+        second_tree = TreeNode.read(["(x,y)z;"])
         self.simple_t.append(second_tree)
 
-        self.assertEqual(self.simple_t.children[0].name, 'i1')
-        self.assertEqual(self.simple_t.children[1].name, 'i2')
-        self.assertEqual(self.simple_t.children[2].name, 'z')
+        self.assertEqual(self.simple_t.children[0].name, "i1")
+        self.assertEqual(self.simple_t.children[1].name, "i2")
+        self.assertEqual(self.simple_t.children[2].name, "z")
         self.assertEqual(len(self.simple_t.children), 3)
-        self.assertEqual(self.simple_t.children[2].children[0].name, 'x')
-        self.assertEqual(self.simple_t.children[2].children[1].name, 'y')
+        self.assertEqual(self.simple_t.children[2].children[0].name, "x")
+        self.assertEqual(self.simple_t.children[2].children[1].name, "y")
         self.assertEqual(second_tree.parent, self.simple_t)
 
     def test_extend(self):
         """Extend a few nodes"""
-        second_tree = TreeNode.read(io.StringIO("(x1,y1)z1;"))
-        third_tree = TreeNode.read(io.StringIO("(x2,y2)z2;"))
-        first_tree = TreeNode.read(io.StringIO("(x1,y1)z1;"))
-        fourth_tree = TreeNode.read(io.StringIO("(x2,y2)z2;"))
+        second_tree = TreeNode.read(["(x1,y1)z1;"])
+        third_tree = TreeNode.read(["(x2,y2)z2;"])
+        first_tree = TreeNode.read(["(x1,y1)z1;"])
+        fourth_tree = TreeNode.read(["(x2,y2)z2;"])
         self.simple_t.extend([second_tree, third_tree])
 
         first_tree.extend(fourth_tree.children)
         self.assertEqual(0, len(fourth_tree.children))
-        self.assertEqual(first_tree.children[0].name, 'x1')
-        self.assertEqual(first_tree.children[1].name, 'y1')
-        self.assertEqual(first_tree.children[2].name, 'x2')
-        self.assertEqual(first_tree.children[3].name, 'y2')
+        self.assertEqual(first_tree.children[0].name, "x1")
+        self.assertEqual(first_tree.children[1].name, "y1")
+        self.assertEqual(first_tree.children[2].name, "x2")
+        self.assertEqual(first_tree.children[3].name, "y2")
 
-        self.assertEqual(self.simple_t.children[0].name, 'i1')
-        self.assertEqual(self.simple_t.children[1].name, 'i2')
-        self.assertEqual(self.simple_t.children[2].name, 'z1')
-        self.assertEqual(self.simple_t.children[3].name, 'z2')
+        self.assertEqual(self.simple_t.children[0].name, "i1")
+        self.assertEqual(self.simple_t.children[1].name, "i2")
+        self.assertEqual(self.simple_t.children[2].name, "z1")
+        self.assertEqual(self.simple_t.children[3].name, "z2")
         self.assertEqual(len(self.simple_t.children), 4)
-        self.assertEqual(self.simple_t.children[2].children[0].name, 'x1')
-        self.assertEqual(self.simple_t.children[2].children[1].name, 'y1')
-        self.assertEqual(self.simple_t.children[3].children[0].name, 'x2')
-        self.assertEqual(self.simple_t.children[3].children[1].name, 'y2')
+        self.assertEqual(self.simple_t.children[2].children[0].name, "x1")
+        self.assertEqual(self.simple_t.children[2].children[1].name, "y1")
+        self.assertEqual(self.simple_t.children[3].children[0].name, "x2")
+        self.assertEqual(self.simple_t.children[3].children[1].name, "y2")
         self.assertIs(second_tree.parent, self.simple_t)
         self.assertIs(third_tree.parent, self.simple_t)
 
     def test_extend_empty(self):
         """Extend on the empty case should work"""
         self.simple_t.extend([])
-        self.assertEqual(self.simple_t.children[0].name, 'i1')
-        self.assertEqual(self.simple_t.children[1].name, 'i2')
+        self.assertEqual(self.simple_t.children[0].name, "i1")
+        self.assertEqual(self.simple_t.children[1].name, "i2")
         self.assertEqual(len(self.simple_t.children), 2)
+
+    def test_insert(self):
+        "Insert a node into the branch connecting self and its parent."
+        # insert a new node into a branch with no length
+        node = self.simple_t.find("i1")
+        node.insert(TreeNode("x"))
+        obs = self.simple_t.find("x")
+        self.assertTrue(obs.parent is self.simple_t)
+        self.assertTrue(node.parent is obs)
+        self.assertIn(obs, self.simple_t.children)
+        self.assertIn(node, obs.children)
+        self.assertIsNone(obs.length)
+        self.assertIsNone(node.length)
+
+        msg = "Distance is provided but branch has no length."
+        with self.assertRaisesRegex(ValueError, msg):
+            node.insert(TreeNode("x"), distance=1.0)
+
+        msg = "Self has no parent."
+        with self.assertRaisesRegex(NoParentError, msg):
+            self.simple_t.insert(TreeNode("x"))
+
+        # insert an existing clade into a branch with length
+        t = TreeNode.read(["((a:1,b:1)c:2,(d:3,e:4)f:5,g:1)h;"])
+        donor_t = TreeNode.read(["((x:1,y:1)m:1.5,(z:1,w:1)n:0.5,l:2.5);"])
+        t.find("c").insert(donor_t.find("m"))
+        obs = t.find("m")
+        self.assertTrue(obs.parent is t)
+        self.assertTrue(t.find("c").parent is obs)
+        self.assertNotIn(obs, donor_t.children)
+        self.assertEqual(obs.length, 1)
+        self.assertEqual(t.find("c").length, 1)
+
+        t.find("d").insert(donor_t.find("n"), 2)
+        obs = t.find("n")
+        self.assertTrue(obs.parent is t.find("f"))
+        self.assertTrue(t.find("d").parent is obs)
+        self.assertEqual(obs.length, 1)
+        self.assertEqual(t.find("d").length, 2)
+
+        msg = "Distance cannot exceed branch length."
+        with self.assertRaisesRegex(ValueError, msg):
+            t.find("c").insert(TreeNode("x"), 20)
 
     def test_iter(self):
         """iter wraps children"""
-        exp = ['i1', 'i2']
+        exp = ["i1", "i2"]
         obs = [n.name for n in self.simple_t]
         self.assertEqual(obs, exp)
 
     def test_gops(self):
         """Basic TreeNode operations should work as expected"""
         p = TreeNode()
-        self.assertEqual(str(p), ';\n')
-        p.name = 'abc'
-        self.assertEqual(str(p), 'abc;\n')
+        self.assertEqual(str(p), ";\n")
+        p.name = "abc"
+        self.assertEqual(str(p), "abc;\n")
         p.length = 3
-        self.assertEqual(str(p), 'abc:3;\n')  # don't suppress branch from root
+        self.assertEqual(str(p), "abc:3;\n")  # don"t suppress branch from root
         q = TreeNode()
         p.append(q)
-        self.assertEqual(str(p), '()abc:3;\n')
+        self.assertEqual(str(p), "()abc:3;\n")
         r = TreeNode()
         q.append(r)
-        self.assertEqual(str(p), '(())abc:3;\n')
-        r.name = 'xyz'
-        self.assertEqual(str(p), '((xyz))abc:3;\n')
+        self.assertEqual(str(p), "(())abc:3;\n")
+        r.name = "xyz"
+        self.assertEqual(str(p), "((xyz))abc:3;\n")
         q.length = 2
-        self.assertEqual(str(p), '((xyz):2)abc:3;\n')
+        self.assertEqual(str(p), "((xyz):2)abc:3;\n")
 
     def test_pop(self):
         """Pop off a node"""
-        second_tree = TreeNode.read(io.StringIO("(x1,y1)z1;"))
-        third_tree = TreeNode.read(io.StringIO("(x2,y2)z2;"))
+        second_tree = TreeNode.read(["(x1,y1)z1;"])
+        third_tree = TreeNode.read(["(x2,y2)z2;"])
         self.simple_t.extend([second_tree, third_tree])
 
         i1 = self.simple_t.pop(0)
         z2 = self.simple_t.pop()
 
-        self.assertEqual(i1.name, 'i1')
-        self.assertEqual(z2.name, 'z2')
-        self.assertEqual(i1.children[0].name, 'a')
-        self.assertEqual(i1.children[1].name, 'b')
-        self.assertEqual(z2.children[0].name, 'x2')
-        self.assertEqual(z2.children[1].name, 'y2')
+        self.assertEqual(i1.name, "i1")
+        self.assertEqual(z2.name, "z2")
+        self.assertEqual(i1.children[0].name, "a")
+        self.assertEqual(i1.children[1].name, "b")
+        self.assertEqual(z2.children[0].name, "x2")
+        self.assertEqual(z2.children[1].name, "y2")
 
-        self.assertEqual(self.simple_t.children[0].name, 'i2')
-        self.assertEqual(self.simple_t.children[1].name, 'z1')
+        self.assertEqual(self.simple_t.children[0].name, "i2")
+        self.assertEqual(self.simple_t.children[1].name, "z1")
         self.assertEqual(len(self.simple_t.children), 2)
 
     def test_remove(self):
@@ -300,7 +342,7 @@ class TreeTests(TestCase):
     def test_remove_deleted(self):
         """Remove nodes by function"""
         def f(node):
-            return node.name in ['b', 'd']
+            return node.name in ["b", "d"]
 
         self.simple_t.remove_deleted(f)
         exp = "((a)i1,(c)i2)root;\n"
@@ -309,15 +351,15 @@ class TreeTests(TestCase):
 
     def test_adopt(self):
         """Adopt a node!"""
-        n1 = TreeNode(name='n1')
-        n2 = TreeNode(name='n2')
-        n3 = TreeNode(name='n3')
+        n1 = TreeNode(name="n1")
+        n2 = TreeNode(name="n2")
+        n3 = TreeNode(name="n3")
 
         self.simple_t._adopt(n1)
         self.simple_t.children[-1]._adopt(n2)
         n2._adopt(n3)
 
-        # adopt doesn't update .children
+        # adopt doesn"t update .children
         self.assertEqual(len(self.simple_t.children), 2)
 
         self.assertIs(n1.parent, self.simple_t)
@@ -334,15 +376,15 @@ class TreeTests(TestCase):
 
     def test_shear_prune_parent_dropped(self):
         bugtree = "((a,b),((c,d),(e,f)));"
-        to_keep = ['c', 'd']
+        to_keep = ["c", "d"]
         exp = "(c,d);\n"
-        obs = str(TreeNode.read(io.StringIO(bugtree)).shear(to_keep))
+        obs = str(TreeNode.read([bugtree]).shear(to_keep))
         self.assertEqual(obs, exp)
 
     def test_prune_nested_single_descendent(self):
         bugtree = "(((a,b)));"
         exp = "(a,b);\n"
-        t = TreeNode.read(io.StringIO(bugtree))
+        t = TreeNode.read([bugtree])
         t.prune()
         obs = str(t)
         self.assertEqual(obs, exp)
@@ -367,14 +409,14 @@ class TreeTests(TestCase):
             self.assertEqual(a.name, b.name)
             self.assertEqual(a.length, b.length)
 
-        # create a single descendent by removing tip 'a'
+        # create a single descendent by removing tip "a"
         n = self.simple_t.children[0]
         n.remove(n.children[0])
         self.simple_t.prune()
 
         self.assertEqual(len(self.simple_t.children), 2)
-        self.assertEqual(self.simple_t.children[0].name, 'i2')
-        self.assertEqual(self.simple_t.children[1].name, 'b')
+        self.assertEqual(self.simple_t.children[0].name, "i2")
+        self.assertEqual(self.simple_t.children[1].name, "b")
 
     def test_prune_length(self):
         """Collapse single descendent nodes"""
@@ -393,30 +435,30 @@ class TreeTests(TestCase):
         for n in self.simple_t.traverse():
             n.length = 1.0
 
-        # create a single descendent by removing tip 'a'
+        # create a single descendent by removing tip "a"
         n = self.simple_t.children[0]
         n.remove(n.children[0])
         self.simple_t.prune()
 
         self.assertEqual(len(self.simple_t.children), 2)
-        self.assertEqual(self.simple_t.children[0].name, 'i2')
-        self.assertEqual(self.simple_t.children[1].name, 'b')
+        self.assertEqual(self.simple_t.children[0].name, "i2")
+        self.assertEqual(self.simple_t.children[1].name, "b")
         self.assertEqual(self.simple_t.children[1].length, 2.0)
 
     def test_subset(self):
         """subset should return set of leaves that descends from node"""
         t = self.simple_t
-        self.assertEqual(t.subset(), frozenset('abcd'))
+        self.assertEqual(t.subset(), frozenset("abcd"))
         c = t.children[0]
-        self.assertEqual(c.subset(), frozenset('ab'))
+        self.assertEqual(c.subset(), frozenset("ab"))
         leaf = c.children[1]
-        self.assertEqual(leaf.subset(), frozenset(''))
+        self.assertEqual(leaf.subset(), frozenset(""))
 
     def test_subsets(self):
         """subsets should return all subsets descending from a set"""
         t = self.simple_t
         self.assertEqual(t.subsets(), frozenset(
-            [frozenset('ab'), frozenset('cd')]))
+            [frozenset("ab"), frozenset("cd")]))
 
     def test_is_tip(self):
         """see if we're a tip or not"""
@@ -447,75 +489,75 @@ class TreeTests(TestCase):
         self.assertEqual(root._non_tip_cache, {})
 
     def test_invalidate_attr_caches(self):
-        tree = TreeNode.read(io.StringIO("((a,b,(c,d)e)f,(g,h)i)root;"))
+        tree = TreeNode.read(["((a,b,(c,d)e)f,(g,h)i)root;"])
 
         def f(n):
             return [n.name] if n.is_tip() else []
 
-        tree.cache_attr(f, 'tip_names')
+        tree.cache_attr(f, "tip_names")
         tree.invalidate_caches()
         for n in tree.traverse(include_self=True):
-            self.assertFalse(hasattr(n, 'tip_names'))
+            self.assertFalse(hasattr(n, "tip_names"))
 
     def test_create_caches_duplicate_tip_names(self):
         with self.assertRaises(DuplicateNodeError):
-            TreeNode.read(io.StringIO('(a, a);')).create_caches()
+            TreeNode.read(["(a,a);"]).create_caches()
 
     def test_find_all(self):
-        t = TreeNode.read(io.StringIO("((a,b)c,((d,e)c)c,(f,(g,h)c)a)root;"))
+        t = TreeNode.read(["((a,b)c,((d,e)c)c,(f,(g,h)c)a)root;"])
         exp = [t.children[0],
                t.children[1].children[0],
                t.children[1],
                t.children[2].children[1]]
-        obs = t.find_all('c')
+        obs = t.find_all("c")
         self.assertEqual(obs, exp)
 
         identity = t.find_all(t)
         self.assertEqual(len(identity), 1)
         self.assertEqual(identity[0], t)
 
-        identity_name = t.find_all('root')
+        identity_name = t.find_all("root")
         self.assertEqual(len(identity_name), 1)
         self.assertEqual(identity_name[0], t)
 
         exp = [t.children[2],
                t.children[0].children[0]]
-        obs = t.find_all('a')
+        obs = t.find_all("a")
         self.assertEqual(obs, exp)
 
         with self.assertRaises(MissingNodeError):
-            t.find_all('missing')
+            t.find_all("missing")
 
     def test_find(self):
         """Find a node in a tree"""
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f);"))
+        t = TreeNode.read(["((a,b)c,(d,e)f);"])
         exp = t.children[0]
-        obs = t.find('c')
+        obs = t.find("c")
         self.assertEqual(obs, exp)
 
         exp = t.children[0].children[1]
-        obs = t.find('b')
+        obs = t.find("b")
         self.assertEqual(obs, exp)
 
         with self.assertRaises(MissingNodeError):
-            t.find('does not exist')
+            t.find("does not exist")
 
     def test_find_cache_bug(self):
         """First implementation did not force the cache to be at the root"""
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f,(g,h)f);"))
-        exp_tip_cache_keys = set(['a', 'b', 'd', 'e', 'g', 'h'])
-        exp_non_tip_cache_keys = set(['c', 'f'])
+        t = TreeNode.read(["((a,b)c,(d,e)f,(g,h)f);"])
+        exp_tip_cache_keys = set(["a", "b", "d", "e", "g", "h"])
+        exp_non_tip_cache_keys = set(["c", "f"])
         tip_a = t.children[0].children[0]
         tip_a.create_caches()
         self.assertEqual(tip_a._tip_cache, {})
         self.assertEqual(set(t._tip_cache), exp_tip_cache_keys)
         self.assertEqual(set(t._non_tip_cache), exp_non_tip_cache_keys)
-        self.assertEqual(t._non_tip_cache['f'], [t.children[1], t.children[2]])
+        self.assertEqual(t._non_tip_cache["f"], [t.children[1], t.children[2]])
 
     def test_find_by_id(self):
         """Find a node by id"""
-        t1 = TreeNode.read(io.StringIO("((,),(,,));"))
-        t2 = TreeNode.read(io.StringIO("((,),(,,));"))
+        t1 = TreeNode.read(["((,),(,,));"])
+        t2 = TreeNode.read(["((,),(,,));"])
 
         exp = t1.children[1]
         obs = t1.find_by_id(6)  # right inner node with 3 children
@@ -530,22 +572,22 @@ class TreeTests(TestCase):
 
     def test_find_by_func(self):
         """Find nodes by a function"""
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f);"))
+        t = TreeNode.read(["((a,b)c,(d,e)f);"])
 
         def func(x):
-            return x.parent == t.find('c')
+            return x.parent == t.find("c")
 
-        exp = ['a', 'b']
+        exp = ["a", "b"]
         obs = [n.name for n in t.find_by_func(func)]
         self.assertEqual(obs, exp)
 
     def test_ancestors(self):
         """Get all the ancestors"""
-        exp = ['i1', 'root']
+        exp = ["i1", "root"]
         obs = self.simple_t.children[0].children[0].ancestors()
         self.assertEqual([o.name for o in obs], exp)
 
-        exp = ['root']
+        exp = ["root"]
         obs = self.simple_t.children[0].ancestors()
         self.assertEqual([o.name for o in obs], exp)
 
@@ -559,24 +601,24 @@ class TreeTests(TestCase):
         obs = self.simple_t.siblings()
         self.assertEqual(obs, exp)
 
-        exp = ['i2']
+        exp = ["i2"]
         obs = self.simple_t.children[0].siblings()
         self.assertEqual([o.name for o in obs], exp)
 
-        exp = ['c']
+        exp = ["c"]
         obs = self.simple_t.children[1].children[1].siblings()
         self.assertEqual([o.name for o in obs], exp)
 
         self.simple_t.append(TreeNode(name="foo"))
         self.simple_t.append(TreeNode(name="bar"))
-        exp = ['i1', 'foo', 'bar']
+        exp = ["i1", "foo", "bar"]
         obs = self.simple_t.children[1].siblings()
         self.assertEqual([o.name for o in obs], exp)
 
     def test_ascii_art(self):
         """Make some ascii trees"""
         # unlabeled internal node
-        tr = TreeNode.read(io.StringIO("(B:0.2,(C:0.3,D:0.4):0.6)F;"))
+        tr = TreeNode.read(["(B:0.2,(C:0.3,D:0.4):0.6)F;"])
         obs = tr.ascii_art(show_internal=True, compact=False)
         exp = ("          /-B\n"
                "-F-------|\n"
@@ -599,7 +641,7 @@ class TreeTests(TestCase):
 
     def test_ascii_art_with_support(self):
         """Make some ascii trees with support values"""
-        tr = TreeNode.read(io.StringIO("(B:0.2,(C:0.3,D:0.4)90:0.6)F;"))
+        tr = TreeNode.read(["(B:0.2,(C:0.3,D:0.4)90:0.6)F;"])
         exp = "          /-B\n-F-------|\n         |          /-C\n         "\
               " \\90------|\n                    \\-D"
         obs = tr.ascii_art(show_internal=True, compact=False)
@@ -607,7 +649,7 @@ class TreeTests(TestCase):
         tr.assign_supports()
         obs = tr.ascii_art(show_internal=True, compact=False)
         self.assertEqual(obs, exp)
-        tr = TreeNode.read(io.StringIO("((A,B)75,(C,D)'80:spA');"))
+        tr = TreeNode.read(["((A,B)75,(C,D)'80:spA');"])
         exp = "                    /-A\n          /75------|\n         |    "\
               "      \\-B\n---------|\n         |          /-C\n          \\"\
               "80:spA--|\n                    \\-D"
@@ -618,15 +660,15 @@ class TreeTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_ascii_art_three_children(self):
-        obs = TreeNode.read(io.StringIO('(a,(b,c,d));')).ascii_art()
+        obs = TreeNode.read(["(a,(b,c,d));"]).ascii_art()
         self.assertEqual(obs, exp_ascii_art_three_children)
 
     def test_accumulate_to_ancestor(self):
         """Get the distance from a node to its ancestor"""
-        t = TreeNode.read(io.StringIO(
-            "((a:0.1,b:0.2)c:0.3,(d:0.4,e)f:0.5)root;"))
-        a = t.find('a')
-        b = t.find('b')
+        t = TreeNode.read([
+            "((a:0.1,b:0.2)c:0.3,(d:0.4,e)f:0.5)root;"])
+        a = t.find("a")
+        b = t.find("b")
         exp_to_root = 0.1 + 0.3
         obs_to_root = a.accumulate_to_ancestor(t)
         self.assertEqual(obs_to_root, exp_to_root)
@@ -637,13 +679,12 @@ class TreeTests(TestCase):
     def test_distance_nontip(self):
         # example derived from issue #807, credit @wwood
         tstr = "((A:1.0,B:2.0)'g__genus1':3.0)root;"
-        tree = TreeNode.read(io.StringIO(tstr))
-        self.assertEqual(tree.find('A').distance(tree.find('g__genus1')), 1.0)
+        tree = TreeNode.read([tstr])
+        self.assertEqual(tree.find("A").distance(tree.find("g__genus1")), 1.0)
 
     def test_distance(self):
         """Get the distance between two nodes"""
-        t = TreeNode.read(io.StringIO(
-            "((a:0.1,b:0.2)c:0.3,(d:0.4,e)f:0.5)root;"))
+        t = TreeNode.read(["((a:0.1,b:0.2)c:0.3,(d:0.4,e)f:0.5)root;"])
         tips = sorted([n for n in t.tips()], key=lambda x: x.name)
 
         npt.assert_almost_equal(tips[0].distance(tips[0]), 0.0)
@@ -666,17 +707,17 @@ class TreeTests(TestCase):
 
     def test_lowest_common_ancestor(self):
         """TreeNode lowestCommonAncestor should return LCA for set of tips"""
-        t1 = TreeNode.read(io.StringIO("((a,(b,c)d)e,f,(g,h)i)j;"))
+        t1 = TreeNode.read(["((a,(b,c)d)e,f,(g,h)i)j;"])
         t2 = t1.copy()
         t3 = t1.copy()
         t4 = t1.copy()
-        input1 = ['a']  # return self
-        input2 = ['a', 'b']  # return e
-        input3 = ['b', 'c']  # return d
-        input4 = ['a', 'h', 'g']  # return j
-        exp1 = t1.find('a')
-        exp2 = t2.find('e')
-        exp3 = t3.find('d')
+        input1 = ["a"]  # return self
+        input2 = ["a", "b"]  # return e
+        input3 = ["b", "c"]  # return d
+        input4 = ["a", "h", "g"]  # return j
+        exp1 = t1.find("a")
+        exp2 = t2.find("e")
+        exp3 = t3.find("d")
         exp4 = t4
         obs1 = t1.lowest_common_ancestor(input1)
         obs2 = t2.lowest_common_ancestor(input2)
@@ -689,10 +730,10 @@ class TreeTests(TestCase):
 
         # verify multiple calls work
         t_mul = t1.copy()
-        exp_1 = t_mul.find('d')
-        exp_2 = t_mul.find('i')
-        obs_1 = t_mul.lowest_common_ancestor(['b', 'c'])
-        obs_2 = t_mul.lowest_common_ancestor(['g', 'h'])
+        exp_1 = t_mul.find("d")
+        exp_2 = t_mul.find("i")
+        obs_1 = t_mul.lowest_common_ancestor(["b", "c"])
+        obs_2 = t_mul.lowest_common_ancestor(["g", "h"])
         self.assertEqual(obs_1, exp_1)
         self.assertEqual(obs_2, exp_2)
 
@@ -702,27 +743,25 @@ class TreeTests(TestCase):
 
     def test_get_max_distance(self):
         """get_max_distance should get max tip distance across tree"""
-        tree = TreeNode.read(io.StringIO(
-            "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"))
+        tree = TreeNode.read([
+            "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"])
         dist, nodes = tree.get_max_distance()
         npt.assert_almost_equal(dist, 1.6)
-        self.assertEqual(sorted([n.name for n in nodes]), ['b', 'e'])
+        self.assertEqual(sorted([n.name for n in nodes]), ["b", "e"])
 
     def test_set_max_distance(self):
         """set_max_distance sets MaxDistTips across tree"""
-        tree = TreeNode.read(io.StringIO(
-            "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"))
+        tree = TreeNode.read([
+            "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"])
         tree._set_max_distance()
         tip_a, tip_b = tree.MaxDistTips
         self.assertEqual(tip_a[0] + tip_b[0], 1.6)
-        self.assertEqual(sorted([tip_a[1].name, tip_b[1].name]), ['b', 'e'])
+        self.assertEqual(sorted([tip_a[1].name, tip_b[1].name]), ["b", "e"])
 
     def test_set_max_distance_tie_bug(self):
         """Corresponds to #1077"""
-        s = io.StringIO("((a:1,b:1)c:2,(d:3,e:4)f:5)root;")
-        t = TreeNode.read(s)
-
-        exp = ((3.0, t.find('a')), (9.0, t.find('e')))
+        t = TreeNode.read(["((a:1,b:1)c:2,(d:3,e:4)f:5)root;"])
+        exp = ((3.0, t.find("a")), (9.0, t.find("e")))
 
         # the above tree would trigger an exception in max. The central issue
         # was that the data being passed to max were a tuple of tuple:
@@ -735,16 +774,15 @@ class TreeTests(TestCase):
 
     def test_set_max_distance_inplace_modification_bug(self):
         """Corresponds to #1223"""
-        s = io.StringIO("((a:1,b:1)c:2,(d:3,e:4)f:5)root;")
-        t = TreeNode.read(s)
+        t = TreeNode.read(["((a:1,b:1)c:2,(d:3,e:4)f:5)root;"])
 
-        exp = [((0.0, t.find('a')), (0.0, t.find('a'))),
-               ((0.0, t.find('b')), (0.0, t.find('b'))),
-               ((1.0, t.find('a')), (1.0, t.find('b'))),
-               ((0.0, t.find('d')), (0.0, t.find('d'))),
-               ((0.0, t.find('e')), (0.0, t.find('e'))),
-               ((3.0, t.find('d')), (4.0, t.find('e'))),
-               ((3.0, t.find('a')), (9.0, t.find('e')))]
+        exp = [((0.0, t.find("a")), (0.0, t.find("a"))),
+               ((0.0, t.find("b")), (0.0, t.find("b"))),
+               ((1.0, t.find("a")), (1.0, t.find("b"))),
+               ((0.0, t.find("d")), (0.0, t.find("d"))),
+               ((0.0, t.find("e")), (0.0, t.find("e"))),
+               ((3.0, t.find("d")), (4.0, t.find("e"))),
+               ((3.0, t.find("a")), (9.0, t.find("e")))]
 
         t._set_max_distance()
 
@@ -752,14 +790,14 @@ class TreeTests(TestCase):
 
     def test_shear(self):
         """Shear the nodes"""
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        obs = str(t.shear(['G', 'M']))
-        exp = '(G:3.0,M:3.7);\n'
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        obs = str(t.shear(["G", "M"]))
+        exp = "(G:3.0,M:3.7);\n"
         self.assertEqual(obs, exp)
 
     def test_compare_tip_distances(self):
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        t2 = TreeNode.read(io.StringIO('(((H:1,G:1,O:1):2,R:3):1,X:4);'))
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        t2 = TreeNode.read(["(((H:1,G:1,O:1):2,R:3):1,X:4);"])
         obs = t.compare_tip_distances(t2)
         # note: common taxa are H, G, R (only)
         m1 = np.array([[0, 2, 6.5], [2, 0, 6.5], [6.5, 6.5, 0]])
@@ -768,8 +806,8 @@ class TreeTests(TestCase):
         self.assertAlmostEqual(obs, (1 - r) / 2)
 
     def test_compare_tip_distances_sample(self):
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        t2 = TreeNode.read(io.StringIO('(((H:1,G:1,O:1):2,R:3):1,X:4);'))
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        t2 = TreeNode.read(["(((H:1,G:1,O:1):2,R:3):1,X:4);"])
         obs = t.compare_tip_distances(t2, sample=3, shuffle_f=sorted)
         # note: common taxa are H, G, R (only)
         m1 = np.array([[0, 2, 6.5], [2, 0, 6.5], [6.5, 6.5, 0]])
@@ -778,34 +816,32 @@ class TreeTests(TestCase):
         self.assertAlmostEqual(obs, (1 - r) / 2)
 
         # 4 common taxa, still picking H, G, R
-        s = '((H:1,G:1):2,(R:0.5,M:0.7,Q:5):3);'
-        t = TreeNode.read(io.StringIO(s))
-        s3 = '(((H:1,G:1,O:1):2,R:3,Q:10):1,X:4);'
-        t3 = TreeNode.read(io.StringIO(s3))
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7,Q:5):3);"])
+        t3 = TreeNode.read(["(((H:1,G:1,O:1):2,R:3,Q:10):1,X:4);"])
         obs = t.compare_tip_distances(t3, sample=3, shuffle_f=sorted)
 
     def test_compare_tip_distances_no_common_tips(self):
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        t2 = TreeNode.read(io.StringIO('(((Z:1,Y:1,X:1):2,W:3):1,V:4);'))
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        t2 = TreeNode.read(["(((Z:1,Y:1,X:1):2,W:3):1,V:4);"])
 
         with self.assertRaises(ValueError):
             t.compare_tip_distances(t2)
 
     def test_compare_tip_distances_single_common_tip(self):
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        t2 = TreeNode.read(io.StringIO('(((R:1,Y:1,X:1):2,W:3):1,V:4);'))
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        t2 = TreeNode.read(["(((R:1,Y:1,X:1):2,W:3):1,V:4);"])
 
         self.assertEqual(t.compare_tip_distances(t2), 1)
         self.assertEqual(t2.compare_tip_distances(t), 1)
 
     def test_tip_tip_distances_endpoints(self):
         """Test getting specifc tip distances  with tipToTipDistances"""
-        t = TreeNode.read(io.StringIO('((H:1,G:1):2,(R:0.5,M:0.7):3);'))
-        nodes = [t.find('H'), t.find('G'), t.find('M')]
-        names = ['H', 'G', 'M']
+        t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
+        nodes = [t.find("H"), t.find("G"), t.find("M")]
+        names = ["H", "G", "M"]
         exp = DistanceMatrix(np.array([[0, 2.0, 6.7],
                                        [2.0, 0, 6.7],
-                                       [6.7, 6.7, 0.0]]), ['H', 'G', 'M'])
+                                       [6.7, 6.7, 0.0]]), ["H", "G", "M"])
 
         obs = t.tip_tip_distances(endpoints=names)
         self.assertEqual(obs, exp)
@@ -814,13 +850,13 @@ class TreeTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_tip_tip_distances_non_tip_endpoints(self):
-        t = TreeNode.read(io.StringIO('((H:1,G:1)foo:2,(R:0.5,M:0.7):3);'))
+        t = TreeNode.read(["((H:1,G:1)foo:2,(R:0.5,M:0.7):3);"])
         with self.assertRaises(ValueError):
-            t.tip_tip_distances(endpoints=['foo'])
+            t.tip_tip_distances(endpoints=["foo"])
 
     def test_tip_tip_distances_no_length(self):
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f);"))
-        exp_t = TreeNode.read(io.StringIO("((a:0,b:0)c:0,(d:0,e:0)f:0);"))
+        t = TreeNode.read(["((a,b)c,(d,e)f);"])
+        exp_t = TreeNode.read(["((a:0,b:0)c:0,(d:0,e:0)f:0);"])
         exp_t_dm = exp_t.tip_tip_distances()
 
         t_dm = npt.assert_warns(RepresentationWarning, t.tip_tip_distances)
@@ -830,8 +866,8 @@ class TreeTests(TestCase):
             self.assertIs(node.length, None)
 
     def test_tip_tip_distances_missing_length(self):
-        t = TreeNode.read(io.StringIO("((a,b:6)c:4,(d,e:0)f);"))
-        exp_t = TreeNode.read(io.StringIO("((a:0,b:6)c:4,(d:0,e:0)f:0);"))
+        t = TreeNode.read(["((a,b:6)c:4,(d,e:0)f);"])
+        exp_t = TreeNode.read(["((a:0,b:6)c:4,(d:0,e:0)f:0);"])
         exp_t_dm = exp_t.tip_tip_distances()
 
         t_dm = npt.assert_warns(RepresentationWarning, t.tip_tip_distances)
@@ -839,7 +875,7 @@ class TreeTests(TestCase):
 
     def test_neighbors(self):
         """Get neighbors of a node"""
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f);"))
+        t = TreeNode.read(["((a,b)c,(d,e)f);"])
         exp = t.children
         obs = t.neighbors()
         self.assertEqual(obs, exp)
@@ -858,7 +894,7 @@ class TreeTests(TestCase):
 
     def test_has_children(self):
         """Test if has children"""
-        t = TreeNode.read(io.StringIO("((a,b)c,(d,e)f);"))
+        t = TreeNode.read(["((a,b)c,(d,e)f);"])
         self.assertTrue(t.has_children())
         self.assertTrue(t.children[0].has_children())
         self.assertTrue(t.children[1].has_children())
@@ -869,7 +905,7 @@ class TreeTests(TestCase):
 
     def test_tips(self):
         """Tip traversal of tree"""
-        exp = ['a', 'b', 'c', 'd']
+        exp = ["a", "b", "c", "d"]
         obs = [n.name for n in self.simple_t.tips()]
         self.assertEqual(obs, exp)
         obs2 = [n.name for n in self.simple_t.traverse(False, False)]
@@ -877,26 +913,26 @@ class TreeTests(TestCase):
 
     def test_tips_self(self):
         """ See issue #1509 """
-        tree = TreeNode.read(['(c, (b,a)x)y;'])
-        ts = list(tree.find('c').tips(include_self=True))
+        tree = TreeNode.read(["(c,(b,a)x)y;"])
+        ts = list(tree.find("c").tips(include_self=True))
         self.assertEqual(len(ts), 1)
         t = ts[0]
-        self.assertEqual(t.name, 'c')
+        self.assertEqual(t.name, "c")
         self.assertTrue(t.is_tip())
 
     def test_pre_and_postorder(self):
         """Pre and post order traversal of the tree"""
-        exp = ['root', 'i1', 'a', 'b', 'i1', 'i2', 'c', 'd', 'i2', 'root']
+        exp = ["root", "i1", "a", "b", "i1", "i2", "c", "d", "i2", "root"]
         obs = [n.name for n in self.simple_t.pre_and_postorder()]
         self.assertEqual(obs, exp)
         obs2 = [n.name for n in self.simple_t.traverse(True, True)]
         self.assertEqual(obs2, exp)
 
     def test_pre_and_postorder_no_children(self):
-        t = TreeNode('brofist')
+        t = TreeNode("brofist")
 
         # include self
-        exp = ['brofist']
+        exp = ["brofist"]
         obs = [n.name for n in t.pre_and_postorder()]
         self.assertEqual(obs, exp)
 
@@ -906,22 +942,22 @@ class TreeTests(TestCase):
 
     def test_levelorder(self):
         """Test level order traversal of the tree"""
-        exp = ['root', 'i1', 'i2', 'a', 'b', 'c', 'd']
+        exp = ["root", "i1", "i2", "a", "b", "c", "d"]
         obs = [n.name for n in self.simple_t.levelorder()]
         self.assertEqual(obs, exp)
 
     def test_bifurcate(self):
-        t1 = TreeNode.read(io.StringIO('(((a,b),c),(d,e));'))
-        t2 = TreeNode.read(io.StringIO('((a,b,c));'))
+        t1 = TreeNode.read(["(((a,b),c),(d,e));"])
+        t2 = TreeNode.read(["((a,b,c));"])
         t3 = t2.copy()
 
         t1.bifurcate()
         t2.bifurcate()
         t3.bifurcate(insert_length=0)
 
-        self.assertEqual(str(t1), '(((a,b),c),(d,e));\n')
-        self.assertEqual(str(t2), '((c,(a,b)));\n')
-        self.assertEqual(str(t3), '((c,(a,b):0));\n')
+        self.assertEqual(str(t1), "(((a,b),c),(d,e));\n")
+        self.assertEqual(str(t2), "((c,(a,b)));\n")
+        self.assertEqual(str(t3), "((c,(a,b):0));\n")
 
     def test_bifurcate_with_subclass(self):
         tree = TreeNodeSubclass()
@@ -937,7 +973,7 @@ class TreeTests(TestCase):
 
     def test_index_tree_single_node(self):
         """index_tree handles single node tree"""
-        t1 = TreeNode.read(io.StringIO('root;'))
+        t1 = TreeNode.read(["root;"])
         id_index, child_index = t1.index_tree()
         self.assertEqual(id_index[0], t1)
         npt.assert_equal(child_index, np.array([[]]))
@@ -945,9 +981,9 @@ class TreeTests(TestCase):
     def test_index_tree(self):
         """index_tree should produce correct index and node map"""
         # test for first tree: contains singleton outgroup
-        t1 = TreeNode.read(io.StringIO('(((a,b),c),(d,e));'))
-        t2 = TreeNode.read(io.StringIO('(((a,b),(c,d)),(e,f));'))
-        t3 = TreeNode.read(io.StringIO('(((a,b,c),(d)),(e,f));'))
+        t1 = TreeNode.read(["(((a,b),c),(d,e));"])
+        t2 = TreeNode.read(["(((a,b),(c,d)),(e,f));"])
+        t3 = TreeNode.read(["(((a,b,c),(d)),(e,f));"])
 
         id_1, child_1 = t1.index_tree()
         nodes_1 = [n.id for n in t1.traverse(self_before=False,
@@ -977,18 +1013,23 @@ class TreeTests(TestCase):
         """Root tree at given node"""
         t = TreeNode.read(["(((a,b)c,(d,e)f)g,h)i;"])
 
-        # root at internal node
+        # original behavior (name as branch label); deprecated
         obs = str(t.root_at("c"))
+        exp = "(a,b,((d,e)f,(h)g)c)root;\n"
+        self.assertEqual(obs, exp)
+
+        # root at internal node
+        obs = str(t.root_at("c", branch_attrs=[]))
         exp = "(a,b,((d,e)f,(h)i)g)c;\n"
         self.assertEqual(obs, exp)
 
-        # root at tip
-        obs = str(t.root_at(t.find("h")))
+        # root at tip (and input node instead of name)
+        obs = str(t.root_at(t.find("h"), branch_attrs=[]))
         exp = "((((a,b)c,(d,e)f)g)i)h;\n"
         self.assertEqual(obs, exp)
 
         # root at root (no change)
-        obs = str(t.root_at("i"))
+        obs = str(t.root_at("i", branch_attrs=[]))
         self.assertEqual(obs, str(t))
 
     def test_root_at_midpoint(self):
@@ -998,34 +1039,42 @@ class TreeTests(TestCase):
             n.length = 1
 
         result = t.root_at_midpoint()
-        self.assertEqual(result.distance(result.find('e')), 1.5)
-        self.assertEqual(result.distance(result.find('g')), 2.5)
+        self.assertEqual(result.distance(result.find("e")), 1.5)
+        self.assertEqual(result.distance(result.find("g")), 2.5)
         exp_dist = t.tip_tip_distances()
         obs_dist = result.tip_tip_distances()
         self.assertEqual(obs_dist, exp_dist)
 
     def test_root_at_midpoint_no_lengths(self):
         # should get same tree back (a copy)
-        nwk = '(a,b)c;\n'
-        t = TreeNode.read(io.StringIO(nwk))
+        nwk = "(a,b)c;\n"
+        t = TreeNode.read([nwk])
         obs = t.root_at_midpoint()
         self.assertEqual(str(obs), nwk)
 
     def test_root_at_midpoint_tie(self):
+        # original behavior (name as branch label); deprecated
+        t = TreeNode.read(["(((a:1,b:1)c:2,(d:3,e:4)f:5),g:1)root;"])
+        obs = t.root_at_midpoint()
+        exp = TreeNode.read(["((d:3,e:4)f:2,((a:1,b:1)c:2,(g:1)):3)root;"])
+        for o, e in zip(obs.traverse(), exp.traverse()):
+            self.assertEqual(o.name, e.name)
+            self.assertEqual(o.length, e.length)
+
         t = TreeNode.read(["((a:1,b:1)c:2,(d:3,e:4)f:5,g:1)h;"])
         # farthest tip-to-tip distance is 12 (a or b to e)
         # therefore new root should be 2 above f
-        obs = t.root_at_midpoint()
-        exp = TreeNode.read(["((d:3,e:4)f:2,((a:1,b:1)c:2,g:1)h:3);"])
+        obs = t.root_at_midpoint(branch_attrs=[])
+        exp = TreeNode.read(["((d:3,e:4)f:2,((a:1,b:1)c:2,g:1)h:3)root;"])
         for o, e in zip(obs.traverse(), exp.traverse()):
             self.assertEqual(o.name, e.name)
             self.assertEqual(o.length, e.length)
 
     def test_compare_subsets(self):
         """compare_subsets should return the fraction of shared subsets"""
-        t = TreeNode.read(io.StringIO('((H,G),(R,M));'))
-        t2 = TreeNode.read(io.StringIO('(((H,G),R),M);'))
-        t4 = TreeNode.read(io.StringIO('(((H,G),(O,R)),X);'))
+        t = TreeNode.read(["((H,G),(R,M));"])
+        t2 = TreeNode.read(["(((H,G),R),M);"])
+        t4 = TreeNode.read(["(((H,G),(O,R)),X);"])
 
         result = t.compare_subsets(t)
         self.assertEqual(result, 0)
@@ -1050,9 +1099,9 @@ class TreeTests(TestCase):
 
     def test_compare_rfd(self):
         """compare_rfd should return the Robinson Foulds distance"""
-        t = TreeNode.read(io.StringIO('((H,G),(R,M));'))
-        t2 = TreeNode.read(io.StringIO('(((H,G),R),M);'))
-        t4 = TreeNode.read(io.StringIO('(((H,G),(O,R)),X);'))
+        t = TreeNode.read(["((H,G),(R,M));"])
+        t2 = TreeNode.read(["(((H,G),R),M);"])
+        t4 = TreeNode.read(["(((H,G),(O,R)),X);"])
 
         obs = t.compare_rfd(t2)
         exp = 2.0
@@ -1069,9 +1118,9 @@ class TreeTests(TestCase):
 
     def test_assign_ids(self):
         """Assign IDs to the tree"""
-        t1 = TreeNode.read(io.StringIO("(((a,b),c),(e,f),(g));"))
-        t2 = TreeNode.read(io.StringIO("(((a,b),c),(e,f),(g));"))
-        t3 = TreeNode.read(io.StringIO("((g),(e,f),(c,(a,b)));"))
+        t1 = TreeNode.read(["(((a,b),c),(e,f),(g));"])
+        t2 = TreeNode.read(["(((a,b),c),(e,f),(g));"])
+        t3 = TreeNode.read(["((g),(e,f),(c,(a,b)));"])
         t1_copy = t1.copy()
 
         t1.assign_ids()
@@ -1088,9 +1137,9 @@ class TreeTests(TestCase):
 
     def test_assign_ids_index_tree(self):
         """assign_ids and index_tree should assign the same IDs"""
-        t1 = TreeNode.read(io.StringIO('(((a,b),c),(d,e));'))
-        t2 = TreeNode.read(io.StringIO('(((a,b),(c,d)),(e,f));'))
-        t3 = TreeNode.read(io.StringIO('(((a,b,c),(d)),(e,f));'))
+        t1 = TreeNode.read(["(((a,b),c),(d,e));"])
+        t2 = TreeNode.read(["(((a,b),(c,d)),(e,f));"])
+        t3 = TreeNode.read(["(((a,b,c),(d)),(e,f));"])
         t1_copy = t1.copy()
         t2_copy = t2.copy()
         t3_copy = t3.copy()
@@ -1112,7 +1161,7 @@ class TreeTests(TestCase):
     def test_unrooted_deepcopy(self):
         t = TreeNode.read(["((a,(b,c)d)e,(f,g)h)i;"])
         exp = "(b,c,(a,((f,g)h)e)d)root;\n"
-        obs = t.find('d').unrooted_deepcopy()
+        obs = t.find("d").unrooted_deepcopy()
         self.assertEqual(str(obs), exp)
 
         t_ids = {id(n) for n in t.traverse()}
@@ -1170,135 +1219,135 @@ class TreeTests(TestCase):
         # deep vs shallow copy
         tree = TreeNode.read(["(((a,b)c,d)e,f)g;"])
         tree.find("c").dummy = [1, [2, 3], 4]
-        tcopy = tree.unrooted_copy()
+        tcopy = tree.unrooted_copy(deep=True)
         tcopy.find("c").dummy[1].append(0)
         self.assertListEqual(tree.find("c").dummy[1], [2, 3])
 
-        tcopy = tree.unrooted_copy(deep=False)
+        tcopy = tree.unrooted_copy()
         tcopy.find("c").dummy[1].append(0)
         self.assertListEqual(tree.find("c").dummy[1], [2, 3, 0])
 
     def test_descending_branch_length_bug_1847(self):
-        tr = TreeNode.read(io.StringIO(
-            "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"))
+        tr = TreeNode.read([
+            "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tr.length = 1
         tdbl = tr.descending_branch_length()
         npt.assert_almost_equal(tdbl, 8.9)
 
     def test_descending_branch_length(self):
         """Calculate descending branch_length"""
-        tr = TreeNode.read(io.StringIO(
-            "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"))
+        tr = TreeNode.read([
+            "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
-        sdbl = tr.descending_branch_length(['A', 'E'])
+        sdbl = tr.descending_branch_length(["A", "E"])
         npt.assert_almost_equal(tdbl, 8.9)
         npt.assert_almost_equal(sdbl, 2.2)
         self.assertRaises(ValueError, tr.descending_branch_length,
-                          ['A', 'DNE'])
-        self.assertRaises(ValueError, tr.descending_branch_length, ['A', 'C'])
+                          ["A", "DNE"])
+        self.assertRaises(ValueError, tr.descending_branch_length, ["A", "C"])
 
-        tr = TreeNode.read(io.StringIO(
-            "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"))
+        tr = TreeNode.read([
+            "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
         npt.assert_almost_equal(tdbl, 8.8)
 
-        tr = TreeNode.read(io.StringIO(
-            "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"))
+        tr = TreeNode.read([
+            "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
         npt.assert_almost_equal(tdbl, 7.9)
 
-        tr = TreeNode.read(io.StringIO(
-            "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"))
-        tdbl = tr.descending_branch_length(['A', 'D', 'E'])
+        tr = TreeNode.read([
+            "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
+        tdbl = tr.descending_branch_length(["A", "D", "E"])
         npt.assert_almost_equal(tdbl, 2.1)
 
-        tr = TreeNode.read(io.StringIO(
-            "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"))
-        tdbl = tr.descending_branch_length(['I', 'D', 'E'])
+        tr = TreeNode.read([
+            "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
+        tdbl = tr.descending_branch_length(["I", "D", "E"])
         npt.assert_almost_equal(tdbl, 6.6)
 
         # test with a situation where we have unnamed internal nodes
-        tr = TreeNode.read(io.StringIO(
-            "(((A,B:1.2):.6,(D:.9,E:.6)F):2.4,(H:.4,I:.5)J:1.3);"))
+        tr = TreeNode.read([
+            "(((A,B:1.2):.6,(D:.9,E:.6)F):2.4,(H:.4,I:.5)J:1.3);"])
         tdbl = tr.descending_branch_length()
         npt.assert_almost_equal(tdbl, 7.9)
 
     def test_to_array(self):
         """Convert a tree to arrays"""
-        t = TreeNode.read(io.StringIO(
-            '(((a:1,b:2,c:3)x:4,(d:5)y:6)z:7,(e:8,f:9)z:10);'))
+        t = TreeNode.read([
+            "(((a:1,b:2,c:3)x:4,(d:5)y:6)z:7,(e:8,f:9)z:10);"])
         id_index, child_index = t.index_tree()
         arrayed = t.to_array()
 
-        self.assertEqual(id_index, arrayed['id_index'])
-        npt.assert_equal(child_index, arrayed['child_index'])
+        self.assertEqual(id_index, arrayed["id_index"])
+        npt.assert_equal(child_index, arrayed["child_index"])
 
         exp = np.array([1, 2, 3, 5, 4, 6, 8, 9, 7, 10, np.nan])
-        obs = arrayed['length']
+        obs = arrayed["length"]
         npt.assert_equal(obs, exp)
 
-        exp = np.array(['a', 'b', 'c', 'd', 'x',
-                        'y', 'e', 'f', 'z', 'z', None])
-        obs = arrayed['name']
+        exp = np.array(["a", "b", "c", "d", "x",
+                        "y", "e", "f", "z", "z", None])
+        obs = arrayed["name"]
         npt.assert_equal(obs, exp)
 
         exp = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        obs = arrayed['id']
+        obs = arrayed["id"]
         npt.assert_equal(obs, exp)
 
     def test_to_array_attrs(self):
-        t = TreeNode.read(io.StringIO(
-            '(((a:1,b:2,c:3)x:4,(d:5)y:6)z:7,(e:8,f:9)z:10);'))
+        t = TreeNode.read([
+            "(((a:1,b:2,c:3)x:4,(d:5)y:6)z:7,(e:8,f:9)z:10);"])
         id_index, child_index = t.index_tree()
-        arrayed = t.to_array(attrs=[('name', object)])
+        arrayed = t.to_array(attrs=[("name", object)])
 
         # should only have id_index, child_index, and name since we specified
         # attrs
         self.assertEqual(len(arrayed), 3)
 
-        self.assertEqual(id_index, arrayed['id_index'])
-        npt.assert_equal(child_index, arrayed['child_index'])
+        self.assertEqual(id_index, arrayed["id_index"])
+        npt.assert_equal(child_index, arrayed["child_index"])
 
-        exp = np.array(['a', 'b', 'c', 'd', 'x',
-                        'y', 'e', 'f', 'z', 'z', None])
-        obs = arrayed['name']
+        exp = np.array(["a", "b", "c", "d", "x",
+                        "y", "e", "f", "z", "z", None])
+        obs = arrayed["name"]
         npt.assert_equal(obs, exp)
 
         # invalid attrs
         with self.assertRaises(AttributeError):
-            t.to_array(attrs=[('name', object), ('brofist', int)])
+            t.to_array(attrs=[("name", object), ("brofist", int)])
 
     def test_to_array_nan_length_value(self):
-        t = TreeNode.read(io.StringIO("((a:1, b:2)c:3)root;"))
+        t = TreeNode.read(["((a:1, b:2)c:3)root;"])
         indexed = t.to_array(nan_length_value=None)
-        npt.assert_equal(indexed['length'],
+        npt.assert_equal(indexed["length"],
                          np.array([1, 2, 3, np.nan], dtype=float))
         indexed = t.to_array(nan_length_value=0.0)
-        npt.assert_equal(indexed['length'],
+        npt.assert_equal(indexed["length"],
                          np.array([1, 2, 3, 0.0], dtype=float))
         indexed = t.to_array(nan_length_value=42.0)
-        npt.assert_equal(indexed['length'],
+        npt.assert_equal(indexed["length"],
                          np.array([1, 2, 3, 42.0], dtype=float))
 
-        t = TreeNode.read(io.StringIO("((a:1, b:2)c:3)root:4;"))
+        t = TreeNode.read(["((a:1, b:2)c:3)root:4;"])
         indexed = t.to_array(nan_length_value=42.0)
-        npt.assert_equal(indexed['length'],
+        npt.assert_equal(indexed["length"],
                          np.array([1, 2, 3, 4], dtype=float))
 
-        t = TreeNode.read(io.StringIO("((a:1, b:2)c)root;"))
+        t = TreeNode.read(["((a:1, b:2)c)root;"])
         indexed = t.to_array(nan_length_value=42.0)
-        npt.assert_equal(indexed['length'],
+        npt.assert_equal(indexed["length"],
                          np.array([1, 2, 42.0, 42.0], dtype=float))
 
     def test_from_taxonomy(self):
-        lineages = [('1', ['a', 'b', 'c', 'd', 'e', 'f', 'g']),
-                    ('2', ['a', 'b', 'c', None, None, 'x', 'y']),
-                    ('3', ['h', 'i', 'j', 'k', 'l', 'm', 'n']),
-                    ('4', ['h', 'i', 'j', 'k', 'l', 'm', 'q']),
-                    ('5', ['h', 'i', 'j', 'k', 'l', 'm', 'n'])]
-        exp = TreeNode.read(io.StringIO(
+        lineages = [("1", ["a", "b", "c", "d", "e", "f", "g"]),
+                    ("2", ["a", "b", "c", None, None, "x", "y"]),
+                    ("3", ["h", "i", "j", "k", "l", "m", "n"]),
+                    ("4", ["h", "i", "j", "k", "l", "m", "q"]),
+                    ("5", ["h", "i", "j", "k", "l", "m", "n"])]
+        exp = TreeNode.read([
             "((((((((1)g)f)e)d,((((2)y)x)))c)b)a,"
-            "(((((((3,5)n,(4)q)m)l)k)j)i)h);"))
+            "(((((((3,5)n,(4)q)m)l)k)j)i)h);"])
 
         # input as 2-element tuples
         obs = TreeNode.from_taxonomy(lineages)
@@ -1320,37 +1369,37 @@ class TreeTests(TestCase):
 
 
     def test_to_taxonomy(self):
-        input_lineages = {'1': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
-                          '2': ['a', 'b', 'c', None, None, 'x', 'y'],
-                          '3': ['h', 'i', 'j', 'k', 'l', 'm', 'n'],
-                          '4': ['h', 'i', 'j', 'k', 'l', 'm', 'q'],
-                          '5': ['h', 'i', 'j', 'k', 'l', 'm', 'n']}
+        input_lineages = {"1": ["a", "b", "c", "d", "e", "f", "g"],
+                          "2": ["a", "b", "c", None, None, "x", "y"],
+                          "3": ["h", "i", "j", "k", "l", "m", "n"],
+                          "4": ["h", "i", "j", "k", "l", "m", "q"],
+                          "5": ["h", "i", "j", "k", "l", "m", "n"]}
         tree = TreeNode.from_taxonomy(input_lineages.items())
         exp = sorted(input_lineages.items())
         obs = [(n.name, lin) for n, lin in tree.to_taxonomy(allow_empty=True)]
         self.assertEqual(sorted(obs), exp)
 
     def test_to_taxonomy_filter(self):
-        input_lineages = {'1': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
-                          '2': ['a', 'b', 'c', None, None, 'x', 'y'],
-                          '3': ['h', 'i', 'j', 'k', 'l'],  # test jagged
-                          '4': ['h', 'i', 'j', 'k', 'l', 'm', 'q'],
-                          '5': ['h', 'i', 'j', 'k', 'l', 'm', 'n']}
+        input_lineages = {"1": ["a", "b", "c", "d", "e", "f", "g"],
+                          "2": ["a", "b", "c", None, None, "x", "y"],
+                          "3": ["h", "i", "j", "k", "l"],  # test jagged
+                          "4": ["h", "i", "j", "k", "l", "m", "q"],
+                          "5": ["h", "i", "j", "k", "l", "m", "n"]}
         tree = TreeNode.from_taxonomy(input_lineages.items())
 
         def f(node, lin):
-            return 'k' in lin or 'x' in lin
+            return "k" in lin or "x" in lin
 
-        exp = [('2', ['a', 'b', 'c', 'x', 'y']),
-               ('3', ['h', 'i', 'j', 'k', 'l']),
-               ('4', ['h', 'i', 'j', 'k', 'l', 'm', 'q']),
-               ('5', ['h', 'i', 'j', 'k', 'l', 'm', 'n'])]
+        exp = [("2", ["a", "b", "c", "x", "y"]),
+               ("3", ["h", "i", "j", "k", "l"]),
+               ("4", ["h", "i", "j", "k", "l", "m", "q"]),
+               ("5", ["h", "i", "j", "k", "l", "m", "n"])]
         obs = [(n.name, lin) for n, lin in tree.to_taxonomy(filter_f=f)]
         self.assertEqual(sorted(obs), exp)
 
     def test_linkage_matrix(self):
         # Ensure matches: http://www.southampton.ac.uk/~re1u06/teaching/upgma/
-        id_list = ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+        id_list = ["A", "B", "C", "D", "E", "F", "G"]
         linkage = np.asarray([[1.0,  5.0,  1.0,  2.0],
                               [0.0,  3.0,  8.0,  2.0],
                               [6.0,  7.0, 12.5,  3.0],
@@ -1402,7 +1451,7 @@ class TreeTests(TestCase):
                "(((a,b)int1,(x,y,(w,z)int2,(c,d)int3)int4),(e,f)int5);\n"]
 
         obs_g = self.complex_tree.shuffle(shuffle_f=self.rev_f,
-                                          names=['c', 'd', 'e', 'f'], n=4)
+                                          names=["c", "d", "e", "f"], n=4)
         obs = [str(next(obs_g)) for i in range(4)]
         self.assertEqual(obs, exp)
 
@@ -1412,7 +1461,7 @@ class TreeTests(TestCase):
                "((a,b)i1,(c,d)i2)root;\n",
                "((c,a)i1,(b,d)i2)root;\n"]
 
-        obs_g = self.simple_t.shuffle(names=['a', 'b', 'c'],
+        obs_g = self.simple_t.shuffle(names=["a", "b", "c"],
                                       shuffle_f=self.rotate_f, n=np.inf)
         obs = [str(next(obs_g)) for i in range(4)]
         self.assertEqual(obs, exp)
@@ -1422,15 +1471,15 @@ class TreeTests(TestCase):
             next(self.simple_t.shuffle(k=1))
 
         with self.assertRaises(ValueError):
-            next(self.simple_t.shuffle(k=5, names=['a', 'b']))
+            next(self.simple_t.shuffle(k=5, names=["a", "b"]))
 
         with self.assertRaises(MissingNodeError):
-            next(self.simple_t.shuffle(names=['x', 'y']))
+            next(self.simple_t.shuffle(names=["x", "y"]))
 
     def test_assign_supports(self):
         """Extract support values of internal nodes."""
         # test nodes with support values alone as labels
-        tree = TreeNode.read(['((a,b)75,(c,d)90);'])
+        tree = TreeNode.read(["((a,b)75,(c,d)90);"])
         tree.assign_supports()
         node1, node2 = tree.children
         # check if internal nodes are assigned correct support values
@@ -1441,18 +1490,18 @@ class TreeTests(TestCase):
         self.assertIsNone(node2.name)
         # check if support values are not assigned to root and tips
         self.assertIsNone(tree.support)
-        for taxon in ('a', 'b', 'c', 'd'):
+        for taxon in ("a", "b", "c", "d"):
             self.assertIsNone(tree.find(taxon).support)
 
         # test nodes with support values and branch lengths
-        tree = TreeNode.read(['((a,b)0.85:1.23,(c,d)0.95:4.56);'])
+        tree = TreeNode.read(["((a,b)0.85:1.23,(c,d)0.95:4.56);"])
         tree.assign_supports()
         node1, node2 = tree.children
         self.assertEqual(node1.support, 0.85)
         self.assertEqual(node2.support, 0.95)
 
         # test whether integer or float support values can be correctly parsed
-        tree = TreeNode.read(['((a,b)75,(c,d)80.0,(e,f)97.5,(g,h)0.95);'])
+        tree = TreeNode.read(["((a,b)75,(c,d)80.0,(e,f)97.5,(g,h)0.95);"])
         tree.assign_supports()
         node1, node2, node3, node4 = tree.children
         self.assertTrue(isinstance(node1.support, int))
@@ -1466,24 +1515,24 @@ class TreeTests(TestCase):
 
         # test support values that are negative or scientific notation (not a
         # common scenario but can happen)
-        tree = TreeNode.read(['((a,b)-1.23,(c,d)1.23e-4);'])
+        tree = TreeNode.read(["((a,b)-1.23,(c,d)1.23e-4);"])
         tree.assign_supports()
         node1, node2 = tree.children
         self.assertEqual(node1.support, -1.23)
         self.assertEqual(node2.support, 0.000123)
 
         # test nodes with support and extra label
-        tree = TreeNode.read(['((a,b)\'80:X\',(c,d)\'60:Y\');'])
+        tree = TreeNode.read(["((a,b)'80:X',(c,d)'60:Y');"])
         tree.assign_supports()
         node1, node2 = tree.children
         self.assertEqual(node1.support, 80)
-        self.assertEqual(node1.name, 'X')
+        self.assertEqual(node1.name, "X")
         self.assertEqual(node2.support, 60)
-        self.assertEqual(node2.name, 'Y')
+        self.assertEqual(node2.name, "Y")
 
         # test nodes without label, with non-numeric label, and with branch
         # length only
-        tree = TreeNode.read(['((a,b),(c,d)x,(e,f):1.0);'])
+        tree = TreeNode.read(["((a,b),(c,d)x,(e,f):1.0);"])
         tree.assign_supports()
         for node in tree.children:
             self.assertIsNone(node.support)
@@ -1491,27 +1540,27 @@ class TreeTests(TestCase):
     def test_unpack(self):
         """Unpack an internal node."""
         # test unpacking a node without branch length
-        tree = TreeNode.read(['((c,d)a,(e,f)b);'])
-        tree.find('b').unpack()
-        exp = '((c,d)a,e,f);\n'
+        tree = TreeNode.read(["((c,d)a,(e,f)b);"])
+        tree.find("b").unpack()
+        exp = "((c,d)a,e,f);\n"
         self.assertEqual(str(tree), exp)
 
         # test unpacking a node with branch length
-        tree = TreeNode.read(['((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);'])
-        tree.find('b').unpack()
-        exp = '((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);'
+        tree = TreeNode.read(["((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);"])
+        tree.find("b").unpack()
+        exp = "((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);"
         self.assertEqual(str(tree).rstrip(), exp)
 
         # test attempting to unpack root
-        tree = TreeNode.read(['((d,e)b,(f,g)c)a;'])
-        msg = 'Cannot unpack root.'
+        tree = TreeNode.read(["((d,e)b,(f,g)c)a;"])
+        msg = "Cannot unpack root."
         with self.assertRaisesRegex(TreeError, msg):
-            tree.find('a').unpack()
+            tree.find("a").unpack()
 
         # test attempting to unpack tip
-        msg = 'Cannot unpack tip.'
+        msg = "Cannot unpack tip."
         with self.assertRaisesRegex(TreeError, msg):
-            tree.find('d').unpack()
+            tree.find("d").unpack()
 
     def test_unpack_by_func(self):
         """Unpack internal nodes of a tree by a function."""
@@ -1519,130 +1568,130 @@ class TreeTests(TestCase):
         def func(x):
             return x.length <= 1.0
 
-        # will unpack node 'a', but not tip 'e'
-        # will add the branch length of 'a' to its child nodes 'c' and 'd'
-        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        # will unpack node "a", but not tip "e"
+        # will add the branch length of "a" to its child nodes "c" and "d"
+        tree = TreeNode.read(["((c:2,d:3)a:1,(e:1,f:2)b:2);"])
         tree.unpack_by_func(func)
-        exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
+        exp = "((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);"
         self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack internal nodes with branch length < 2.01
-        # will unpack both 'a' and 'b'
-        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        # will unpack both "a" and "b"
+        tree = TreeNode.read(["((c:2,d:3)a:1,(e:1,f:2)b:2);"])
         tree.unpack_by_func(lambda x: x.length <= 2.0)
-        exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
+        exp = "(c:3.0,d:4.0,e:3.0,f:4.0);"
         self.assertEqual(str(tree).rstrip(), exp)
 
-        # unpack two nested nodes 'a' and 'c' simultaneously
-        tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
+        # unpack two nested nodes "a" and "c" simultaneously
+        tree = TreeNode.read(["(((e:3,f:2)c:1,d:3)a:1,b:4);"])
         tree.unpack_by_func(lambda x: x.length <= 2.0)
-        exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
+        exp = "(b:4.0,d:4.0,e:5.0,f:4.0);"
         self.assertEqual(str(tree).rstrip(), exp)
 
-        # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
+        # test a complicated scenario (unpacking nodes "g", "h" and "m")
         def func(x):
             return x.length < 2.0
-        tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
-                              '(e:3.91,f:2.47)g:1.21)h:1.75,'
-                              '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
+        tree = TreeNode.read(["(((a:1.04,b:2.32,c:1.44)d:3.20,"
+                              "(e:3.91,f:2.47)g:1.21)h:1.75,"
+                              "(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);"])
         tree.unpack_by_func(func)
-        exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
-               '(j:2.06,k:1.58)l:4.09);')
+        exp = ("((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,"
+               "(j:2.06,k:1.58)l:4.09);")
         self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 75
         def func(x):
             return x.support < 75
-        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        tree = TreeNode.read(["(((a,b)85,(c,d)78)75,(e,(f,g)64)80);"])
         tree.assign_supports()
         tree.unpack_by_func(func)
-        exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
+        exp = "(((a,b)85,(c,d)78)75,(e,f,g)80);"
         self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 85
-        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        tree = TreeNode.read(["(((a,b)85,(c,d)78)75,(e,(f,g)64)80);"])
         tree.assign_supports()
         tree.unpack_by_func(lambda x: x.support < 85)
-        exp = '((a,b)85,c,d,e,f,g);'
+        exp = "((a,b)85,c,d,e,f,g);"
         self.assertEqual(str(tree).rstrip(), exp)
 
         # unpack nodes with support < 0.95
-        tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
+        tree = TreeNode.read(["(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);"])
         tree.assign_supports()
         tree.unpack_by_func(lambda x: x.support < 0.95)
-        exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
+        exp = "(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);"
         self.assertEqual(str(tree).rstrip(), exp)
 
         # test a case where there are branch lengths, none support values and
         # node labels
-        tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
-                              '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
-                              'node:0.35)root;'])
+        tree = TreeNode.read(["(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)"
+                              "70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)"
+                              "node:0.35)root;"])
         tree.assign_supports()
         tree.unpack_by_func(lambda x: x.support is not None and x.support < 75)
-        exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
-               '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
+        exp = ("(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,"
+               "(e:1.43,f:1.89,g:2.12)node:0.35)root;")
         self.assertEqual(str(tree).rstrip(), exp)
 
     def test_from_taxdump(self):
         # same example as in skbio.io.format.taxdump
         nodes = pd.DataFrame([
-            [1,       1,      'no rank'],
-            [2,       131567, 'superkingdom'],
-            [543,     91347,  'family'],
-            [548,     570,    'species'],
-            [561,     543,    'genus'],
-            [562,     561,    'species'],
-            [570,     543,    'genus'],
-            [620,     543,    'genus'],
-            [622,     620,    'species'],
-            [766,     28211,  'order'],
-            [1224,    2,      'phylum'],
-            [1236,    1224,   'class'],
-            [28211,   1224,   'class'],
-            [91347,   1236,   'order'],
-            [118884,  1236,   'no rank'],
-            [126792,  36549,  'species'],
-            [131567,  1,      'no rank'],
-            [585056,  562,    'no rank'],
-            [1038927, 562,    'no rank'],
-            [2580236, 488338, 'species']],
-            columns=['tax_id', 'parent_tax_id', 'rank']).set_index('tax_id')
+            [1,       1,      "no rank"],
+            [2,       131567, "superkingdom"],
+            [543,     91347,  "family"],
+            [548,     570,    "species"],
+            [561,     543,    "genus"],
+            [562,     561,    "species"],
+            [570,     543,    "genus"],
+            [620,     543,    "genus"],
+            [622,     620,    "species"],
+            [766,     28211,  "order"],
+            [1224,    2,      "phylum"],
+            [1236,    1224,   "class"],
+            [28211,   1224,   "class"],
+            [91347,   1236,   "order"],
+            [118884,  1236,   "no rank"],
+            [126792,  36549,  "species"],
+            [131567,  1,      "no rank"],
+            [585056,  562,    "no rank"],
+            [1038927, 562,    "no rank"],
+            [2580236, 488338, "species"]],
+            columns=["tax_id", "parent_tax_id", "rank"]).set_index("tax_id")
 
         names = pd.DataFrame([
-            [1, 'root', np.nan, 'scientific name'],
-            [2, 'Bacteria', 'Bacteria <bacteria>', 'scientific name'],
-            [2, 'eubacteria', np.nan, 'genbank common name'],
-            [543, 'Enterobacteriaceae', np.nan, 'scientific name'],
-            [548, 'Klebsiella aerogenes', np.nan, 'scientific name'],
-            [561, 'Escherichia', np.nan, 'scientific name'],
-            [562, '"Bacillus coli" Migula 1895', np.nan, 'authority'],
-            [562, 'Escherichia coli', np.nan, 'scientific name'],
-            [562, 'Escherichia/Shigella coli', np.nan, 'equivalent name'],
-            [570, 'Donovania', np.nan, 'synonym'],
-            [570, 'Klebsiella', np.nan, 'scientific name'],
-            [620, 'Shigella', np.nan, 'scientific name'],
-            [622, 'Shigella dysenteriae', np.nan, 'scientific name'],
-            [766, 'Rickettsiales', np.nan, 'scientific name'],
-            [1224, 'Proteobacteria', np.nan, 'scientific name'],
-            [1236, 'Gammaproteobacteria', np.nan, 'scientific name'],
-            [28211, 'Alphaproteobacteria', np.nan, 'scientific name'],
-            [91347, 'Enterobacterales', np.nan, 'scientific name'],
-            [118884, 'unclassified Gammaproteobacteria', np.nan,
-             'scientific name'],
-            [126792, 'Plasmid pPY113', np.nan, 'scientific name'],
-            [131567, 'cellular organisms', np.nan, 'scientific name'],
-            [585056, 'Escherichia coli UMN026', np.nan, 'scientific name'],
-            [1038927, 'Escherichia coli O104:H4', np.nan, 'scientific name'],
-            [2580236, 'synthetic Escherichia coli Syn61', np.nan,
-             'scientific name']],
-             columns=['tax_id', 'name_txt', 'unique_name',
-                      'name_class']).set_index('tax_id')
+            [1, "root", np.nan, "scientific name"],
+            [2, "Bacteria", "Bacteria <bacteria>", "scientific name"],
+            [2, "eubacteria", np.nan, "genbank common name"],
+            [543, "Enterobacteriaceae", np.nan, "scientific name"],
+            [548, "Klebsiella aerogenes", np.nan, "scientific name"],
+            [561, "Escherichia", np.nan, "scientific name"],
+            [562, "\"Bacillus coli\" Migula 1895", np.nan, "authority"],
+            [562, "Escherichia coli", np.nan, "scientific name"],
+            [562, "Escherichia/Shigella coli", np.nan, "equivalent name"],
+            [570, "Donovania", np.nan, "synonym"],
+            [570, "Klebsiella", np.nan, "scientific name"],
+            [620, "Shigella", np.nan, "scientific name"],
+            [622, "Shigella dysenteriae", np.nan, "scientific name"],
+            [766, "Rickettsiales", np.nan, "scientific name"],
+            [1224, "Proteobacteria", np.nan, "scientific name"],
+            [1236, "Gammaproteobacteria", np.nan, "scientific name"],
+            [28211, "Alphaproteobacteria", np.nan, "scientific name"],
+            [91347, "Enterobacterales", np.nan, "scientific name"],
+            [118884, "unclassified Gammaproteobacteria", np.nan,
+             "scientific name"],
+            [126792, "Plasmid pPY113", np.nan, "scientific name"],
+            [131567, "cellular organisms", np.nan, "scientific name"],
+            [585056, "Escherichia coli UMN026", np.nan, "scientific name"],
+            [1038927, "Escherichia coli O104:H4", np.nan, "scientific name"],
+            [2580236, "synthetic Escherichia coli Syn61", np.nan,
+             "scientific name"]],
+             columns=["tax_id", "name_txt", "unique_name",
+                      "name_class"]).set_index("tax_id")
 
         # nodes without names (use tax_id as name)
         obs = TreeNode.from_taxdump(nodes)
-        exp = ('(((((((((585056,1038927)562)561,(548)570,(622)620)543)91347,'
-               '118884)1236,(766)28211)1224)2)131567)1;')
+        exp = ("(((((((((585056,1038927)562)561,(548)570,(622)620)543)91347,"
+               "118884)1236,(766)28211)1224)2)131567)1;")
         self.assertEqual(str(obs).rstrip(), exp)
         self.assertEqual(obs.count(), 18)
         self.assertEqual(obs.count(tips=True), 6)
@@ -1656,51 +1705,51 @@ class TreeTests(TestCase):
 
         # check id, name and rank are correctly set at root
         self.assertEqual(obs.id, 1)
-        self.assertEqual(obs.name, 'root')
-        self.assertEqual(obs.rank, 'no rank')
+        self.assertEqual(obs.name, "root")
+        self.assertEqual(obs.rank, "no rank")
 
         # check an internal node
-        node = obs.find('Enterobacteriaceae')
+        node = obs.find("Enterobacteriaceae")
         self.assertEqual(node.id, 543)
-        self.assertEqual(node.rank, 'family')
+        self.assertEqual(node.rank, "family")
 
         # check its children (which should preserve input order)
         self.assertEqual(len(node.children), 3)
         self.assertListEqual([x.name for x in node.children], [
-            'Escherichia', 'Klebsiella', 'Shigella'])
+            "Escherichia", "Klebsiella", "Shigella"])
 
-        # check that non-scientific name isn't used
+        # check that non-scientific name isn"t used
         with self.assertRaises(MissingNodeError):
-            obs.find('Donovania')
+            obs.find("Donovania")
 
         # name as a dictionary
-        names = names[names['name_class'] == 'scientific name'][
-            'name_txt'].to_dict()
+        names = names[names["name_class"] == "scientific name"][
+            "name_txt"].to_dict()
         obs = TreeNode.from_taxdump(nodes, names)
         self.assertEqual(obs.count(), 18)
-        self.assertEqual(obs.name, 'root')
-        self.assertEqual(obs.find('Enterobacteriaceae').id, 543)
+        self.assertEqual(obs.name, "root")
+        self.assertEqual(obs.find("Enterobacteriaceae").id, 543)
 
         # nodes has no top level
         nodes = pd.DataFrame([
-            [2, 1, 'A'],
-            [3, 2, 'B'],
-            [1, 3, 'C']],
-            columns=['tax_id', 'parent_tax_id', 'rank']).set_index('tax_id')
+            [2, 1, "A"],
+            [3, 2, "B"],
+            [1, 3, "C"]],
+            columns=["tax_id", "parent_tax_id", "rank"]).set_index("tax_id")
         with self.assertRaises(ValueError) as ctx:
             TreeNode.from_taxdump(nodes)
-        self.assertEqual(str(ctx.exception), 'There is no top-level node.')
+        self.assertEqual(str(ctx.exception), "There is no top-level node.")
 
         # nodes has more than one top level
         nodes = pd.DataFrame([
-            [1, 1, 'A'],
-            [2, 2, 'B'],
-            [3, 3, 'C']],
-            columns=['tax_id', 'parent_tax_id', 'rank']).set_index('tax_id')
+            [1, 1, "A"],
+            [2, 2, "B"],
+            [3, 3, "C"]],
+            columns=["tax_id", "parent_tax_id", "rank"]).set_index("tax_id")
         with self.assertRaises(ValueError) as ctx:
             TreeNode.from_taxdump(nodes)
         self.assertEqual(str(
-            ctx.exception), 'There are more than one top-level node.')
+            ctx.exception), "There are more than one top-level node.")
 
 
 sample = """
@@ -1741,11 +1790,11 @@ minimal = "();"
 no_names = "((,),(,));"
 missing_tip_name = "((a,b),(c,));"
 
-empty = '();'
-single = '(abc:3);'
-double = '(abc:3, def:4);'
-onenest = '(abc:3, (def:4, ghi:5):6 );'
-nodedata = '(abc:3, (def:4, ghi:5)jkl:6 );'
+empty = "();"
+single = "(abc:3);"
+double = "(abc:3, def:4);"
+onenest = "(abc:3, (def:4, ghi:5):6 );"
+nodedata = "(abc:3, (def:4, ghi:5)jkl:6 );"
 
 exp_ascii_art_three_children = r"""          /-a
          |
@@ -1756,5 +1805,5 @@ exp_ascii_art_three_children = r"""          /-a
                     \-d"""
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -957,26 +957,33 @@ class TreeTests(TestCase):
                                             [9, 6, 7], [10, 8, 9]]))
 
     def test_root_at(self):
-        """Form a new root"""
-        t = TreeNode.read(io.StringIO("(((a,b)c,(d,e)f)g,h)i;"))
-        with self.assertRaises(TreeError):
-            t.root_at(t.find('h'))
+        """Root tree at given node"""
+        t = TreeNode.read(["(((a,b)c,(d,e)f)g,h)i;"])
 
-        exp = "(a,b,((d,e)f,(h)g)c)root;\n"
-        rooted = t.root_at('c')
-        obs = str(rooted)
+        # root at internal node
+        obs = str(t.root_at("c"))
+        exp = "(a,b,((d,e)f,(h)i)g)c;\n"
         self.assertEqual(obs, exp)
 
+        # root at tip
+        obs = str(t.root_at(t.find("h")))
+        exp = "((((a,b)c,(d,e)f)g)i)h;\n"
+        self.assertEqual(obs, exp)
+
+        # root at root (no change)
+        obs = str(t.root_at("i"))
+        self.assertEqual(obs, str(t))
+
     def test_root_at_midpoint(self):
-        """Root at the midpoint"""
-        tree1 = self.TreeRoot
-        for n in tree1.traverse():
+        """Root tree at the midpoint"""
+        t = self.TreeRoot
+        for n in t.traverse():
             n.length = 1
 
-        result = tree1.root_at_midpoint()
+        result = t.root_at_midpoint()
         self.assertEqual(result.distance(result.find('e')), 1.5)
         self.assertEqual(result.distance(result.find('g')), 2.5)
-        exp_dist = tree1.tip_tip_distances()
+        exp_dist = t.tip_tip_distances()
         obs_dist = result.tip_tip_distances()
         self.assertEqual(obs_dist, exp_dist)
 
@@ -988,14 +995,12 @@ class TreeTests(TestCase):
         self.assertEqual(str(obs), nwk)
 
     def test_root_at_midpoint_tie(self):
-        nwk = "(((a:1,b:1)c:2,(d:3,e:4)f:5),g:1)root;"
-        t = TreeNode.read(io.StringIO(nwk))
-        exp = "((d:3,e:4)f:2,((a:1,b:1)c:2,(g:1)):3)root;"
-        texp = TreeNode.read(io.StringIO(exp))
-
+        t = TreeNode.read(["((a:1,b:1)c:2,(d:3,e:4)f:5,g:1)h;"])
+        # farthest tip-to-tip distance is 12 (a or b to e)
+        # therefore new root should be 2 above f
         obs = t.root_at_midpoint()
-
-        for o, e in zip(obs.traverse(), texp.traverse()):
+        exp = TreeNode.read(["((d:3,e:4)f:2,((a:1,b:1)c:2,g:1)h:3);"])
+        for o, e in zip(obs.traverse(), exp.traverse()):
             self.assertEqual(o.name, e.name)
             self.assertEqual(o.length, e.length)
 
@@ -1088,9 +1093,8 @@ class TreeTests(TestCase):
                          [n.id for n in t3_copy.traverse()])
 
     def test_unrooted_deepcopy(self):
-        """Do an unrooted_copy"""
-        t = TreeNode.read(io.StringIO("((a,(b,c)d)e,(f,g)h)i;"))
-        exp = "(b,c,(a,((f,g)h)e)d)root;\n"
+        t = TreeNode.read(["((a,(b,c)d)e,(f,g)h)i;"])
+        exp = "(b,c,(a,((f,g)h)i)e)d;\n"
         obs = t.find('d').unrooted_deepcopy()
         self.assertEqual(str(obs), exp)
 

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1398,17 +1398,6 @@ class TreeTests(TestCase):
         self.assertEqual([n.id for n in t3.traverse()],
                          [n.id for n in t3_copy.traverse()])
 
-    def test_unrooted_deepcopy(self):
-        t = TreeNode.read(["((a,(b,c)d)e,(f,g)h)i;"])
-        exp = "(b,c,(a,((f,g)h)e)d)root;\n"
-        obs = t.find("d").unrooted_deepcopy()
-        self.assertEqual(str(obs), exp)
-
-        t_ids = {id(n) for n in t.traverse()}
-        obs_ids = {id(n) for n in obs.traverse()}
-
-        self.assertEqual(t_ids.intersection(obs_ids), set())
-
     def test_unrooted_copy(self):
         tree = TreeNode.read(["((a,(b,c)d)e,(f,g)h)i;"])
         node = tree.find("d")
@@ -1466,6 +1455,28 @@ class TreeTests(TestCase):
         tcopy = tree.unrooted_copy()
         tcopy.find("c").dummy[1].append(0)
         self.assertListEqual(tree.find("c").dummy[1], [2, 3, 0])
+
+    def test_unrooted_deepcopy(self):
+        t = TreeNode.read(["((a,(b,c)d)e,(f,g)h)i;"])
+        exp = "(b,c,(a,((f,g)h)e)d)root;\n"
+        obs = t.find("d").unrooted_deepcopy()
+        self.assertEqual(str(obs), exp)
+
+        t_ids = {id(n) for n in t.traverse()}
+        obs_ids = {id(n) for n in obs.traverse()}
+
+        self.assertEqual(t_ids.intersection(obs_ids), set())
+
+    def test_unrooted_move(self):
+        t = TreeNode.read(["(((a:1,b:1)c:1,(d:1,e:1)f:2)g:0.5,(h:1,i:1)j:0.5)k;"])
+        tcopy = t.copy()
+        obs = tcopy.find("c")
+        obs.unrooted_move()
+        exp = TreeNode.read(["(a:1,b:1,((d:1,e:1)f:2,((h:1,i:1)j:0.5)k:0.5)g:1)c;"])
+        self.assertTrue(obs.is_root())
+        for o, e in zip(obs.traverse(), exp.traverse()):
+            self.assertEqual(o.name, e.name)
+            self.assertEqual(o.length, e.length)
 
     def test_descending_branch_length_bug_1847(self):
         tr = TreeNode.read([

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1118,6 +1118,10 @@ class TreeTests(TestCase):
         exp = "(a,b,((d,e)f,(h)i)g)c;\n"
         self.assertEqual(obs, exp)
 
+        # root at self
+        obs = str(t.find("c").root_at(branch_attrs=[]))
+        self.assertEqual(obs, exp)
+
         # root at tip (and input node instead of name)
         obs = str(t.root_at(t.find("h"), branch_attrs=[]))
         exp = "((((a,b)c,(d,e)f)g)i)h;\n"


### PR DESCRIPTION
Update: Some substantial work has been done to make the rooting functionality of `TreeNode` complete and robust. Specifically:

1. The current default behavior is preserved. Therefore no API break will happen in the downstream.
2. Meanwhile, a warning is displayed during executing the code and in the documentation, saying that the default behavior will change in 0.7.0. The approach to mimick the new default behavior using the current code is provided.
3. Added method `insert` and parameter `above`, such that the root can be placed inside a branch, making the resulting tree rooted.
4. Added parameter `branch_attrs`, such that one can customize which attributes are branch attributes and should be transferred to the other side of the branch when it is flipped during rerooting.
5. Added method `unroot` to convert a rooted tree into unrooted.
6. Added method `root_by_outgroup`, as the name tells.
7. Added method `unrooted_move` which resembles `unrooted_copy`, but modifies the tree in place, thus avoiding copying all nodes.
8. Also improved the copy mechanisms of `TreeNode`. There are now shallow and deep copies. Some unnecessary copies (such as `unrooted_deepcopy` are removed.

@wasade @mortonjt This PR is very long. It may be hard to read through. But I can tell that all functions have been tested using old cases and cases that I used during the WoL project to make sure results are consistent.

***

@christapo This will be the prerequisite for fast NJ and ME.

Example tree:

```python
>>> from skbio import TreeNode
>>> tree = TreeNode.read(['(((a,b)c,(d,e)f)g,(h,i)j)k;'])
>>> print(tree.ascii_art())
                              /-a
                    /c-------|
                   |          \-b
          /g-------|
         |         |          /-d
         |          \f-------|
-k-------|                    \-e
         |
         |          /-h
          \j-------|
                    \-i
```

Original behavior:

```python
>>> print(tree.root_at('c').ascii_art())
          /-a
         |
         |--b
-root----|
         |                    /-d
         |          /f-------|
         |         |          \-e
          \c-------|
                   |                    /-h
                    \g------- /j-------|
                                        \-i
```

Modified behavior:

```python
>>> print(tree.root_at('c').ascii_art())
          /-a
         |
         |--b
-c-------|
         |                    /-d
         |          /f-------|
         |         |          \-e
          \g-------|
                   |                    /-h
                    \k------- /j-------|
                                        \-i
```

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
