### PR TITLE
Optimized `TreeNode.ancestors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@
 * Wrapped UPGMA and WPGMA from SciPy's linkage method ([#2094](https://github.com/scikit-bio/scikit-bio/pull/2094)).
 * Added `TreeNode.has_caches` to check if a tree has caches ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added `TreeNode.is_bifurcating` to check if a tree is bifurcating (i.e., binary) ([#2117](https://github.com/scikit-bio/scikit-bio/pull/2117)).
-* Added support for Python's `pathlib` module in the IO system. ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119))
-* Added Balanced Minimum Evolution (BME) function and `balanced` option for NNI ([#2105](https://github.com/scikit-bio/scikit-bio/pull/2105))
-* Added path function to `TreeNode`. ([#2131](https://github.com/scikit-bio/scikit-bio/pull/2131))
+* Added support for Python's `pathlib` module in the IO system ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119)).
+* Added Balanced Minimum Evolution (BME) function and `balanced` option for NNI ([#2105](https://github.com/scikit-bio/scikit-bio/pull/2105)).
+* Added `TreeNode.path` to return a list of nodes representing the path from one node to another ([#2131](https://github.com/scikit-bio/scikit-bio/pull/2131)).
 
 ### Performance enhancements
 
 * Improved the performance of `TreeNode.lowest_common_ancestor` ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
-* Improved the performance of the `siblings` and `neighbors` of `TreeNode` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133)).
+* Improved the performance of `TreeNode` methods: `ancestors`, `siblings`, and `neighbors` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133), [#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).
 * Improved the performance of tree copying ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Further improved the caching mechanism of `TreeNode`. Specifically: 1. Node attribute caches are only registered at the root node, which improves memory efficiency. 2. Method `clear_caches` can be customized to clear node attribute and/or lookup caches, or specified attribute caches ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)). 3. Added parameter `uncache` to multiple methods that involves tree manipulation. Default is True. When one knows that caches are not present or relevant, one may set this parameter as False to skip cache clearing to significantly improve performance ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
@@ -26,6 +26,7 @@
 * Added parameter `exclude_attrs` to `TreeNode.unrooted_copy` ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added support for legacy random generator to `get_rng`, such that outputs of scikit-bio functions become reproducible with code that starts with `np.random.seed` or uses `RandomState` ([#2130](https://github.com/scikit-bio/scikit-bio/pull/2130)).
 * Allowed `shuffle` and `compare_tip_distances` of `TreeNode` to accept a random seed or random generator to generate the shuffling function, which ensures output reproducibility ([#2118](https://github.com/scikit-bio/scikit-bio/pull/2118)).
+* Added parameter `include_self` to `TreeNode.ancestors` to optionally include the initial node in the path (default: False) ([#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Added parameter `seed` to functions `pcoa`, `anosim`, `permanova`, `permdisp`, `randdm`, `lladser_pe`, `lladser_ci`, `isubsample`, `subsample_power`, `subsample_paired_power`, `paired_subsamples` and `hommola_cospeciation` to accept a random seed or random generator to ensure output reproducibility ([#2120](https://github.com/scikit-bio/scikit-bio/pull/2120) and [#2129](https://github.com/scikit-bio/scikit-bio/pull/2129)).
 * Made the `IORegistry` sniffer only attempt file formats which are logical given a specific object, thus improving reading efficiency.
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -460,7 +460,7 @@ class TreeNode(SkbioObject):
             curr = curr.parent
         return curr
 
-    def ancestors(self):
+    def ancestors(self, include_self=False):
         r"""Return all ancestors from self back to the root.
 
         This call will return all nodes in the path back to root, but does not
@@ -469,7 +469,9 @@ class TreeNode(SkbioObject):
         Returns
         -------
         list of TreeNode
-            The path, toward the root, from self
+            The path, toward the root, from self.
+        include_self : bool, optional
+            Whether to include the initial node in the path (default: False).
 
         Examples
         --------
@@ -479,10 +481,11 @@ class TreeNode(SkbioObject):
         ['c', 'root']
 
         """
-        result = []
         curr = self
-        while not curr.is_root():
-            result.append((curr := curr.parent))
+        result = [curr] if include_self else []
+        result_append = result.append
+        while (curr := curr.parent) is not None:
+            result_append(curr)
         return result
 
     def siblings(self):

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -461,10 +461,7 @@ class TreeNode(SkbioObject):
         return curr
 
     def ancestors(self, include_self=False):
-        r"""Return all ancestors from self back to the root.
-
-        This call will return all nodes in the path back to root, but does not
-        include the node instance that the call was made from.
+        r"""Return all ancestral nodes from self back to the root.
 
         Returns
         -------
@@ -476,9 +473,20 @@ class TreeNode(SkbioObject):
         Examples
         --------
         >>> from skbio import TreeNode
-        >>> tree = TreeNode.read(["((a,b)c,(d,e)f)root;"])
-        >>> [node.name for node in tree.find('a').ancestors()]
-        ['c', 'root']
+        >>> tree = TreeNode.read(["((a,b)c,(d,e)f)g;"])
+        >>> print(tree.ascii_art())
+                            /-a
+                  /c-------|
+                 |          \-b
+        -g-------|
+                 |          /-d
+                  \f-------|
+                            \-e
+        >>> tip = tree.find('a')
+        >>> [node.name for node in tip.ancestors()]
+        ['c', 'g']
+        >>> [node.name for node in tip.ancestors(include_self=True)]
+        ['a', 'c', 'g']
 
         """
         curr = self

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -188,6 +188,10 @@ class TreeTests(TestCase):
         obs = self.simple_t.children[0].children[0].ancestors()
         self.assertEqual([o.name for o in obs], exp)
 
+        exp = ["a", "i1", "root"]
+        obs = self.simple_t.children[0].children[0].ancestors(include_self=True)
+        self.assertEqual([o.name for o in obs], exp)
+
         exp = ["root"]
         obs = self.simple_t.children[0].ancestors()
         self.assertEqual([o.name for o in obs], exp)


### PR DESCRIPTION
This PR adds parameter `include_self` to `TreeNode.ancestors` to optionally include the initial node in the path (default: False). This logic is consistent with the newly added `path`, which has `include_ends`. With this parameter, one can easily generate a lineage from any taxon to the root.

@christapo I guess this addition can also make `path` simpler. What do you think?

This PR also improved the performance of `ancestors`. In my benchmarks:

Before: 40.3 ms ± 565 μs
After: 21.8 ms ± 194 μs
After (with `include_self=True`): 22.1 ms ± 278 μs

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
