### PR TITLE
Optimized tree traversal algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.6.3-dev
 
+### Performance enhancements
+
+* Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).
+
 
 ## Version 0.6.2
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1967,7 +1967,6 @@ class TreeNode(SkbioObject):
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
         >>> for node in tree.pre_and_postorder():
         ...     print(node.name)
-        None
         g
         c
         a

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1782,6 +1782,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.traverse():
         ...     print(node.name)
         g
@@ -1835,6 +1844,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.preorder():
         ...     print(node.name)
         g
@@ -1885,6 +1903,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.postorder():
         ...     print(node.name)
         a
@@ -1965,6 +1992,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.pre_and_postorder():
         ...     print(node.name)
         g
@@ -2049,6 +2085,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.levelorder():
         ...     print(node.name)
         g
@@ -2095,6 +2140,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f);"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.tips():
         ...     print(node.name)
         a
@@ -2134,6 +2188,15 @@ class TreeNode(SkbioObject):
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f);"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+
         >>> for node in tree.non_tips():
         ...     print(node.name)
         c

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1880,17 +1880,19 @@ class TreeNode(SkbioObject):
 
         """
         child_index_stack = [0]
+        child_index_stack_append = child_index_stack.append
+        child_index_stack_pop = child_index_stack.pop
         curr = self
         curr_children = self.children
         curr_children_len = len(curr_children)
-        while 1:
+        while True:
             curr_index = child_index_stack[-1]
             # if there are children left, process them
             if curr_index < curr_children_len:
                 curr_child = curr_children[curr_index]
                 # if the current child has children, go there
                 if curr_child.children:
-                    child_index_stack.append(0)
+                    child_index_stack_append(0)
                     curr = curr_child
                     curr_children = curr.children
                     curr_children_len = len(curr_children)
@@ -1909,7 +1911,7 @@ class TreeNode(SkbioObject):
                 curr = curr.parent
                 curr_children = curr.children
                 curr_children_len = len(curr_children)
-                child_index_stack.pop()
+                child_index_stack_pop()
                 child_index_stack[-1] += 1
 
     def pre_and_postorder(self, include_self=True):
@@ -1954,9 +1956,11 @@ class TreeNode(SkbioObject):
                 yield self
             return
         child_index_stack = [0]
+        child_index_stack_append = child_index_stack.append
+        child_index_stack_pop = child_index_stack.pop
         curr = self
         curr_children = self.children
-        while 1:
+        while True:
             curr_index = child_index_stack[-1]
             if not curr_index:
                 if include_self or (curr is not self):
@@ -1966,7 +1970,7 @@ class TreeNode(SkbioObject):
                 curr_child = curr_children[curr_index]
                 # if the current child has children, go there
                 if curr_child.children:
-                    child_index_stack.append(0)
+                    child_index_stack_append(0)
                     curr = curr_child
                     curr_children = curr.children
                     curr_index = 0
@@ -1983,7 +1987,7 @@ class TreeNode(SkbioObject):
                     break
                 curr = curr.parent
                 curr_children = curr.children
-                child_index_stack.pop()
+                child_index_stack_pop()
                 child_index_stack[-1] += 1
 
     def levelorder(self, include_self=True):

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -11,7 +11,7 @@ from operator import or_, itemgetter
 from copy import copy, deepcopy
 from itertools import combinations
 from functools import reduce
-from collections import defaultdict
+from collections import defaultdict, deque
 
 import numpy as np
 import pandas as pd
@@ -2023,13 +2023,13 @@ class TreeNode(SkbioObject):
         e
 
         """
-        queue = [self]
+        queue = deque([self]) if include_self else deque(self.children)
+        queue_popleft = queue.popleft
+        queue_extend = queue.extend
         while queue:
-            curr = queue.pop(0)
-            if include_self or (curr is not self):
-                yield curr
+            yield (curr := queue_popleft())
             if curr.children:
-                queue.extend(curr.children)
+                queue_extend(curr.children)
 
     def tips(self, include_self=False):
         r"""Iterate over tips descended from `self`.

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -2144,7 +2144,7 @@ class TreeNode(SkbioObject):
                             /-a
                   /c-------|
                  |          \-b
-        -g-------|
+        ---------|
                  |          /-d
                   \f-------|
                             \-e
@@ -2192,7 +2192,7 @@ class TreeNode(SkbioObject):
                             /-a
                   /c-------|
                  |          \-b
-        -g-------|
+        ---------|
                  |          /-d
                   \f-------|
                             \-e

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1833,13 +1833,13 @@ class TreeNode(SkbioObject):
         b
 
         """
-        stack = [self]
+        stack = [self] if include_self else self.children[::-1]
+        stack_pop = stack.pop
+        stack_extend = stack.extend
         while stack:
-            curr = stack.pop()
-            if include_self or (curr is not self):
-                yield curr
+            yield (curr := stack_pop())
             if curr.children:
-                stack.extend(curr.children[::-1])
+                stack_extend(curr.children[::-1])
 
     def postorder(self, include_self=True):
         r"""Perform postorder iteration over tree.

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -971,6 +971,16 @@ class TreeTests(TestCase):
         self.assertEqual(t.name, "c")
         self.assertTrue(t.is_tip())
 
+    def test_preorder(self):
+        """Test preorder traversal of the tree"""
+        exp = ["root", "i1", "a", "b", "i2", "c", "d"]
+        obs = [n.name for n in self.simple_t.preorder()]
+        self.assertEqual(obs, exp)
+
+        exp = ["i1", "a", "b", "i2", "c", "d"]
+        obs = [n.name for n in self.simple_t.preorder(include_self=False)]
+        self.assertEqual(obs, exp)
+
     def test_pre_and_postorder(self):
         """Pre and post order traversal of the tree"""
         exp = ["root", "i1", "a", "b", "i1", "i2", "c", "d", "i2", "root"]

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -972,7 +972,7 @@ class TreeTests(TestCase):
         self.assertTrue(t.is_tip())
 
     def test_preorder(self):
-        """Test preorder traversal of the tree"""
+        """Preorder traversal of the tree"""
         exp = ["root", "i1", "a", "b", "i2", "c", "d"]
         obs = [n.name for n in self.simple_t.preorder()]
         self.assertEqual(obs, exp)
@@ -1002,9 +1002,13 @@ class TreeTests(TestCase):
         self.assertEqual(obs, [])
 
     def test_levelorder(self):
-        """Test level order traversal of the tree"""
+        """Level order traversal of the tree"""
         exp = ["root", "i1", "i2", "a", "b", "c", "d"]
         obs = [n.name for n in self.simple_t.levelorder()]
+        self.assertEqual(obs, exp)
+
+        exp = ["i1", "i2", "a", "b", "c", "d"]
+        obs = [n.name for n in self.simple_t.levelorder(include_self=False)]
         self.assertEqual(obs, exp)
 
     def test_bifurcate(self):

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -981,6 +981,16 @@ class TreeTests(TestCase):
         obs = [n.name for n in self.simple_t.preorder(include_self=False)]
         self.assertEqual(obs, exp)
 
+    def test_postorder(self):
+        """Postorder traversal of the tree"""
+        exp = ["a", "b", "i1", "c", "d", "i2", "root"]
+        obs = [n.name for n in self.simple_t.postorder()]
+        self.assertEqual(obs, exp)
+
+        exp = ["a", "b", "i1", "c", "d", "i2"]
+        obs = [n.name for n in self.simple_t.postorder(include_self=False)]
+        self.assertEqual(obs, exp)
+
     def test_pre_and_postorder(self):
         """Pre and post order traversal of the tree"""
         exp = ["root", "i1", "a", "b", "i1", "i2", "c", "d", "i2", "root"]


### PR DESCRIPTION
This PR did some minor but effective optimizations of the tree traversal methods: `preorder`, `postorder` and `levelorder`. Most notably, the performance of `levelorder` has been increased by some 4x fold. This is because the previous code used a Python `list` as a queue (FIFO), which is inefficient. This PR replaced it with a `deque`, which is highly efficient in left append and pop. Benchmarks on a tree with 200k tips showed (sec):

- Pre-order: 0.1273 -> 0.1118 (**12%** decrease)
- Post-order: 0.1543 -> 0.1524 (**1.2%** decrease)
- Level-order: 0.8084 -> 0.1935 (**76%** decrease)

This PR also enriched documentation of these methods.

---

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
