### PR TITLE
Make IO registry sniffer only sniff relevant formats for a given skbio object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * Added parameter `exclude_attrs` to `TreeNode.unrooted_copy` ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Allowed `shuffle` and `compare_tip_distances` of `TreeNode` to accept a random seed or random generator to generate the shuffling function, which ensures output reproducibility ([#2118](https://github.com/scikit-bio/scikit-bio/pull/2118)).
 * Added parameter `seed` to functions `lladser_pe`, `lladser_ci`, `isubsample`, `subsample_power`, `subsample_paired_power`, and `paired_subsamples` to accept a random seed or random generator to ensure output reproducibility ([#2120](https://github.com/scikit-bio/scikit-bio/pull/2120)).
+* Made the `IORegistry` sniffer only attempt file formats which are logical given a specific object
+to be read into ([#2128](https://github.com/scikit-bio/scikit-bio/pull/2128))
 
 ### Bug fixes
 

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -399,9 +399,9 @@ class IORegistry:
             # BufferedReader which has already been iterated over (via next()).
             matches = []
             backup = fh.tell()
-            text_lookup = self._text_formats
-            bin_lookup = self._binary_formats
+
             if is_binary_file and kwargs.get("encoding", "binary") == "binary":
+                bin_lookup = self._binary_formats
                 if into is not None:
                     bin_lookup = self._reduce_formats(bin_lookup, into)
                 matches = self._find_matches(fh, bin_lookup, **kwargs)
@@ -409,6 +409,7 @@ class IORegistry:
             if kwargs.get("encoding", None) != "binary":
                 # We can always turn a binary file into a text file, but the
                 # reverse doesn't make sense.
+                text_lookup = self._text_formats
                 if into is not None:
                     text_lookup = self._reduce_formats(text_lookup, into)
                 matches += self._find_matches(fh, text_lookup, **kwargs)
@@ -431,10 +432,7 @@ class IORegistry:
     def _reduce_formats(self, lookup, into):
         # Reduce possible formats to only those which make sense for the given object.
         pos_fmts = self.list_read_formats(into)
-        new_lookup = {
-            key: fmt for key, fmt in lookup.copy().items() if fmt.name in pos_fmts
-        }
-        return new_lookup
+        return {k: v for k, v in lookup.items() if k in pos_fmts}
 
     def _find_matches(self, file, lookup, **kwargs):
         matches = []


### PR DESCRIPTION
This PR partially addresses issue #2059 by making the IO registry sniffer only try formats which make sense for a given skbio object passed to the `into` parameter of `skbio.read`.

For example, if a user is trying to read a file into a `TreeNode` object, it doesn't make sense for the sniffer to check if the file is FASTA format or any other format which cannot represent a tree.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
