### PR TITLE
Remodeled autosummary template for class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Miscellaneous
 
 * Renamed `TreeNode.invalidate_caches` as `clear_caches`. The old name is preserved as an alias ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
+* Remodeled documentation. Special methods (previously referred to as built-in methods) and inherited methods of a class no longer have separate stub pages. This significantly reduced the total number of webpages in the documentation ([#2110](https://github.com/scikit-bio/scikit-bio/pull/2110)).
 
 ### Deprecated functionality
 

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -69,7 +69,6 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :show-inheritance:
 
 
 {# Table of contents #}
@@ -87,7 +86,7 @@
    {% if inherited_attributes %}
    .. rubric:: Attributes (inherited)
 
-   .. autosummary::
+   .. autoinherit::
    {% for item in inherited_attributes %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
@@ -102,14 +101,14 @@
       :toctree:
    {% for item in own_methods %}
       ~{{ name }}.{{ item }}
-   {%- endfor %}
+   {% endfor %}
    {% endif %}
 
    {% if inherited_methods %}
    .. rubric:: Methods (inherited)
 
-   .. autosummary::
-   {% for item in inherited_methods %}
+   .. autoinherit::
+   {%- for item in inherited_methods %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}
@@ -128,7 +127,7 @@
    {% if inherited_special_methods %}
    .. rubric:: Special methods (inherited)
 
-   .. autosummary::
+   .. autoinherit::
    {% for item in inherited_special_methods %}
       ~{{ name }}.{{ item }}
    {%- endfor %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,59 +1,155 @@
-{# This template was modified from autosummaries default format #}
+{# This template was modified from autosummary's default template. #}
 {{ fullname | escape | underline}}
 
-{# We need a list of the built-ins that we implemented, not the default ones #}
-{% set built_in_methods = []  %}
+
+{# Identify special methods (i.e., dunder or magic methods) that are relevant. #}
+
+{% set methods_to_ignore = [
+   '__class__',
+   '__delattr__',
+   '__getattribute__',
+   '__init__',
+   '__dir__',
+   '__format__',
+   '__new__',
+   '__reduce__',
+   '__reduce_ex__',
+   '__repr__',
+   '__setattr__',
+   '__sizeof__',
+   '__subclasshook__',
+   '__init_subclass__',
+   '__class_getitem__',
+] %}
+{% set special_methods = [] %}
 {% for item in all_methods %}
-   {% if (item not in ['__class__',
-                        '__delattr__',
-                        '__getattribute__',
-                        '__init__',
-                        '__dir__',
-                        '__format__',
-                        '__new__',
-                        '__reduce__',
-                        '__reduce_ex__',
-                        '__repr__',
-                        '__setattr__',
-                        '__sizeof__',
-                        '__subclasshook__',
-                        '__init_subclass__',
-                        '__class_getitem__'] and item.startswith('__')) %}
-      {{ built_in_methods.append(item) or '' }}
+   {% if item.startswith('__') and item not in methods_to_ignore %}
+      {{ special_methods.append(item) or '' }}
    {% endif %}
 {% endfor %}
+
+
+{# Distinguish inherited and own members. #}
+
+{% set inherited_attributes = [] %}
+{% set own_attributes = [] %}
+{% for item in attributes %}
+   {% if item in inherited_members %}
+      {{ inherited_attributes.append(item) or '' }}
+   {% else %}
+      {{ own_attributes.append(item) or '' }}
+   {% endif %}
+{% endfor %}
+
+{% set inherited_methods = [] %}
+{% set own_methods = [] %}
+{% for item in methods %}
+   {% if item != '__init__' %}
+      {% if item in inherited_members %}
+         {{ inherited_methods.append(item) or '' }}
+      {% else %}
+         {{ own_methods.append(item) or '' }}
+      {% endif %}
+   {% endif %}
+{% endfor %}
+
+{% set inherited_special_methods = [] %}
+{% set own_special_methods = [] %}
+{% for item in special_methods %}
+   {% if item in inherited_members %}
+      {{ inherited_special_methods.append(item) or '' }}
+   {% else %}
+      {{ own_special_methods.append(item) or '' }}
+   {% endif %}
+{% endfor %}
+
+
+{# Class name, signatures, superclass (if any) and docstring. #}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
 
-   {% if attributes %}
+
+{# Table of contents #}
+
+   {% block attributes %}
+   {% if own_attributes %}
    .. rubric:: Attributes
 
    .. autosummary::
-   {% for item in attributes %}
+   {% for item in own_attributes %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}
 
-   {% if built_in_methods %}
-   .. rubric:: Built-ins
+   {% if inherited_attributes %}
+   .. rubric:: Attributes (inherited)
 
    .. autosummary::
-      :toctree:
-   {% for item in built_in_methods %}
+   {% for item in inherited_attributes %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}
+   {% endblock %}
 
-   {% if methods %}
+   {% block methods %}
+   {% if own_methods %}
    .. rubric:: Methods
 
    .. autosummary::
       :toctree:
-   {% for item in methods %}
-      {% if item != '__init__' %}
+   {% for item in own_methods %}
       ~{{ name }}.{{ item }}
-      {% endif %}
    {%- endfor %}
    {% endif %}
+
+   {% if inherited_methods %}
+   .. rubric:: Methods (inherited)
+
+   .. autosummary::
+   {% for item in inherited_methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block special_methods %}
+   {% if own_special_methods %}
+   .. rubric:: Special methods
+
+   .. autosummary::
+   {% for item in own_special_methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+
+   {% if inherited_special_methods %}
+   .. rubric:: Special methods (inherited)
+
+   .. autosummary::
+   {% for item in inherited_special_methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+
+{# Detailed documentation #}
+
+   {% block details %}
+   .. rubric:: Details
+
+   {% for item in own_attributes %}
+   {% if item not in inherited_members %}
+   .. autoattribute:: {{ name }}.{{ item }}
+   {% endif %}
+   {% endfor %}
+
+   {% for item in own_special_methods %}
+   {% if item not in inherited_members %}
+   .. automethod:: {{ name }}.{{ item }}
+   {% endif %}
+   {% endfor %}
+   {% endblock %}

--- a/doc/source/autoinherit.py
+++ b/doc/source/autoinherit.py
@@ -1,0 +1,81 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+# Custom class to patch Sphinx extension "autosummary". When applied to the
+# inherited members of a class, this patch automatically trace up to the base
+# class from which each member is inherited, and create a link to the stub
+# page of the base class' member.
+
+# See: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+
+from sphinx.ext.autosummary import Autosummary
+from sphinx.util.inspect import safe_getattr
+
+
+def trace_inherit(name, real_name):
+    # `real_name` is the full path to the member, such as:
+    #   skbio.sequence.DNA.frequencies
+    # It can be split into:
+    #   module: skbio.sequence
+    #   class: DNA
+    #   member: frequencies
+    # `member` should be identical to `name`, therefore the `name` parameter
+    # is actually redundant in this function.
+    try:
+        mod_name, cls_name, _ = real_name.rsplit(".", 2)
+    except ValueError:
+        return
+
+    # import the class which has the member
+    try:
+        module = __import__(mod_name, fromlist=[cls_name])
+        cls = safe_getattr(module, cls_name, None)
+    except ModuleNotFoundError:
+        return
+    if not hasattr(cls, name):
+        return
+
+    # Trace back the method resolution order (MRO) of the class to identify
+    # the base class that has the same member.
+    # If the member is owned by the current class (i.e., not inherited), it
+    # will return the current class.
+    origin = None
+    for base in cls.__mro__:
+        if not base.__module__.startswith("skbio."):
+            break
+        if name in base.__dict__:
+            origin = base
+            break
+    if not origin:
+        return
+
+    # Get fully qualified name of the base class, such as:
+    #   skbio.sequence.Sequence
+    # In scikit-bio, classes are implemented in files starting with `_` (e.g.,
+    # `_base.py`) but are imported in `__init__.py` of the module. Therefore,
+    # the following code converts the name below into the above:
+    #   skbio.sequence._sequence.Sequence
+    # However, if in the future this structure changes, the code needs to be
+    # modified.
+    path = origin.__module__.split(".")
+    while path and path[-1].startswith("_"):
+        del path[-1]
+
+    # Eventually, it returns:
+    #   skbio.sequence.Sequence.frequencies
+    return ".".join(path + [origin.__name__, name])
+
+
+class InheritedAutosummary(Autosummary):
+    def get_items(self, names):
+        items = super().get_items(names)
+        new_items = []
+        for name, sig, summary, real_name in items:
+            origin = trace_inherit(name, real_name)
+            new_items.append((name, sig, summary, origin or real_name))
+        return new_items

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,9 +14,11 @@
 import sys
 import inspect
 from datetime import datetime
-from os.path import relpath, dirname
+from os.path import abspath, relpath, dirname
 
 import skbio
+
+sys.path.insert(0, abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -262,3 +264,12 @@ def _closure():
 
     classproperty.__get__ = __get__
 _closure()
+
+
+# Import the patched autosummary extension to support automatic inheritance.
+
+from autoinherit import InheritedAutosummary
+
+
+def setup(app):
+    app.add_directive('autoinherit', InheritedAutosummary)

--- a/skbio/embedding/__init__.py
+++ b/skbio/embedding/__init__.py
@@ -24,6 +24,7 @@ Embedding vector types
 .. autosummary::
     :toctree: generated/
 
+    EmbeddingVector
     SequenceVector
     ProteinVector
 

--- a/skbio/io/__init__.py
+++ b/skbio/io/__init__.py
@@ -74,7 +74,7 @@ Develop custom formats
 
 
 Exceptions and warnings
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 .. currentmodule:: skbio.io
 

--- a/skbio/metadata/__init__.py
+++ b/skbio/metadata/__init__.py
@@ -40,6 +40,17 @@ Interval metadata
    Interval
    IntervalMetadata
 
+
+Abstract classes
+----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   MetadataMixin
+   PositionalMetadataMixin
+   IntervalMetadataMixin
+
 """  # noqa: D205, D415
 
 # ----------------------------------------------------------------------------
@@ -57,6 +68,11 @@ from ._metadata import (
     CategoricalMetadataColumn,
 )
 from ._interval import Interval, IntervalMetadata
+from ._mixin import (
+    MetadataMixin,
+    PositionalMetadataMixin,
+    IntervalMetadataMixin,
+)
 
 __all__ = [
     "SampleMetadata",
@@ -65,4 +81,7 @@ __all__ = [
     "CategoricalMetadataColumn",
     "Interval",
     "IntervalMetadata",
+    "MetadataMixin",
+    "PositionalMetadataMixin",
+    "IntervalMetadataMixin",
 ]

--- a/skbio/sequence/__init__.py
+++ b/skbio/sequence/__init__.py
@@ -46,6 +46,15 @@ Distance calculation
    distance
 
 
+Abstract classes
+----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   NucleotideMixin
+
+
 Tutorial
 --------
 
@@ -327,6 +336,7 @@ from ._rna import RNA
 from ._genetic_code import GeneticCode
 from ._grammared_sequence import GrammaredSequence
 from ._substitution import SubstitutionMatrix
+from ._nucleotide_mixin import NucleotideMixin
 
 __all__ = [
     "Sequence",
@@ -336,4 +346,5 @@ __all__ = [
     "GeneticCode",
     "GrammaredSequence",
     "SubstitutionMatrix",
+    "NucleotideMixin",
 ]

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -7,8 +7,9 @@ This package provides general exception/warning definitions used throughout
 scikit-bio, as well as various utility functionality, including I/O and
 unit-testing convenience functions.
 
-Testing functionality
-^^^^^^^^^^^^^^^^^^^^^
+
+Testing utilities
+-----------------
 
 Common functionality to support testing in skbio.
 
@@ -19,8 +20,18 @@ Common functionality to support testing in skbio.
    assert_ordination_results_equal
    assert_data_frame_almost_equal
 
-Miscellaneous functionality
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Plotting utilities
+------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   PlottableMixin
+
+
+Miscellaneous utilities
+-----------------------
 
 Generally useful functionality that doesn't fit in more specific locations.
 
@@ -32,14 +43,21 @@ Generally useful functionality that doesn't fit in more specific locations.
    safe_md5
    classproperty
 
+
 Developer warnings
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. autosummary::
-   :toctree: generated/
 
    EfficiencyWarning
    RepresentationWarning
+
+
+Details
+-------
+
+.. autoexception:: EfficiencyWarning
+.. autoexception:: RepresentationWarning
 
 
 """  # noqa: D412, D416, D205, D415
@@ -61,6 +79,7 @@ from ._testing import (
     pytestrunner,
 )
 from ._decorator import classproperty
+from ._plotting import PlottableMixin
 
 __all__ = [
     "SkbioWarning",
@@ -75,4 +94,5 @@ __all__ = [
     "assert_data_frame_almost_equal",
     "classproperty",
     "pytestrunner",
+    "PlottableMixin",
 ]


### PR DESCRIPTION
This PR simplified the documentation of scikit-bio. Previously, a substantial proportion of the entire documentation belonged to two categories of webpages. These pages are usually redundant or of little information. They make the navigation panel crowded and hard to navigate. They may also confuse crawlers of search engines.

1. Special methods (a.k.a., dunder methods or magic methods), such as `__eq__`, `__len__`. They were previously referred to as "built-in" in scikit-bio. Many of them are from Python, and they don't need to be documented. But some of them were explicitly implemented in scikit-bio.

2. Inherited methods, such as `DNA.frequencies`, which is inherited from `Sequence`. In the previous mechanism, all of them will have separate stub pages, causing redundancy.

This PR did two things:

1. Edited the Sphinx autosummary template file for classes, such that attributes and special methods are documented in the same page as the class, rather than having separate pages.

2. Implemented a patch of `sphinx.ext.autosummary`, which automatically traces up in the inheritance hierarchy of each class member to identify the original member of the base class. The generated documentation will link to the original member, rather than creating a redundant page of the inherited member.

After these modifications, only methods owned by each class (not inherited) will have separate stub pages. All other members (inherited ones, attributes and special methods) are merely link. This substantially simplified the documentation of scikit-bio while not removing any useful information. Actually, the documentation became more accurate, because the docstring of an original member may not precisely describe the situation of the inherited member.

This PR reduced the total number of stub pages from 1102 to 491 (44.6%). The total file size reduced from 35.6 MB to 16.8 MB.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
