### PR TITLE
pathlib support for skbio.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Wrapped UPGMA and WPGMA from SciPy's linkage method ([#2094](https://github.com/scikit-bio/scikit-bio/pull/2094)).
 * Added `TreeNode.has_caches` to check if a tree has caches ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added `TreeNode.is_bifurcating` to check if a tree is bifurcating (i.e., binary) ([#2117](https://github.com/scikit-bio/scikit-bio/pull/2117)).
+* Added support for Python's `pathlib` module in the IO system. ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119))
 
 ### Performance enhancements
 

--- a/skbio/io/_iosources.py
+++ b/skbio/io/_iosources.py
@@ -11,6 +11,7 @@ import gzip
 import bz2
 import tempfile
 import itertools
+from pathlib import Path
 
 import requests
 
@@ -83,7 +84,7 @@ class Compressor(IOSource):
 
 class FilePathSource(IOSource):
     def can_read(self):
-        return isinstance(self.file, str)
+        return isinstance(self.file, (str, Path))
 
     def can_write(self):
         return self.can_read()

--- a/skbio/io/tests/test_iosources.py
+++ b/skbio/io/tests/test_iosources.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import unittest
+from pathlib import Path
 
 from skbio.io._iosources import IOSource, Compressor
 
@@ -15,27 +16,35 @@ class TestIOSource(unittest.TestCase):
 
     def setUp(self):
         self.file = 'somepath'
+        self.file_path = Path('somepath')
         self.options = {'a': 1, 'b': 2}
 
         self.source = IOSource(self.file, self.options)
+        self.source_path = IOSource(self.file_path, self.options)
 
     def test_attributes(self):
         self.assertEqual(self.source.file, self.file)
         self.assertEqual(self.source.options, self.options)
+        self.assertEqual(self.source_path.file, self.file_path)
+        self.assertEqual(self.source_path.options, self.options)
 
     def test_can_read(self):
         self.assertEqual(self.source.can_read(), False)
+        self.assertEqual(self.source_path.can_read(), False)
 
     def test_can_write(self):
         self.assertEqual(self.source.can_write(), False)
+        self.assertEqual(self.source_path.can_write(), False)
 
     def test_get_reader(self):
         with self.assertRaises(NotImplementedError):
             self.source.get_reader()
+            self.source_path.get_reader()
 
     def test_get_writer(self):
         with self.assertRaises(NotImplementedError):
             self.source.get_writer()
+            self.source_path.get_writer()
 
 
 class TestCompressor(TestIOSource):


### PR DESCRIPTION
This PR addresses issue #2058, #1983, and #1421 with an extremely simple fix to add support for Python's `pathlib` module. Based on the examples from issues #2058 and #1983, I believe this enables `skbio.io.read` and `skbio.io.write` both to handle `Path` objects. Please test rigorously as this seems almost too easy!

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
