### PR TITLE
Allowed PCoA's number of dimensions to accept float values to capture fractional cumulative variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Added parameter `include_self` to `TreeNode.ancestors` to optionally include the initial node in the path (default: False) ([#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Added parameter `seed` to functions `pcoa`, `anosim`, `permanova`, `permdisp`, `randdm`, `lladser_pe`, `lladser_ci`, `isubsample`, `subsample_power`, `subsample_paired_power`, `paired_subsamples` and `hommola_cospeciation` to accept a random seed or random generator to ensure output reproducibility ([#2120](https://github.com/scikit-bio/scikit-bio/pull/2120) and [#2129](https://github.com/scikit-bio/scikit-bio/pull/2129)).
 * Made the `IORegistry` sniffer only attempt file formats which are logical given a specific object, thus improving reading efficiency.
+* Allowed the `number_of_dimensions` parameter in the function `pcoa` to accept float values between 0 and 1 to capture fractional cumulative variance. 
 
 ### Bug fixes
 

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -83,7 +83,7 @@ def pcoa(
 
     Notes
     -----
-    If the distance is not euclidean (for example if it is a
+    If the distance is not Euclidean (for example if it is a
     semimetric and the triangle inequality doesn't hold),
     negative eigenvalues can appear. There are different ways
     to deal with that problem (see Legendre & Legendre 1998, \S

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -162,7 +162,7 @@ def pcoa(
             )
             num_dimensions = matrix_data.shape[0]
         eigvals, eigvecs = _fsvd(matrix_data, num_dimensions, seed=seed)
-        long_method_name = "Approximate Principal Coordinate Analysis " "using FSVD"
+        long_method_name = "Approximate Principal Coordinate Analysis using FSVD"
     else:
         raise ValueError(
             "PCoA eigendecomposition method {} not supported.".format(method)

--- a/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
@@ -123,6 +123,35 @@ class TestPCoA(TestCase):
                                    r"no value for number_of_dimensions"):
             pcoa(dm_big, method="fsvd", number_of_dimensions=0)
 
+    def test_integer_dimensions(self):
+        """Test with an integer number_of_dimensions."""
+        results = pcoa(self.dm, number_of_dimensions=3)
+        self.assertEqual(results.samples.shape[1], 3)
+
+    def test_large_float(self):
+        """Test with a float number_of_dimensions > 1."""
+        msg = "A floating-point number greater than 1 cannot be"
+        with self.assertRaisesRegex(ValueError, msg):
+            pcoa(self.dm, number_of_dimensions=2.5)
+
+    def test_eigh_method_with_float(self):
+        """Test with a float number_of_dimensions with eigh method to retain 80% variance."""
+        results = pcoa(self.dm, method="eigh", number_of_dimensions=0.8, inplace=False, seed=None)
+        cumulative_variance = np.cumsum(results.proportion_explained.values)
+        self.assertGreaterEqual(cumulative_variance[-1], 0.8)
+
+    def test_edge_case_for_all_variance(self):
+        """Test with a number_of_dimensions close to 1 to retain nearly all variance."""
+        results = pcoa(self.dm, number_of_dimensions=0.9999)
+        cumulative_variance = np.cumsum(results.proportion_explained.values)
+        self.assertGreaterEqual(cumulative_variance[-1], 0.9999)
+
+    def test_fsvd_method_with_float(self):
+        """Test FSVD with float number_of_dimensions for variance threshold."""
+        results = pcoa(self.dm, method="fsvd", number_of_dimensions=0.7, inplace=False, seed=None)
+        cumulative_variance = np.cumsum(results.proportion_explained.values)
+        self.assertGreaterEqual(cumulative_variance[-1], 0.7)
+
     def test_permutted(self):
         dm1 = DistanceMatrix.read(get_data_path('PCoA_sample_data_3'))
         # this should not throw


### PR DESCRIPTION
This pull request allows the number of dimensions parameter in the PCoA function to accept float values between 0 and 1, in addition to integers. This will allow the user to input fractional numbers to compute percentage variance. 

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
