### PR TITLE
Improved topological analysis and comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Implemented linear mixed effects with Dirichlet-multinomial distribution ([#2113](https://github.com/scikit-bio/scikit-bio/pull/2113)).
 * Wrapped UPGMA and WPGMA from SciPy's linkage method ([#2094](https://github.com/scikit-bio/scikit-bio/pull/2094)).
+* Added `TreeNode` methods: `bipartition`, `bipartitions` and `compare_bipartitions` to retrieve and compare bipartitions in a tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Added `TreeNode.has_caches` to check if a tree has caches ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added `TreeNode.is_bifurcating` to check if a tree is bifurcating (i.e., binary) ([#2117](https://github.com/scikit-bio/scikit-bio/pull/2117)).
 * Added support for Python's `pathlib` module in the IO system ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119)).
@@ -14,6 +15,9 @@
 
 ### Performance enhancements
 
+* Supported Robinson-Foulds distance calculation (`TreeNode.compare_rfd`) based on bipartitions (equivalent to `compare_bipartitions`). This is automatically enabled when the input tree is unrooted. Otherwise the calculation is still based on subsets (equivalent to `compare_subsets`). The user can override this behavior using the `rooted` parameter ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Re-wrote the underlying algorithm of `TreeNode.compare_subsets` because it is equivalent to the Robinson-Foulds distance on rooted trees. Added parameter `proportion`. Renamed parameter `exclude_absent_taxa` as `shared_only` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Added parameter `include_self` to `TreeNode.subset`. Added parameters `within`, `include_full` and `include_singles` to `TreeNode.subsets` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Improved the performance of `TreeNode.lowest_common_ancestor` ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Improved the performance of `TreeNode` methods: `ancestors`, `siblings`, and `neighbors` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133), [#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).
@@ -33,6 +37,8 @@
 
 ### Bug fixes
 
+* Fixed an issue in `TreeNode.subsets` which left a remnant attribute at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Fixed a bug in `TreeNode.compare_rfd` which raised an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.lowest_common_ancestor` which returns the parent of input node X instead of X itself if X is ancestral to other input nodes ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Fixed a bug in `TreeNode.find_all` which does not look for other nodes with the same name if a `TreeNode` instance is provided, as in contrast to what the documentation claims ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Fixed a bug in `skbio.io.format.embed` which was not correctly updating the idptr sizing. ([#2100](https://github.com/scikit-bio/scikit-bio/pull/2100)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Bug fixes
 
+* Fixed a bug in `TreeNode.get_max_distance` which returns tip names instead of tip instances when there are single-child nodes in the tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed an issue in `subsets` and `tip_tip_distances` of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.compare_rfd` which raises an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.lowest_common_ancestor` which returns the parent of input node X instead of X itself if X is ancestral to other input nodes ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Fixed a bug in `TreeNode.get_max_distance` which returns tip names instead of tip instances when there are single-child nodes in the tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed an issue in `subsets` and `tip_tip_distances` of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.compare_rfd` which raises an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Fixed a bug in `TreeNode.compare_subsets` which includes the full set (not a subset) of shared taxa between two trees if a basal clade of either tree consists of entirely unshared taxa ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.lowest_common_ancestor` which returns the parent of input node X instead of X itself if X is ancestral to other input nodes ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Fixed a bug in `TreeNode.find_all` which does not look for other nodes with the same name if a `TreeNode` instance is provided, as in contrast to what the documentation claims ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Fixed a bug in `skbio.io.format.embed` which was not correctly updating the idptr sizing. ([#2100](https://github.com/scikit-bio/scikit-bio/pull/2100)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Features
 
 * Implemented linear mixed effects with Dirichlet-multinomial distribution ([#2113](https://github.com/scikit-bio/scikit-bio/pull/2113)).
+* Added `TreeNode.compare_wrfd` to calculate the weighted Robinson-Foulds distance or its variants between two trees ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Wrapped UPGMA and WPGMA from SciPy's linkage method ([#2094](https://github.com/scikit-bio/scikit-bio/pull/2094)).
-* Added `TreeNode` methods: `bipartition`, `bipartitions` and `compare_bipartitions` to retrieve and compare bipartitions in a tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Added `TreeNode` methods: `bipart`, `biparts` and `compare_biparts` to encode and compare bipartitions in a tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Added `TreeNode.has_caches` to check if a tree has caches ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added `TreeNode.is_bifurcating` to check if a tree is bifurcating (i.e., binary) ([#2117](https://github.com/scikit-bio/scikit-bio/pull/2117)).
 * Added support for Python's `pathlib` module in the IO system ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119)).
@@ -16,9 +17,9 @@
 
 ### Performance enhancements
 
-* Supported Robinson-Foulds distance calculation (`TreeNode.compare_rfd`) based on bipartitions (equivalent to `compare_bipartitions`). This is automatically enabled when the input tree is unrooted. Otherwise the calculation is still based on subsets (equivalent to `compare_subsets`). The user can override this behavior using the `rooted` parameter ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Supported Robinson-Foulds distance calculation (`TreeNode.compare_rfd`) based on bipartitions (equivalent to `compare_biparts`). This is automatically enabled when the input tree is unrooted. Otherwise the calculation is still based on subsets (equivalent to `compare_subsets`). The user can override this behavior using the `rooted` parameter ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Re-wrote the underlying algorithm of `TreeNode.compare_subsets` because it is equivalent to the Robinson-Foulds distance on rooted trees. Added parameter `proportion`. Renamed parameter `exclude_absent_taxa` as `shared_only` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
-* Added parameter `include_self` to `TreeNode.subset`. Added parameters `within`, `include_full` and `include_singles` to `TreeNode.subsets` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Added parameter `include_self` to `TreeNode.subset`. Added parameters `within`, `include_full` and `include_single` to `TreeNode.subsets` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Improved the performance of `TreeNode.lowest_common_ancestor` ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Improved the performance of `TreeNode` methods: `ancestors`, `siblings`, and `neighbors` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133), [#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).
@@ -126,6 +127,7 @@
 * Removed hdmedians as a dependency by porting its `geomedian` function (geometric median) into scikit-bio ([#2003](https://github.com/scikit-bio/scikit-bio/pull/2003)).
 * Removed 98% warnings issued during the test process ([#2045](https://github.com/scikit-bio/scikit-bio/pull/2045) and [#2037](https://github.com/scikit-bio/scikit-bio/pull/2037)).
 
+
 ## Version 0.6.0
 
 ### Performance enhancements
@@ -185,6 +187,7 @@
 * Incorporated Ruff's formatting and linting via pre-commit hooks and GitHub Actions. See PR [#1924](https://github.com/scikit-bio/scikit-bio/pull/1924).
 * Improved docstrings for functions accross the entire codebase. See [#1933](https://github.com/scikit-bio/scikit-bio/pull/1933) and [#1940](https://github.com/scikit-bio/scikit-bio/pull/1940)
 * Removed API lifecycle decorators in favor of deprecation warnings. See [#1916](https://github.com/scikit-bio/scikit-bio/issues/1916)
+
 
 ## Version 0.5.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
 
 ### Bug fixes
 
-* Fixed an issue in `TreeNode.subsets` which left a remnant attribute at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
-* Fixed a bug in `TreeNode.compare_rfd` which raised an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Fixed an issue in `subsets` and `tip_tip_distances` of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Fixed a bug in `TreeNode.compare_rfd` which raises an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.lowest_common_ancestor` which returns the parent of input node X instead of X itself if X is ancestral to other input nodes ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Fixed a bug in `TreeNode.find_all` which does not look for other nodes with the same name if a `TreeNode` instance is provided, as in contrast to what the documentation claims ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Fixed a bug in `skbio.io.format.embed` which was not correctly updating the idptr sizing. ([#2100](https://github.com/scikit-bio/scikit-bio/pull/2100)).

--- a/doc/source/_templates/TreeNode.rst
+++ b/doc/source/_templates/TreeNode.rst
@@ -107,6 +107,8 @@
       ~{{ name }}.count
       ~{{ name }}.subset
       ~{{ name }}.subsets
+      ~{{ name }}.bipartition
+      ~{{ name }}.bipartitions
       ~{{ name }}.assign_supports
       ~{{ name }}.is_bifurcating
       ~{{ name }}.observed_node_counts
@@ -117,6 +119,7 @@
       ~{{ name }}.tip_tip_distances
       ~{{ name }}.compare_rfd
       ~{{ name }}.compare_subsets
+      ~{{ name }}.compare_bipartitions
       ~{{ name }}.compare_tip_distances
 
    .. rubric:: Tree visualization

--- a/doc/source/_templates/TreeNode.rst
+++ b/doc/source/_templates/TreeNode.rst
@@ -107,8 +107,8 @@
       ~{{ name }}.count
       ~{{ name }}.subset
       ~{{ name }}.subsets
-      ~{{ name }}.bipartition
-      ~{{ name }}.bipartitions
+      ~{{ name }}.bipart
+      ~{{ name }}.biparts
       ~{{ name }}.assign_supports
       ~{{ name }}.is_bifurcating
       ~{{ name }}.observed_node_counts
@@ -118,8 +118,9 @@
       ~{{ name }}.get_max_distance
       ~{{ name }}.tip_tip_distances
       ~{{ name }}.compare_rfd
+      ~{{ name }}.compare_wrfd
       ~{{ name }}.compare_subsets
-      ~{{ name }}.compare_bipartitions
+      ~{{ name }}.compare_biparts
       ~{{ name }}.compare_tip_distances
 
    .. rubric:: Tree visualization

--- a/skbio/tree/__init__.py
+++ b/skbio/tree/__init__.py
@@ -155,7 +155,7 @@ indicates the trees do not share any common clades:
 >>> print(tree1.compare_subsets(tree2))  # same tree but different clade order
 0.0
 >>> print(tree1.compare_subsets(tree3))  # only 1 of 3 common subsets
-0.6666666666666667
+0.6666666666666666
 
 We can additionally take into account branch length when computing distances
 between trees. First, we're going to construct two new trees with described

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -31,30 +31,6 @@ from skbio.util._warning import _warn_deprecated
 from skbio.io.registry import Read, Write
 
 
-def distance_from_r(m1, m2):
-    r"""Estimate distance as (1-r)/2: neg correl = max distance.
-
-    .. deprecated:: 0.6.3
-        This function will become a private member in version 0.7.0. It has never
-        been exposed in the documentation, and it has a very specific usage in this
-        module.
-
-    Parameters
-    ----------
-    m1 : DistanceMatrix
-        First distance matrix to compare.
-    m2 : DistanceMatrix
-        Second distance matrix to compare.
-
-    Returns
-    -------
-    float
-        The distance between m1 and m2.
-
-    """
-    return spdist.correlation(m1.data.flat, m2.data.flat) / 2
-
-
 # ----------------------------------------------------------------------------
 # Important note: The TreeNode class has a large number of methods. They are
 # organized under several categories, which are defined in this script as well
@@ -3865,7 +3841,7 @@ class TreeNode(SkbioObject):
             )
 
     def distance(self, other, use_length=True, missing_as_zero=False):
-        """Calculate the distance between self and another node.
+        r"""Calculate the distance between self and another node.
 
         Parameters
         ----------
@@ -3879,7 +3855,8 @@ class TreeNode(SkbioObject):
 
         missing_as_zero : bool, optional
             When a node without an associated branch length is encountered, raise an
-            error (False, default) or use 0 (True). Applicable when `length` is True.
+            error (False, default) or use 0 (True). Applicable when ``use_length`` is
+            True.
 
             .. versionadded:: 0.6.3
 
@@ -4401,11 +4378,11 @@ class TreeNode(SkbioObject):
         The Robinson-Foulds (RF) distance, a.k.a. symmetric difference, is a measure of
         topological dissimilarity between two trees. It was originally described in
         [1]_. It is calculated as the number of bipartitions that differ between two
-        unrooted trees. It is equivalent to :meth:`compare_bipartitions`.
+        unrooted trees. It is equivalent to :meth:`compare_biparts`.
 
         .. math::
 
-           RF(T_1, T_2) = |S_1 \triangle S_2| = |(S_1 \setminus S_2) \cup (S_2
+           \text{RF}(T_1, T_2) = |S_1 \triangle S_2| = |(S_1 \setminus S_2) \cup (S_2
            \setminus S_1)|
 
         where :math:`S_1` and :math:`S_2` are the sets of bipartitions of trees
@@ -4514,7 +4491,7 @@ class TreeNode(SkbioObject):
         rooted : bool, optional
             Whether to consider the trees as rooted or unrooted. If None (default),
             this will be determined based on whether self is rooted. However, one
-            can override it by explicitly specifying True (rooted) or False (unrooted).
+            can override it by explicitly setting True (rooted) or False (unrooted).
             See :meth:`compare_rfd` for details.
         include_single : bool, optional
             Whether to include single-taxon biparitions (terminal branches) in the
@@ -4540,7 +4517,7 @@ class TreeNode(SkbioObject):
 
         .. math::
 
-           wRF(T_1, T_2) = \sum_{s \in S_1 \cup S_2} |l_1(s) - l_2(s)|
+           \text{wRF}(T_1, T_2) = \sum_{s \in S_1 \cup S_2} |l_1(s) - l_2(s)|
 
         where :math:`S_1` and :math:`S_2` are the sets of bipartitions of trees
         :math:`T_1` and :math:`T_2`, respectively. :math:`l_1` and :math:`l_2` are the
@@ -4553,7 +4530,7 @@ class TreeNode(SkbioObject):
 
         .. math::
 
-           KF(T_1, T_2) = \sqrt{\sum_{s \in S_1 \cup S_2} (l_1(s) - l_2(s))^2}
+           \text{KF}(T_1, T_2) = \sqrt{\sum_{s \in S_1 \cup S_2} (l_1(s) - l_2(s))^2}
 
         Only taxa shared between the two trees are considered. Taxa unique to either
         tree are excluded from the calculation.

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -3381,6 +3381,8 @@ class TreeNode(SkbioObject):
         if (size := len(bipart)) > (th := len(full) * 0.5):
             bipart = full - bipart
         elif size == th:
+            # sort the elements of each part by lexicographic order, then order the two
+            # parts and pick the smaller part
             bipart, _ = sorted([bipart, full - bipart], key=sorted)
         return bipart
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -4284,6 +4284,9 @@ class TreeNode(SkbioObject):
         proportion : bool, optional
             Whether to return count (False) or proportion (True, default) of different
             subsets.
+
+            .. versionadded:: 0.6.3
+
         symmetric : bool, optional
             Whether to calculate the symmetric difference between self and other (True,
             default), or only the difference from self to other (False).
@@ -4294,16 +4297,10 @@ class TreeNode(SkbioObject):
             Alias of ``shared_only`` for backward compatibility. Deprecated and to be
             removed in a future release.
 
-            .. deprecated:: 0.6.3
-
         Returns
         -------
         int or float
             The count or proportion of subsets that differ between the trees.
-
-        .. versionchanged:: 0.6.3
-            The algorithm is now identical to that of :meth:`compare_rfd` for rooted
-            trees.
 
         See Also
         --------

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -4235,7 +4235,7 @@ class TreeNode(SkbioObject):
 
         # branch length weighted (vector distance)
         else:
-            union = frozenset(sets1.keys()).union(sets2.keys())
+            union = frozenset(sets1).union(sets2)
             L1 = [sets1.get(x, 0) for x in union]
             L2 = [sets2.get(x, 0) for x in union]
             if isinstance(metric, str):

--- a/skbio/tree/tests/test_bme.py
+++ b/skbio/tree/tests/test_bme.py
@@ -175,7 +175,7 @@ class BmeTests(TestCase):
         _bal_ols_edge(actual_TreeNode, dm)
         expected_TreeNode = TreeNode.read(io.StringIO(expected_str))
         self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
-            expected_TreeNode), 1, places=10)
+            expected_TreeNode), 0.0, places=10)
 
 if __name__ == "__main__":
     main()

--- a/skbio/tree/tests/test_gme.py
+++ b/skbio/tree/tests/test_gme.py
@@ -246,7 +246,7 @@ class GmeTests(TestCase):
         _ols_edge(actual_TreeNode, dm)
         expected_TreeNode = TreeNode.read(io.StringIO(expected_str))
         self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
-            expected_TreeNode), 1, places=10)
+            expected_TreeNode), 0.0, places=10)
 
 if __name__ == "__main__":
     main()

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1865,7 +1865,7 @@ class TreeTests(TestCase):
         self.assertEqual([n.MaxDistTips for n in t.postorder()], exp)
 
     def test_tip_tip_distances_endpoints(self):
-        """Test getting specifc tip distances  with tipToTipDistances"""
+        """Test getting specifc tip distances with tipToTipDistances"""
         t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
         nodes = [t.find("H"), t.find("G"), t.find("M")]
         names = ["H", "G", "M"]
@@ -1878,6 +1878,10 @@ class TreeTests(TestCase):
 
         obs = t.tip_tip_distances(endpoints=nodes)
         self.assertEqual(obs, exp)
+
+        for node in t.traverse(include_self=True):
+            assert not hasattr(node, '_start')
+            assert not hasattr(node, '_stop')
 
     def test_tip_tip_distances_non_tip_endpoints(self):
         t = TreeNode.read(["((H:1,G:1)foo:2,(R:0.5,M:0.7):3);"])

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1508,6 +1508,11 @@ class TreeTests(TestCase):
         self.assertDictEqual(t.subsets(map_to_length=True), {
             frozenset("ab"): 0, frozenset("de"): 2, frozenset("def"): 1})
 
+        # when a basal taxon is excluded
+        t = TreeNode.read(['(((a,b),(c,d)),e);'])
+        self.assertSetEqual(t.subsets(within="abcd"), frozenset(
+            [frozenset("ab"), frozenset("cd")]))
+
     def test_bipart(self):
         """Return a set of tip names on the smaller side of the branch."""
         t = self.complex_tree
@@ -1599,6 +1604,11 @@ class TreeTests(TestCase):
         t.children[0].length = None
         self.assertDictEqual(t.biparts(map_to_length=True), {
             frozenset("ab"): 1, frozenset("de"): 2, frozenset("abc"): 2})
+
+        # when a basal taxon is excluded
+        t = TreeNode.read(['(((a,b),(c,d)),e);'])
+        self.assertSetEqual(t.biparts(within="abcd"), frozenset(
+            [frozenset("ab")]))
 
     def test_assign_supports(self):
         """Extract support values of internal nodes."""
@@ -2005,6 +2015,10 @@ class TreeTests(TestCase):
         self.assertEqual(t1.compare_rfd(t2), 8)
         self.assertEqual(t1.compare_rfd(t2, rooted=False), 6)
 
+        c1, c2 = t1.children[0], t2.children[0]
+        self.assertEqual(c1.compare_rfd(c2), 2)
+        self.assertEqual(c1.compare_rfd(c2, rooted=False), 0)
+
     def test_compare_wrfd(self):
         """Return weighted Robinson-Foulds distance or variants."""
         t1 = TreeNode.read(["((a:1,b:2):1,c:4,((d:4,e:5):2,f:6):1);"])
@@ -2063,7 +2077,7 @@ class TreeTests(TestCase):
         self.assertEqual(result, 3)
 
         result = t.compare_subsets(t4, shared_only=True)
-        self.assertAlmostEqual(result, 1 / 3)
+        self.assertEqual(result, 0)
 
         result = t.compare_subsets(t4, symmetric=False)
         self.assertEqual(result, 0.5)

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1993,6 +1993,12 @@ class TreeTests(TestCase):
         self.assertEqual(t1.compare_rfd(t2), 4)
         self.assertEqual(t1.compare_rfd(t2, rooted=True), 6)
 
+        # make self a subtree (therefore rooted)
+        t1.parent = TreeNode("x")
+        self.assertEqual(t1.compare_rfd(t2), 6)
+        self.assertEqual(t1.compare_rfd(t2, rooted=False), 4)
+        t1.parent = None
+
         # with polytomy
         t1 = TreeNode.read(["((a,b,(c,d)),((e,f),(g,h),i));"])
         t2 = TreeNode.read(["((((a,b),c,d),e),((f,g,h),i));"])
@@ -2021,6 +2027,11 @@ class TreeTests(TestCase):
         self.assertAlmostEqual(t1.compare_wrfd(t2, rooted=True), 18)
         self.assertAlmostEqual(
             t1.compare_wrfd(t2, metric="euclidean", rooted=True), 6.6332496)
+
+        # make self a subtree, therefore it is considered as rooted
+        t1.parent = TreeNode("x")
+        self.assertAlmostEqual(t1.compare_wrfd(t2), 18)
+        t1.parent = None
 
         # correlation distance
         self.assertAlmostEqual(t1.compare_wrfd(t2, metric="correlation"), 0.3164447)

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1776,8 +1776,8 @@ class TreeTests(TestCase):
             "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
         sdbl = tr.descending_branch_length(["A", "E"])
-        npt.assert_almost_equal(tdbl, 8.9)
-        npt.assert_almost_equal(sdbl, 2.2)
+        self.assertAlmostEqual(tdbl, 8.9)
+        self.assertAlmostEqual(sdbl, 2.2)
         self.assertRaises(ValueError, tr.descending_branch_length,
                           ["A", "DNE"])
         self.assertRaises(ValueError, tr.descending_branch_length, ["A", "C"])
@@ -1785,35 +1785,35 @@ class TreeTests(TestCase):
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
-        npt.assert_almost_equal(tdbl, 8.8)
+        self.assertAlmostEqual(tdbl, 8.8)
 
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length()
-        npt.assert_almost_equal(tdbl, 7.9)
+        self.assertAlmostEqual(tdbl, 7.9)
 
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length(["A", "D", "E"])
-        npt.assert_almost_equal(tdbl, 2.1)
+        self.assertAlmostEqual(tdbl, 2.1)
 
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tdbl = tr.descending_branch_length(["I", "D", "E"])
-        npt.assert_almost_equal(tdbl, 6.6)
+        self.assertAlmostEqual(tdbl, 6.6)
 
         # test with a situation where we have unnamed internal nodes
         tr = TreeNode.read([
             "(((A,B:1.2):.6,(D:.9,E:.6)F):2.4,(H:.4,I:.5)J:1.3);"])
         tdbl = tr.descending_branch_length()
-        npt.assert_almost_equal(tdbl, 7.9)
+        self.assertAlmostEqual(tdbl, 7.9)
 
         # issue 1847
         tr = TreeNode.read([
             "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tr.length = 1
         tdbl = tr.descending_branch_length()
-        npt.assert_almost_equal(tdbl, 8.9)
+        self.assertAlmostEqual(tdbl, 8.9)
 
     def test_distance_nontip(self):
         # example derived from issue #807, credit @wwood
@@ -1826,24 +1826,24 @@ class TreeTests(TestCase):
         t = TreeNode.read(["((a:0.1,b:0.2)c:0.3,(d:0.4,e)f:0.5)root;"])
         tips = sorted([n for n in t.tips()], key=lambda x: x.name)
 
-        npt.assert_almost_equal(tips[0].distance(tips[0]), 0.0)
-        npt.assert_almost_equal(tips[0].distance(tips[1]), 0.3)
-        npt.assert_almost_equal(tips[0].distance(tips[2]), 1.3)
+        self.assertAlmostEqual(tips[0].distance(tips[0]), 0.0)
+        self.assertAlmostEqual(tips[0].distance(tips[1]), 0.3)
+        self.assertAlmostEqual(tips[0].distance(tips[2]), 1.3)
         with self.assertRaises(NoLengthError):
             tips[0].distance(tips[3])
 
-        npt.assert_almost_equal(
+        self.assertAlmostEqual(
             tips[0].distance(tips[3], missing_as_zero=True), 0.9)
 
-        npt.assert_almost_equal(tips[1].distance(tips[0]), 0.3)
-        npt.assert_almost_equal(tips[1].distance(tips[1]), 0.0)
-        npt.assert_almost_equal(tips[1].distance(tips[2]), 1.4)
+        self.assertAlmostEqual(tips[1].distance(tips[0]), 0.3)
+        self.assertAlmostEqual(tips[1].distance(tips[1]), 0.0)
+        self.assertAlmostEqual(tips[1].distance(tips[2]), 1.4)
         with self.assertRaises(NoLengthError):
             tips[1].distance(tips[3])
 
-        self.assertEqual(tips[2].distance(tips[0]), 1.3)
-        self.assertEqual(tips[2].distance(tips[1]), 1.4)
-        self.assertEqual(tips[2].distance(tips[2]), 0.0)
+        self.assertAlmostEqual(tips[2].distance(tips[0]), 1.3)
+        self.assertAlmostEqual(tips[2].distance(tips[1]), 1.4)
+        self.assertAlmostEqual(tips[2].distance(tips[2]), 0.0)
         with self.assertRaises(NoLengthError):
             tips[2].distance(tips[3])
 
@@ -1873,7 +1873,7 @@ class TreeTests(TestCase):
         tree = TreeNode.read([
             "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"])
         dist, nodes = tree.get_max_distance()
-        npt.assert_almost_equal(dist, 1.6)
+        self.assertAlmostEqual(dist, 1.6)
         self.assertListEqual([n.name for n in nodes], ["e", "b"])
 
         # number of branches
@@ -1884,7 +1884,7 @@ class TreeTests(TestCase):
         # tree with a single-child node and missing lengths
         tree = TreeNode.read(["((a:1,b:2),c:4,(((d:4,e:5):2):3,f:6));"])
         dist, nodes = tree.get_max_distance()
-        npt.assert_almost_equal(dist, 16)
+        self.assertAlmostEqual(dist, 16)
         self.assertListEqual([n.name for n in nodes], ["e", "f"])
 
         dist, nodes = tree.get_max_distance(use_length=False)
@@ -1952,8 +1952,6 @@ class TreeTests(TestCase):
 
         t_dm = npt.assert_warns(RepresentationWarning, t.tip_tip_distances)
         self.assertEqual(t_dm, exp_t_dm)
-
-
 
     def test_compare_rfd(self):
         """Return Robinson-Foulds distance."""

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -59,6 +59,25 @@ class TreeTests(TestCase):
 
         self.complex_tree = TreeNode.read([
             "(((a,b)int1,(x,y,(w,z)int2,(c,d)int3)int4),(e,f)int5);"])
+        #                               /-a
+        #                     /int1----|
+        #                    |          \-b
+        #                    |
+        #           /--------|          /-x
+        #          |         |         |
+        #          |         |         |--y
+        #          |         |         |
+        #          |          \int4----|          /-w
+        #          |                   |-int2----|
+        # ---------|                   |          \-z
+        #          |                   |
+        #          |                   |          /-c
+        #          |                    \int3----|
+        #          |                              \-d
+        #          |
+        #          |          /-e
+        #           \int5----|
+        #                     \-f
 
     def test_gops(self):
         """Basic TreeNode operations should work as expected."""
@@ -1438,19 +1457,121 @@ class TreeTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_subset(self):
-        """subset should return set of leaves that descends from node"""
+        """Return a set of tip names descending from a node."""
         t = self.simple_t
         self.assertEqual(t.subset(), frozenset("abcd"))
         c = t.children[0]
         self.assertEqual(c.subset(), frozenset("ab"))
         leaf = c.children[1]
         self.assertEqual(leaf.subset(), frozenset(""))
+        self.assertEqual(leaf.subset(include_self=True), frozenset("b"))
 
     def test_subsets(self):
-        """subsets should return all subsets descending from a set"""
+        """Return all subsets descending from a node."""
         t = self.simple_t
-        self.assertEqual(t.subsets(), frozenset(
+
+        # default case
+        self.assertSetEqual(t.subsets(), frozenset(
             [frozenset("ab"), frozenset("cd")]))
+
+        # make sure intermediates are cleaned
+        for node in t.traverse(include_self=False):
+            self.assertFalse(hasattr(node, "_subset"))
+
+        # custom range
+        self.assertSetEqual(t.subsets(within={"a", "b", "c"}), frozenset(
+            [frozenset("ab")]))
+        self.assertSetEqual(t.subsets(within="abc"), frozenset(
+            [frozenset("ab")]))
+
+        # include all
+        self.assertSetEqual(t.subsets(include_full=True), frozenset(
+            [frozenset("ab"), frozenset("cd"), frozenset("abcd")]))
+        for node in t.traverse(include_self=False):
+            self.assertFalse(hasattr(node, "_subset"))
+
+        # include singles
+        self.assertSetEqual(t.subsets(include_singles=True), frozenset(
+            [frozenset("ab"), frozenset("cd"), frozenset("a"), frozenset("b"),
+             frozenset("c"), frozenset("d")]))
+
+    def test_bipartition(self):
+        """Return a set of tip names on the smaller side of the branch."""
+        t = self.complex_tree
+
+        # typical cases (internal node): get smaller side
+        # taxa below node (same as subset)
+        self.assertSetEqual(t.find("int1").bipartition(), frozenset("ab"))
+        self.assertSetEqual(t.find("int3").bipartition(), frozenset("cd"))
+        self.assertSetEqual(t.find("int5").bipartition(), frozenset("ef"))
+
+        # when clade is larger than half of tree, get remaining taxa
+        self.assertSetEqual(t.find("int4").bipartition(), frozenset("abef"))
+
+        # at root: empty set
+        self.assertSetEqual(t.bipartition(), frozenset())
+
+        # at tip: singleton
+        self.assertSetEqual(t.find("a").bipartition(), frozenset("a"))
+
+        # when size is equal, get lexicographically smaller side
+        t = self.simple_t
+        self.assertSetEqual(t.find("i1").bipartition(), frozenset("ab"))
+        self.assertSetEqual(t.find("i2").bipartition(), frozenset("ab"))
+
+        # an unrooted tree
+        t = TreeNode.read(["((a,(b,c))X,(d,e)Y,f);"])
+        self.assertSetEqual(t.find("X").bipartition(), frozenset("abc"))
+        self.assertSetEqual(t.find("Y").bipartition(), frozenset("de"))
+
+    def test_bipartitions(self):
+        """Return all sets of tip names on the smaller side of each branch."""
+
+        # an unrooted, bifurcating tree (typical case)
+        t = TreeNode.read(["(((a,(b,c)),d),(e,f),g);"])
+        self.assertSetEqual(t.bipartitions(), frozenset({
+            frozenset({"e", "f"}),
+            frozenset({"e", "f", "g"}),
+            frozenset({"b", "c"}),
+            frozenset({"a", "b", "c"})}))
+
+        # a rooted tree with polytomy
+        t = self.complex_tree
+        self.assertSetEqual(t.bipartitions(), frozenset({
+            frozenset({"e", "f"}),
+            frozenset({"c", "d"}),
+            frozenset({"a", "b"}),
+            frozenset({"w", "z"}),
+            frozenset({"a", "b", "e", "f"})}))
+
+        # within given taxa
+        self.assertSetEqual(t.bipartitions(within="abcdef"), frozenset({
+            frozenset({"c", "d"}),
+            frozenset({"a", "b"}),
+            frozenset({"e", "f"})}))
+
+        self.assertSetEqual(
+            t.bipartitions(within="cbda"),
+            t.bipartitions(within={"a", "b", "c", "d"}))
+
+        # within a subtree
+        self.assertSetEqual(t.children[0].bipartitions(), frozenset({
+            frozenset({"c", "d"}),
+            frozenset({"a", "b"}),
+            frozenset({"w", "z"})}))
+
+        # a simple tree with only one bipartition
+        t = self.simple_t
+        self.assertSetEqual(t.bipartitions(), frozenset({
+            frozenset({"a", "b"})}))
+
+        # include singletons (tips)
+        self.assertSetEqual(t.bipartitions(include_singles=True), frozenset({
+            frozenset({"a", "b"}),
+            frozenset({"a"}),
+            frozenset({"b"}),
+            frozenset({"c"}),
+            frozenset({"d"})}))
 
     def test_assign_supports(self):
         """Extract support values of internal nodes."""
@@ -1783,26 +1904,49 @@ class TreeTests(TestCase):
         self.assertEqual(t_dm, exp_t_dm)
 
     def test_compare_rfd(self):
-        """compare_rfd should return the Robinson Foulds distance"""
+        """Return the Robinson-Foulds distance."""
+        # original example          
         t = TreeNode.read(["((H,G),(R,M));"])
         t2 = TreeNode.read(["(((H,G),R),M);"])
-        t4 = TreeNode.read(["(((H,G),(O,R)),X);"])
-
-        obs = t.compare_rfd(t2)
-        exp = 2.0
-        self.assertEqual(obs, exp)
-
+        self.assertEqual(t.compare_rfd(t2), 2)
         self.assertEqual(t.compare_rfd(t2), t2.compare_rfd(t))
+        self.assertEqual(t.compare_rfd(t2, proportion=True), 0.5)
 
-        obs = t.compare_rfd(t2, proportion=True)
-        exp = 0.5
-        self.assertEqual(obs, exp)
+        # two conflicting quartets
+        t1 = TreeNode.read(["((a,b),(c,d));"])
+        t2 = TreeNode.read(["((a,c),(b,d));"])
+        self.assertEqual(t1.compare_rfd(t2), 4)
+        self.assertEqual(t1.compare_rfd(t2, proportion=True), 1.0)
+        self.assertEqual(t1.compare_rfd(t2, rooted=False), 2)
 
-        with self.assertRaises(ValueError):
-            t.compare_rfd(t4)
+        # same topology but different rooting
+        t1 = TreeNode.read(["(((a,b),c),(d,e));"])
+        t2 = TreeNode.read(["((a,b),(c,(d,e)));"])
+        self.assertEqual(t1.compare_rfd(t2), 2)
+        self.assertAlmostEqual(t1.compare_rfd(t2, proportion=True), 1 / 3)
+        self.assertEqual(t1.compare_rfd(t2, rooted=False), 0)
+
+        # different topologies
+        t1 = TreeNode.read(["(((a,b),c),((d,e),f));"])
+        t2 = TreeNode.read(["(((a,(b,c)),d),(e,f));"])
+        self.assertEqual(t1.compare_rfd(t2), 6)
+        self.assertEqual(t1.compare_rfd(t2, proportion=True), 0.75)
+        self.assertEqual(t1.compare_rfd(t2, rooted=False), 4)
+
+        # unrooted trees
+        t1.unroot()
+        t2.unroot()
+        self.assertEqual(t1.compare_rfd(t2), 4)
+        self.assertEqual(t1.compare_rfd(t2, rooted=True), 6)
+
+        # with polytomy
+        t1 = TreeNode.read(["((a,b,(c,d)),((e,f),(g,h),i));"])
+        t2 = TreeNode.read(["((((a,b),c,d),e),((f,g,h),i));"])
+        self.assertEqual(t1.compare_rfd(t2), 8)
+        self.assertEqual(t1.compare_rfd(t2, rooted=False), 6)
 
     def test_compare_subsets(self):
-        """compare_subsets should return the fraction of shared subsets"""
+        """Return the amount of unshared subsets."""
         t = TreeNode.read(["((H,G),(R,M));"])
         t2 = TreeNode.read(["(((H,G),R),M);"])
         t4 = TreeNode.read(["(((H,G),(O,R)),X);"])
@@ -1810,22 +1954,40 @@ class TreeTests(TestCase):
         result = t.compare_subsets(t)
         self.assertEqual(result, 0)
 
-        result = t2.compare_subsets(t2)
-        self.assertEqual(result, 0)
-
         result = t.compare_subsets(t2)
         self.assertEqual(result, 0.5)
 
-        result = t.compare_subsets(t4)
-        self.assertEqual(result, 1 - 2. / 5)
+        result = t.compare_subsets(t4, proportion=False)
+        self.assertEqual(result, 3)
 
-        result = t.compare_subsets(t4, exclude_absent_taxa=True)
-        self.assertEqual(result, 1 - 2. / 3)
+        result = t.compare_subsets(t4, shared_only=True)
+        self.assertAlmostEqual(result, 1 / 3)
 
         result = t.compare_subsets(self.TreeRoot, exclude_absent_taxa=True)
         self.assertEqual(result, 1)
 
         result = t.compare_subsets(self.TreeRoot)
+        self.assertEqual(result, 1)
+
+    def test_compare_bipartitions(self):
+        """Return the amount of unshared bipartitions."""
+        t = TreeNode.read(["((H,G),(R,M));"])
+        t2 = TreeNode.read(["(((H,G),R),M);"])
+        t3 = TreeNode.read(["(((H,R),G),M);"])
+
+        result = t.compare_bipartitions(t)
+        self.assertEqual(result, 0)
+
+        result = t.compare_bipartitions(t2)
+        self.assertEqual(result, 0)
+
+        result = t.compare_bipartitions(t3)
+        self.assertEqual(result, 1)
+
+        result = t.compare_bipartitions(t3, proportion=False)
+        self.assertEqual(result, 2)
+
+        result = t.compare_bipartitions(self.TreeRoot)
         self.assertEqual(result, 1)
 
     def test_compare_tip_distances(self):

--- a/skbio/util/_warning.py
+++ b/skbio/util/_warning.py
@@ -57,5 +57,5 @@ def _warn_deprecated(func, ver, msg=None):
                 f"{func.__name__} is deprecated as of {ver}. {msg}", DeprecationWarning
             )
         else:
-            warn(f"{func.__name__} is deprecated as of {ver}.")
+            warn(f"{func.__name__} is deprecated as of {ver}.", DeprecationWarning)
         func.warned = True


### PR DESCRIPTION
Following our internal discussions on tree comparison metrics, I have implemented or updated multiple common metrics, following their accurate definitions in the literature. The results were compared with those of popular programs to ensure consistency. A strong focus was placed on the flexibility of the metrics, such that a larger spectrum of measurements other than published ones may be calculated. Meanwhile, the original default behaviors of the relevant functions are largely preserved. Additionally, documentation has been significantly enriched to inform the users how to use use metrics and what to expect.

A summary of code added or changed in this large PR:

- The **Robinson-Foulds (RF) distance** (`compare_rfd`) was updated to match its original definition, which is based on bipartitions in unrooted trees. The rationales were discussed separately. To accomondate this, new methods `bipart`, `biparts` and `compare_biparts` were added, which mirror `subset`, `subsets` and `compare_subsets`. Specifically, the former category is for unrooted trees while the latter category is for rooted trees (the only original behavior). The method `compare_rfd` automatically determines which category to use, but the user can override this.

- The underlying algorithm for RF distance has been updated and uniformized. Previously, `compare_subsets` actually calculated the rooted RF distance, with the same output, but with different (and less efficient) implementation. Now they all use the same implementation under a new helper function `_compare_topology`. The main improvement is that the previous implementation sheared both trees to match the common taxon set, which is expensive because it involves copying the entire trees. But the new implementation directly identifies subsets or bipartitions of a given taxon set in the original trees. This resulted in about 5x performance gain.

- Meanwhile, the function `_compare_topology` and its frontends allow great flexibility, such that it can base the calculation on shared or all taxa, symmetric or asymmetric, normalized or not, weighted by branch length (i.e., weighted RF, see below) or not, including terminal branches or not, etc. The algorithm was carefully optimized such that this flexibility doesn't introduce much overhead.

- A new method `compare_wrfd` was added to calculate the **weighted Robinson-Foulds (RF) distance**. Basically, it is the difference in bipartitions weighted by their branch lengths. This is comparable to Bray-Curtis vs Jaccard in community ecology. Depending on the choice of a pairwise distance metric, it can also calculate the **Kuhner-Felsenstein (KF) distance**, or a unit distance within [0, 1], or other custom metrics.

- The method `compare_tip_distances` was restructured, following our internal discussion. It retains the default behavior (calculating a unit distance within [0, 1] to indicate the correlation distance between evolutionary distances among taxa). But the new parameters allow it to calculate two published metrics: **path distance** and **path-length distance**, both are based on the Euclidean distance. Although "path distance" or "patristic distance" are widely used in the literature, I think "tip distance" is a reasonable term because it is more intuitive to general users.

- The algorithm underlying `get_max_distance` (i.e., diameter) was re-written. The new implementation is about 5x faster that the previous version, and avoids some undesired issues with the previous version.

- The algorithm for finding a path between two nodes was optimized. This impacts methods `distance` and `path`.

- Other minor tweaks that enhance the flexibility of the `TreeNode` class.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
