### PR TITLE
Added meta description tags to documentation pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Make documentation
         run: make doc
       # save built documentation (HTML) for deployment
-      - name: Substitute URLs
+      - name: Modify documentation
         if: github.event_name == 'push'
         run: |
           python doc/suburl.py
+          python doc/metatag.py
           python doc/editmap.py
       - name: Save documentation
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Modify documentation
         run: |
           python doc/suburl.py
+          python doc/metatag.py
           python doc/editmap.py
 
       - name: Check out website

--- a/doc/metatag.py
+++ b/doc/metatag.py
@@ -1,0 +1,68 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+# Script to insert a meta description tag into each documentation page. The
+# content is the first line of the docstring of the corresponding object.
+
+import os
+import re
+import glob
+import html
+
+
+# -- Configuration -----------------------------------------------------------
+
+rootdir = "build/html"
+max_length = 160
+
+
+# -- Workflow ----------------------------------------------------------------
+
+dd_pattern = re.compile(r'<dd>(.*?)</dd>', flags=re.DOTALL)
+p_pattern = re.compile(r'<p>(.*?)</p>', flags=re.DOTALL)
+meta_pattern = re.compile(r'(\s*)(<meta\b[^>]*\/?>)')
+
+cwd = os.getcwd()
+os.chdir(os.path.join(os.path.dirname(__file__), rootdir))
+
+for file in glob.glob("**/*.html", recursive=True):
+    with open(file, "r") as fh:
+        content = fh.read()
+
+    # find first line of docstring (summary)
+    dd_match = dd_pattern.search(content)
+    if not dd_match:
+        continue
+    p_match = p_pattern.search(dd_match.group(1))
+    if not p_match:
+        continue
+    summary = p_match.group(1)
+
+    # truncate summary to given length
+    if len(summary) > max_length:
+        summary = summary[:max_length - 3]
+        if ' ' in summary:
+            summary = summary.rsplit(' ', 1)[0]
+        summary += "..."
+
+    # make summary safe for HTML
+    summary = html.escape(summary)
+
+    # insert summary into metadata
+    line = f'<meta name="description" content="{summary}" />'
+    meta_match = meta_pattern.search(content)
+    if not meta_match:
+        continue
+    indent = meta_match.group(1)
+    pos = meta_match.end()
+    content = content[:pos] + indent + line + content[pos:]
+
+    with open(file, "w") as fh:
+        fh.write(content)
+
+os.chdir(cwd)

--- a/doc/source/alignment.rst
+++ b/doc/source/alignment.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Computing and manipulating biological sequence alignments.
+
 .. automodule:: skbio.alignment

--- a/doc/source/diversity.rst
+++ b/doc/source/diversity.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Analyzing biodiversity of communities -- groups of organisms living in the same area.
+
 .. automodule:: skbio.diversity

--- a/doc/source/embedding.rst
+++ b/doc/source/embedding.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Storing and working with embeddings of biological objects for machine learning.
+
 .. automodule:: skbio.embedding

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,6 +14,8 @@
 
    </style>
 
+.. meta::
+   :description: A community-driven Python library for bioinformatics, providing versatile data structures, algorithms and educational resources.
 
 .. hidden page title
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Input/output (I/O) functionality for scikit-bio.
+
 .. automodule:: skbio.io

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Storing and working with metadata -- information about other data.
+
 .. automodule:: skbio.metadata

--- a/doc/source/sequence.rst
+++ b/doc/source/sequence.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Storing and working with sequences: nucleotides, amino acids, custom alphabets and unrestricted ones.
+
 .. automodule:: skbio.sequence

--- a/doc/source/stats.rst
+++ b/doc/source/stats.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Statistical methods for analyzing high-dimensional biological data.
+
 .. automodule:: skbio.stats

--- a/doc/source/table.rst
+++ b/doc/source/table.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Working with biological data tables in BIOM format.
+
 .. automodule:: skbio.table

--- a/doc/source/tree.rst
+++ b/doc/source/tree.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Storing and working with tree structures, including phylogenetic trees and hierarchies.
+
 .. automodule:: skbio.tree

--- a/doc/source/util.rst
+++ b/doc/source/util.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: General exception/warning definitions, utilities, and unit-testing functionality.
+
 .. automodule:: skbio.util

--- a/doc/source/workflow.rst
+++ b/doc/source/workflow.rst
@@ -1,1 +1,4 @@
+.. meta::
+   :description: Constructing arbitrarily complex workflows.
+
 .. automodule:: skbio.workflow


### PR DESCRIPTION
This PR adds meta description tags to the HTML files of individual documentation pages. These tags are automatically generated according to the first line of the docstring of each object. It provides a brief description of the webpage. This information is useful for search engines to understand the topic of the webpage.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
