### PR TITLE
TreeNode: Improved time and memory efficiency by making caches lazy

### DIFF
--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -426,8 +426,8 @@ class TreeTests(TestCase):
         self.assertNotEqual(root._tip_cache, {})
         self.assertNotEqual(root._non_tip_cache, {})
         root.invalidate_caches()
-        self.assertEqual(root._tip_cache, {})
-        self.assertEqual(root._non_tip_cache, {})
+        self.assertFalse(hasattr(root, "_tip_cache"))
+        self.assertFalse(hasattr(root, "_non_tip_cache"))
 
     def test_invalidate_attr_caches(self):
         tree = TreeNode.read(io.StringIO("((a,b,(c,d)e)f,(g,h)i)root;"))
@@ -490,7 +490,7 @@ class TreeTests(TestCase):
         exp_non_tip_cache_keys = set(['c', 'f'])
         tip_a = t.children[0].children[0]
         tip_a.create_caches()
-        self.assertEqual(tip_a._tip_cache, {})
+        self.assertFalse(hasattr(tip_a, "_tip_cache"))
         self.assertEqual(set(t._tip_cache), exp_tip_cache_keys)
         self.assertEqual(set(t._non_tip_cache), exp_non_tip_cache_keys)
         self.assertEqual(t._non_tip_cache['f'], [t.children[1], t.children[2]])


### PR DESCRIPTION
I examined the mechanism of loading and storing phylogenetic trees in scikit-bio, and realized that a major bottleneck is the following [three lines](https://github.com/scikit-bio/scikit-bio/blob/0131e023a72cc45d650032a1237c35f290c23805/skbio/tree/_tree.py#L93) during the initiation of a `TreeNode` instance:

```python
self._tip_cache = {}
self._non_tip_cache = {}
self._registered_caches = set()
```

These three private attributes significantly increased the memory and runtime burden.

Here, `_tip_cache` and `_non_tip_cache` are dictionaries to facilitate searching by node name. They are only needed at the root node of a tree (see `create_caches`). However, they are created for every single node, which causes a huge waste. `_registered_caches` is very useful in customizing node attributes in a postorder style. But it is not used elsewhere in scikit-bio, and its creation is done through the public method `cache_attr`, which a user will use.

The current PR made these three private attributes created-by-need. This simple change significantly improved the time and memory efficiency of tree loading, especially with extremely large trees.

Benchmark on a tree with 212,293 tips:

Tree object:
- Memory (MB): 275.8 -> 126.8 (**54%** decrease)

Load Newick tree:
- Time (sec): 5.585 -> 3.822 (**32%** decrease)

Find 100 tips:
- Time (sec): 0.5700 ->0.4572 (**20%** decrease)

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
