### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
     paths-ignore: ["web/**", "**.md", "README.rst"]
 
 env:
-  latest_python: "3.12"
-  supported_pythons: '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+  latest_python: "3.13"
+  supported_pythons: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
   miniforge_version: "23.11.0-0"
   miniforge_variant: "Mambaforge"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   earliest_python: "3.8"
-  latest_python: "3.12"
+  latest_python: "3.13"
   miniforge_version: "23.11.0-0"
   miniforge_variant: "Mambaforge"
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ on:
     paths: [ "web/**", "!**.md" ]
 
 env:
-  latest_python: "3.12"
+  latest_python: "3.13"
   miniforge_version: "23.11.0-0"
   miniforge_variant: "Mambaforge"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added support for Python's `pathlib` module in the IO system ([#2119](https://github.com/scikit-bio/scikit-bio/pull/2119)).
 * Added Balanced Minimum Evolution (BME) function and `balanced` option for NNI ([#2105](https://github.com/scikit-bio/scikit-bio/pull/2105)).
 * Added `TreeNode.path` to return a list of nodes representing the path from one node to another ([#2131](https://github.com/scikit-bio/scikit-bio/pull/2131)).
+* Python 3.13+ is now supported ([#2146](https://github.com/scikit-bio/scikit-bio/pull/2146))
 
 ### Performance enhancements
 

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ classes = """
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Operating System :: Unix
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -162,13 +162,13 @@ def permdisp(
     make the output deterministic. You may skip it if that's not necessary.
 
     >>> from skbio.stats.distance import permdisp
-    >>> permdisp(dm, grouping, permutations=99, seed=42)
+    >>> permdisp(dm, grouping, permutations=99, seed=42) # doctest: +ELLIPSIS
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
     number of groups                 2
     test statistic             1.03296
-    p-value                       0.28
+    p-value                       ...
     number of permutations          99
     Name: PERMDISP results, dtype: object
 

--- a/skbio/util/tests/test_misc.py
+++ b/skbio/util/tests/test_misc.py
@@ -8,6 +8,7 @@
 
 import io
 import unittest
+import re
 
 import numpy as np
 import numpy.testing as npt
@@ -104,24 +105,30 @@ class TestMiniRegistry(unittest.TestCase):
         self.registry.interpolate(SomethingToInterpolate, "interpolate_me")
         subclass_registry.interpolate(Subclass, "interpolate_me")
 
-        self.assertEqual(SomethingToInterpolate.interpolate_me.__doc__,
-                         "First line\n\n                Some description of th"
-                         "ings, also this:\n\n\t'a'\n\t  x\n\t'b'\n\t  y\n\t'c"
-                         "'\n\t  z\n\n                Other things are happeni"
-                         "ng now.\n                ")
-        self.assertEqual(SomethingToInterpolate.dont_interpolate_me.__doc__,
-                         "First line\n\n                Some description of th"
-                         "ings, also this:\n\n                Other things are"
-                         " happening now.\n                ")
-        self.assertEqual(Subclass.interpolate_me.__doc__,
-                         "First line\n\n                Some description of th"
-                         "ings, also this:\n\n\t'a'\n\t  x\n\t'b'\n\t  y\n\t'c"
-                         "'\n\t  z\n\t'o'\n\t  p\n\n                Other thin"
-                         "gs are happening now.\n                ")
-        self.assertEqual(Subclass.dont_interpolate_me.__doc__,
-                         "First line\n\n                Some description of th"
-                         "ings, also this:\n\n                Other things are"
-                         " happening now.\n                ")
+        # Python 3.13+ removes leading whitespaces from a docstring, therefore it is
+        # necessary to make this edit.
+        def _strip_spaces(s):
+            return re.sub(r'^\s+', '', s, flags=re.MULTILINE)
+
+        obs = _strip_spaces(SomethingToInterpolate.interpolate_me.__doc__)
+        exp = ("First line\nSome description of things, also this:\n'a'\nx"
+               "\n'b'\ny\n'c'\nz\nOther things are happening now.\n")
+        self.assertEqual(obs, exp)
+
+        obs = _strip_spaces(SomethingToInterpolate.dont_interpolate_me.__doc__)
+        exp = ("First line\nSome description of things, also this:\nOther things "
+               "are happening now.\n")
+        self.assertEqual(obs, exp)
+
+        obs = _strip_spaces(Subclass.interpolate_me.__doc__)
+        exp = ("First line\nSome description of things, also this:\n'a'\nx\n'b'\ny\n"
+               "'c'\nz\n'o'\np\nOther things are happening now.\n")
+        self.assertEqual(obs, exp)
+
+        obs = _strip_spaces(Subclass.dont_interpolate_me.__doc__)
+        exp = ("First line\nSome description of things, also this:\nOther things "
+               "are happening now.\n")
+        self.assertEqual(obs, exp)
 
 
 class ResolveKeyTests(unittest.TestCase):


### PR DESCRIPTION
Upon further investigation into the segmentation fault found in issue #2137, it appears that while scikit-bio 0.6.2 is not compatible with Python 3.13, scikit-bio's current development version is compatible with Python 3.13. This will be verified by the CI tests either passing or failing.

Out of curiosity, I looked into the history of `_intersection.pyx`. Looks like I made a [commit](https://github.com/scikit-bio/scikit-bio/commit/5e04026c488a101a61419d614325a1ff23e2bbcb#diff-28213528b0b5444704b20f32b2020c39e6b251a3bbe4989df039c917233fc127R97) on July 8th that fixed the segmentation fault on Windows. This was one day after scikit-bio 0.6.2 released on July 7th. 

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
