### PR TITLE
Fixed the Zenodo link in the README to always point to the most recent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 [#2032](https://github.com/scikit-bio/scikit-bio/pull/2032), [#2005](https://github.com/scikit-bio/scikit-bio/pull/2005))
 * Added alpha diversity metrics: Hill number (`hill`), Renyi entropy (`renyi`) and Tsallis entropy (`tsallis`) ([#2074](https://github.com/scikit-bio/scikit-bio/pull/2074)).
 * Added `nni` function for phylogenetic tree rearrangement using nearest neighbor interchange (NNI) ([#2050](https://github.com/scikit-bio/scikit-bio/pull/2050)).
+* Fixed the Zenodo link in the README to always point to the most recent version
 
 ## Version 0.6.1
 

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ The development of scikit-bio is currently supported by the U.S. Department of E
 Citation
 --------
 
-If you use scikit-bio for any published research, please see our `Zenodo page <https://zenodo.org/record/8209901>`_ for how to cite.
+If you use scikit-bio for any published research, please see our `Zenodo page <https://zenodo.org/doi/10.5281/zenodo.593387>`_ for how to cite.
 
 
 Collaboration


### PR DESCRIPTION
Currently, the Zenodo link in the README points to the 0.5.9 version. This PR updates the Zenodo link in the README to point to the DOI that always redirects to the most recent version.

Please complete the following checklist:

* [X] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [X] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [X] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
