### PR TITLE
Improving beta diversity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@
 * Added parameter `exclude_attrs` to `TreeNode.unrooted_copy` ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Allowed `shuffle` and `compare_tip_distances` of `TreeNode` to accept a random seed or random generator to generate the shuffling function, which ensures output reproducibility ([#2118](https://github.com/scikit-bio/scikit-bio/pull/2118)).
 * Added parameter `seed` to functions `lladser_pe`, `lladser_ci`, `isubsample`, `subsample_power`, `subsample_paired_power`, and `paired_subsamples` to accept a random seed or random generator to ensure output reproducibility ([#2120](https://github.com/scikit-bio/scikit-bio/pull/2120)).
+* Added beta diversity metric `jensenshannon`, which calculates Jensen-Shannon distance. Thank @quliping for suggesting this in [#2125](https://github.com/scikit-bio/scikit-bio/pull/2125).
 
 ### Bug fixes
 
 * Fixed a bug in `TreeNode.find_all` which does not look for other nodes with the same name if a `TreeNode` instance is provided, as in contrast to what the documentation claims ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Fixed a bug in `skbio.io.format.embed` which was not correctly updating the idptr sizing. ([#2100](https://github.com/scikit-bio/scikit-bio/pull/2100)).
 * Fixed a bug in `TreeNode.unrooted_move` which does not respect specified branch attributes ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
+* Fixed a bug in `skbio.diversity.get_beta_diversity_metrics` which does not display metrics other than UniFrac ([#2126](https://github.com/scikit-bio/scikit-bio/pull/2126)).
 
 ### Miscellaneous
 
@@ -41,6 +43,10 @@
 
 * Method `TreeNode.create_caches` is deprecated. It will become a private member in version 0.7.0 ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Method `TreeNode.subtree` is deprecated. It will become a private member in version 0.7.0 ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
+
+### Backward-incompatible changes
+
+* Beta diversity metric `mahalanobis` was removed. This metric requires sample number greater than feature number, which is rarely the case in omic data analysis. Thank @quliping for noting this in [#2125](https://github.com/scikit-bio/scikit-bio/pull/2125).
 
 
 ## Version 0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Fixed a bug in `skbio.io.format.embed` which was not correctly updating the idptr sizing. ([#2100](https://github.com/scikit-bio/scikit-bio/pull/2100)).
 * Fixed a bug in `TreeNode.unrooted_move` which does not respect specified branch attributes ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Fixed a bug in `skbio.diversity.get_beta_diversity_metrics` which does not display metrics other than UniFrac ([#2126](https://github.com/scikit-bio/scikit-bio/pull/2126)).
+* Raises an error when beta diversity metric `mahalanobis` is called but sample number is smaller than or equal to feature number in the data. Thank @quliping for noting this in [#2125](https://github.com/scikit-bio/scikit-bio/pull/2125).
 
 ### Miscellaneous
 
@@ -50,10 +51,6 @@
 
 * Method `TreeNode.create_caches` is deprecated. It will become a private member in version 0.7.0 ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Method `TreeNode.subtree` is deprecated. It will become a private member in version 0.7.0 ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
-
-### Backward-incompatible changes
-
-* Beta diversity metric `mahalanobis` was removed. This metric requires sample number greater than feature number, which is rarely the case in omic data analysis. Thank @quliping for noting this in [#2125](https://github.com/scikit-bio/scikit-bio/pull/2125).
 
 
 ## Version 0.6.2

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -8,7 +8,6 @@
 
 from functools import partial
 from itertools import chain
-from operator import lt
 from warnings import warn
 
 import numpy as np
@@ -460,10 +459,13 @@ def beta_diversity(
         counts = counts_by_node
     elif metric == "manhattan":
         metric = "cityblock"
-    elif metric == "mahalanobis" and lt(*counts.shape):
-        raise ValueError(
-            "Metric 'mahalanobis' requires more samples than features in the data."
-        )
+    elif metric == "mahalanobis":
+        nrow, ncol = counts.shape
+        if nrow < ncol:
+            raise ValueError(
+                "Metric 'mahalanobis' requires more samples than features. "
+                f"The input has {nrow} samples and {ncol} features."
+            )
     elif callable(metric):
         metric = partial(metric, **kwargs)
         # remove all values from kwargs, since they have already been provided

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -123,7 +123,7 @@ def get_beta_diversity_metrics():
     ``scipy.spatial.distance.pdist`` for more details.
 
     """
-    return sorted(["unweighted_unifrac", "weighted_unifrac"])
+    return sorted(_valid_beta_metrics + ["unweighted_unifrac", "weighted_unifrac"])
 
 
 def alpha_diversity(metric, counts, ids=None, validate=True, **kwargs):
@@ -338,7 +338,7 @@ _valid_beta_metrics = [
     "dice",
     "hamming",
     "jaccard",
-    "mahalanobis",
+    "jensenshannon",
     "manhattan",  # aliases to "cityblock" in beta_diversity
     "matching",
     "minkowski",

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -436,7 +436,7 @@ class BetaDiversityTests(TestCase):
                            tree=self.tree1)
 
     def test_invalid_input_mahalanobis(self):
-        error_msg = (r"requires more samples than features in the data")
+        error_msg = (r"requires more samples than features")
         with self.assertRaisesRegex(ValueError, error_msg):
             beta_diversity('mahalanobis', self.table2)
 

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -435,6 +435,11 @@ class BetaDiversityTests(TestCase):
             beta_diversity(weighted_unifrac, example_table, taxa=['foo', 'bar'],
                            tree=self.tree1)
 
+    def test_invalid_input_mahalanobis(self):
+        error_msg = (r"requires more samples than features in the data")
+        with self.assertRaisesRegex(ValueError, error_msg):
+            beta_diversity('mahalanobis', self.table2)
+
     def test_invalid_input_phylogenetic(self):
         # taxa not provided
         self.assertRaises(ValueError, beta_diversity, 'weighted_unifrac',


### PR DESCRIPTION
Thank you @quliping for doing a comprehensive and critical assessment of skbio's beta diversity functionality #2125 . This PR addresses your comments by:

- Removing `mahalanobis` metric because it requires more samples than features, which is rarely the case in omic data analysis.
- Adding `jensenshannon` metric because it is a valid and commonly used beta diversity metric. Addressing #1541.
- Continuing to exclude `kulczynski1` metric based on the rationale in #1887.
- Letting `get_beta_diversity_metrics` display all metrics, not just UniFrac.

@ebolyen I want to bring this to your attention because it may impact q2-diversity's functionality.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
