### PR TITLE
Exposed `get_rng` in documentation

### DIFF
--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -38,6 +38,7 @@ Generally useful functionality that doesn't fit in more specific locations.
 .. autosummary::
    :toctree: generated/
 
+   get_rng
    cardinal_to_ordinal
    find_duplicates
    safe_md5


### PR DESCRIPTION
This is a very minor issue that I overlooked recently. @mataton Feel free to directly merge if it looks good to you. Thanks!

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
