### PR TITLE
Update FASTA doc to include reading multi

### DIFF
--- a/skbio/io/__init__.py
+++ b/skbio/io/__init__.py
@@ -213,6 +213,20 @@ In the procedural interface, ``format`` is required. Without it, scikit-bio does
 not know how you want to serialize an object. OO interfaces define a default
 ``format``, so it may not be necessary to include it.
 
+Streaming files with read and write
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you are working with particularly large files, streaming them might be preferable.
+Scikit-bio's ``io`` module offers the ability to contruct a streaming interface from
+the ``read`` and ``write`` functions.
+
+``skbio.io.read`` returns a generator, which can then be passed to ``skbio.io.write``
+to write only one chunk from the generator at a time.
+
+.. code-block:: python
+
+   seq_gen = skbio.io.read(big_file, format='someformat')
+   skbio.io.write(seq_gen, into=write_file, format='someformat')
+
 
 """  # noqa: D205, D415
 

--- a/skbio/io/format/fasta.py
+++ b/skbio/io/format/fasta.py
@@ -581,6 +581,60 @@ CATCGTC
 >>> new_fasta_fh.close()
 >>> new_qual_fh.close()
 
+Reading multi-FASTA Files
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Suppose you have a multi-FASTA file and want to read each sequence into a ``DNA``
+object in a list. We'll be using ``io.StringIO`` to make a mock FASTA file in
+memory.
+
+>>> from io import StringIO
+>>> import skbio
+>>> from skbio.sequence import DNA
+>>> fl = ">seq1 Turkey\n" +\
+...      "AAGCTNGGGCATTTCAGGGTGAGCCCGGGCAATACAGGGTAT\n" +\
+...      ">seq2 Salmo gair\n" +\
+...      "AAGCCTTGGCAGTGCAGGGTGAGCCGTGG\n" +\
+...      "CCGGGCACGGTAT\n" +\
+...      ">seq3 H. Sapiens\n" +\
+...      "ACCGGTTGGCCGTTCAGGGTACAGGTTGGCCGTTCAGGGTAA\n" +\
+...      ">seq4 Chimp\n" +\
+...      "AAACCCTTGCCG\n" +\
+...      "TTACGCTTAAAC\n" +\
+...      "CGAGGCCGGGAC\n" +\
+...      "ACTCAT\n" +\
+...      ">seq5 Gorilla\n" +\
+...      "AAACCCTTGCCGGTACGCTTAAACCATTGCCGGTACGCTTAA\n"
+>>> mock_fl = StringIO(fl)
+>>> res = list(skbio.io.read(mock_fl, format="fasta", constructor=DNA))
+>>> res[0]
+DNA
+------------------------------------------------
+Metadata:
+    'description': 'Turkey'
+    'id': 'seq1'
+Stats:
+    length: 42
+    has gaps: False
+    has degenerates: True
+    has definites: True
+    GC-content: 54.76%
+------------------------------------------------
+0 AAGCTNGGGC ATTTCAGGGT GAGCCCGGGC AATACAGGGT AT
+>>> res[1]
+DNA
+------------------------------------------------
+Metadata:
+    'description': 'Salmo gair'
+    'id': 'seq2'
+Stats:
+    length: 42
+    has gaps: False
+    has degenerates: False
+    has definites: True
+    GC-content: 66.67%
+------------------------------------------------
+0 AAGCCTTGGC AGTGCAGGGT GAGCCGTGGC CGGGCACGGT AT
+
 References
 ----------
 .. [1] Lipman, DJ; Pearson, WR (1985). "Rapid and sensitive protein similarity

--- a/skbio/io/format/fasta.py
+++ b/skbio/io/format/fasta.py
@@ -605,6 +605,10 @@ memory.
 ...      ">seq5 Gorilla\n" +\
 ...      "AAACCCTTGCCGGTACGCTTAAACCATTGCCGGTACGCTTAA\n"
 >>> mock_fl = StringIO(fl)
+
+The following code will read the sequences into scikit-bio. In practice, ``mock_fl``
+may be replaced with an opened file handle, or the path to the file.
+
 >>> res = list(skbio.io.read(mock_fl, format="fasta", constructor=DNA))
 >>> res[0]
 DNA


### PR DESCRIPTION
@qiyunzhu and @mortonjt this should address the documentation deficiency we discussed in the past regarding reading multi-FASTA files. Jamie, I believe you mentioned adding a line similar to this, `list(skbio.io.read(mock_fl, format="fasta", constructor=DNA))`, to any skbio object which returns a generator upon being read, which I will add to this PR if this first example looks good to each of you.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
