### PR TITLE
Optimized the neighbor joining (NJ) tree building algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Performance enhancements
 
+* Significantly improved the performance of the neighbor joining (NJ) algorithm for phylogenetic reconstruction (`nj`) ([#2147](https://github.com/scikit-bio/scikit-bio/pull/2147)).
 * Improved the performance of `TreeNode.lowest_common_ancestor` ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Improved the performance of `TreeNode` methods: `ancestors`, `siblings`, and `neighbors` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133), [#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,11 @@ extensions = [
         include_dirs=[np.get_include()],
     ),
     Extension(
+        "skbio.tree._cutils",
+        ["skbio/tree/_cutils" + ext],
+        include_dirs=[np.get_include()],
+    ),
+    Extension(
         "skbio.diversity._phylogenetic",
         ["skbio/diversity/_phylogenetic" + ext],
         include_dirs=[np.get_include()],

--- a/skbio/tree/_cutils.pyx
+++ b/skbio/tree/_cutils.pyx
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+#  Copyright (c) 2021-2021, scikit-bio development team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+cimport cython
+from libc.float cimport DBL_MAX
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def nj_minq_cy(double[:, :] dm, double[:] sums):
+    r"""Find the minimum value in a Q-matrix during the NJ algorithm.
+
+    Parameters
+    ----------
+    dm : (N, N) ndarray
+        Distance matrix.
+    sums : (N,) ndarray
+        Distance sum vector.
+
+    Returns
+    -------
+    (int, int)
+        Row and column indices of the minimum value.
+
+    See Also
+    --------
+    skbio.tree.nj
+
+    Notes
+    -----
+    The agglomerative clustering algorithm neighbor joining (NJ) involves converting
+    the original distance matrix into a "Q-matrix" and finding the location of the
+    minimum _q_ value in the matrix.
+
+    .. math::
+
+        Q(i, j) = (n - 2) d(i, j) - \sum d(i) - \sum d(j)
+
+    This function calculates _q_ values and finds the minimum as the calculation goes,
+    and avoids creating the entire Q-matrix, thereby saving compute.
+
+    """
+    cdef Py_ssize_t n = dm.shape[0]
+    cdef Py_ssize_t i, j
+    cdef int n_2 = n - 2
+
+    # current minimum q value and its location
+    cdef Py_ssize_t min_i, min_j
+    cdef double min_q = DBL_MAX
+
+    # current minimum q value plus \sum d(i)
+    cdef double min_q_plus
+
+    # loop the upper-right triangle of the distance matrix
+    # i < j is guaranteed
+    for i in range(n):
+        min_q_plus = min_q + sums[i]
+        for j in range(i + 1, n):
+            q = dm[i, j] * n_2 - sums[j]
+            if q < min_q_plus:
+                min_q_plus = q
+                min_q = q - sums[i]
+                min_i, min_j = i, j
+
+    return min_i, min_j

--- a/skbio/tree/_cutils.pyx
+++ b/skbio/tree/_cutils.pyx
@@ -53,18 +53,18 @@ def nj_minq_cy(double[:, :] dm, double[:] sums):
     cdef Py_ssize_t min_i, min_j
     cdef double min_q = DBL_MAX
 
-    # current minimum q value plus \sum d(i)
-    cdef double min_q_plus
+    # current q value and minimum q value plus \sum d(i)
+    cdef double q_plus, min_q_plus
 
     # loop the upper-right triangle of the distance matrix
     # i < j is guaranteed
     for i in range(n):
         min_q_plus = min_q + sums[i]
         for j in range(i + 1, n):
-            q = dm[i, j] * n_2 - sums[j]
-            if q < min_q_plus:
-                min_q_plus = q
-                min_q = q - sums[i]
+            q_plus = dm[i, j] * n_2 - sums[j]
+            if q_plus < min_q_plus:
+                min_q_plus = q_plus
+                min_q = q_plus - sums[i]
                 min_i, min_j = i, j
 
     return min_i, min_j

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -12,31 +12,50 @@ import numpy as np
 
 from skbio.stats.distance import DistanceMatrix
 from skbio.tree import TreeNode
+from skbio.util._warning import _warn_deprecated
+from ._cutils import nj_minq_cy
 
 
-def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
+def nj(
+    dm,
+    clip_to_zero=True,
+    result_constructor=None,
+    disallow_negative_branch_length=None,
+):
     r"""Perform neighbor joining (NJ) for phylogenetic reconstruction.
 
     Parameters
     ----------
     dm : skbio.DistanceMatrix
-        Input distance matrix containing distances between taxa.
-    disallow_negative_branch_length : bool, optional
-        Neighbor joining can result in negative branch lengths, which don't
-        make sense in an evolutionary context. If `True`, negative branch
-        lengths will be returned as zero, a common strategy for handling this
-        issue that was proposed by the original developers of the algorithm.
+        Input distance matrix containing pairwise distances among taxa.
+    clip_to_zero : bool, optional
+        If True (default), convert negative branch lengths into zeros.
+
+        .. versionadded:: 0.6.3
+
     result_constructor : function, optional
         Function to apply to construct the result object. This must take a
-        newick-formatted string as input. The result of applying this function
-        to a newick-formatted string will be returned from this function. This
-        defaults to ``lambda x: TreeNode.read(StringIO(x), format='newick')``.
+        newick-formatted string as input. Deprecated and to be removed in a
+        future release.
+
+        .. deprecated:: 0.6.3
+
+    disallow_negative_branch_length : bool, optional
+        Alias of ``clip_to_zero`` for backward compatibility. Deprecated and to be
+        removed in a future release.
+
+        .. deprecated:: 0.6.3
 
     Returns
     -------
     TreeNode
-        By default, the result object is a `TreeNode`, though this can be
-        overridden by passing `result_constructor`.
+        Reconstructed phylogenetic tree.
+
+        .. versionchanged:: 0.6.3
+            The NJ algorithm has been optimized. The output may be slightly different
+            from the previous one in root placement, node ordering, and the numeric
+            precision of branch lengths. However, the overall tree topology and branch
+            lengths should remain the same.
 
     See Also
     --------
@@ -46,24 +65,31 @@ def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
 
     Notes
     -----
-    Neighbor joining was initially described in Saitou and Nei (1987) [1]_. The
-    example presented here is derived from the Wikipedia page on neighbor
-    joining [2]_. Gascuel and Steel (2006) provide a detailed overview of
-    Neighbor joining in terms of its biological relevance and limitations [3]_.
+    Neighbor joining (NJ) was initially described in Saitou and Nei (1987) [1]_. The
+    example presented here is derived from the Wikipedia page on neighbor joining [2]_.
+    Gascuel and Steel (2006) provide a detailed overview of neighbor joining in terms
+    of its biological relevance and limitations [3]_.
 
-    Neighbor joining, by definition, creates unrooted trees. One strategy for
-    rooting the resulting trees is midpoint rooting, which is accessible as
-    ``TreeNode.root_at_midpoint``.
+    Neighbor joining, by definition, creates unrooted trees with varying tip heights,
+    which contrasts UPGMA (:func:`upgma`). One strategy for rooting the resulting tree
+    is midpoint rooting, which is accessible as :meth:`TreeNode.root_at_midpoint`.
+
+    Note that the tree constructed using neighbor joining is not rooted at a tip,
+    unlike minimum evolution (:func:`bme`), so re-rooting is required before tree
+    re-arrangement operations such as nearest neighbor interchange (NNI) (:func:`nni`)
+    can be performed.
 
     References
     ----------
     .. [1] Saitou N, and Nei M. (1987) "The neighbor-joining method: a new
        method for reconstructing phylogenetic trees." Molecular Biology and
        Evolution. PMID: 3447015.
+
     .. [2] http://en.wikipedia.org/wiki/Neighbour_joining
+
     .. [3] Gascuel O, and Steel M. (2006) "Neighbor-Joining Revealed" Molecular
        Biology and Evolution, Volume 23, Issue 11, November 2006,
-       Pages 1997–2000, https://doi.org/10.1093/molbev/msl072
+       Pages 1997-2000, https://doi.org/10.1093/molbev/msl072
 
     Examples
     --------
@@ -86,209 +112,216 @@ def nj(dm, disallow_negative_branch_length=True, result_constructor=None):
 
     >>> tree = nj(dm)
     >>> print(tree.ascii_art())
-              /-d
+                        /-a
+              /--------|
+             |          \-b
              |
-             |          /-c
-             |---------|
-    ---------|         |          /-b
-             |          \--------|
-             |                    \-a
+    ---------|--c
              |
-              \-e
-
-    Again, construct the neighbor joining tree, but instead return the newick
-    string representing the tree, rather than the TreeNode object. (Note that
-    in this example the string output is truncated when printed to facilitate
-    rendering.)
-
-    >>> newick_str = nj(dm, result_constructor=str)
-    >>> print(newick_str[:55], "...")
-    (d:2.000000, (c:4.000000, (b:3.000000, a:2.000000):3.00 ...
-
-    Notice that the tree constructed using neighbor joining is not rooted at a
-    leaf node, unlike minimum evolution, so re-rooting is required before
-    nearest neighbor interchange can be performed.
+             |          /-d
+              \--------|
+                        \-e
 
     """
+    # @deprecated
+    if disallow_negative_branch_length is not None:
+        _warn_deprecated(
+            nj,
+            "0.6.3",
+            msg=(
+                "`disallow_negative_branch_length` has been renamed as `clip_to_zero`."
+                "The old name will be removed in a future release."
+            ),
+        )
+        clip_to_zero = disallow_negative_branch_length
+    if result_constructor is not None:
+        _warn_deprecated(
+            nj,
+            "0.6.3",
+            msg=(
+                "`result_constructor` is deprecated and will be removed in a future "
+                "release."
+            ),
+        )
+
     if dm.shape[0] < 3:
         raise ValueError(
-            "Distance matrix must be at least 3x3 to "
-            "generate a neighbor joining tree."
+            "Distance matrix must be at least 3x3 to generate a neighbor joining tree."
         )
-
-    if result_constructor is None:
-
-        def result_constructor(x):
-            return TreeNode.read(io.StringIO(x), format="newick")
-
-    # initialize variables
-    node_definition = None
-
-    # while there are still more than three distances in the distance matrix,
-    # join neighboring nodes.
-    while dm.shape[0] > 3:
-        # compute the Q matrix
-        q = _compute_q(dm)
-
-        # identify the pair of nodes that have the lowest Q value. if multiple
-        # pairs have equally low Q values, the first pair identified (closest
-        # to the top-left of the matrix) will be chosen. these will be joined
-        # in the current node.
-        idx1, idx2 = _lowest_index(q)
-        pair_member_1 = dm.ids[idx1]
-        pair_member_2 = dm.ids[idx2]
-        # determine the distance of each node to the new node connecting them.
-        pair_member_1_len, pair_member_2_len = _pair_members_to_new_node(
-            dm, idx1, idx2, disallow_negative_branch_length
-        )
-        # define the new node in newick style
-        node_definition = "(%s:%f, %s:%f)" % (
-            pair_member_1,
-            pair_member_1_len,
-            pair_member_2,
-            pair_member_2_len,
-        )
-        # compute the new distance matrix, which will contain distances of all
-        # other nodes to this new node
-        dm = _compute_collapsed_dm(
-            dm,
-            pair_member_1,
-            pair_member_2,
-            disallow_negative_branch_length=disallow_negative_branch_length,
-            new_node_id=node_definition,
-        )
-
-    # When there are three distances left in the distance matrix, we have a
-    # fully defined tree. The last node is internal, and its distances are
-    # defined by these last three values.
-    # First determine the distance between the last two nodes to be joined in
-    # a pair...
-    pair_member_1 = dm.ids[1]
-    pair_member_2 = dm.ids[2]
-    pair_member_1_len, pair_member_2_len = _pair_members_to_new_node(
-        dm, pair_member_1, pair_member_2, disallow_negative_branch_length
-    )
-    # ...then determine their distance to the other remaining node, but first
-    # handle the trivial case where the input dm was only 3 x 3
-    node_definition = node_definition or dm.ids[0]
-    internal_len = 0.5 * (
-        dm[pair_member_1, node_definition]
-        + dm[pair_member_2, node_definition]
-        - dm[pair_member_1, pair_member_2]
-    )
-    if disallow_negative_branch_length and internal_len < 0:
-        internal_len = 0
-
-    # ...and finally create the newick string describing the whole tree.
-    newick = "(%s:%f, %s:%f, %s:%f);" % (
-        pair_member_1,
-        pair_member_1_len,
-        node_definition,
-        internal_len,
-        pair_member_2,
-        pair_member_2_len,
-    )
-
-    # package the result as requested by the user and return it.
-    return result_constructor(newick)
+    taxa = list(dm.ids)
+    dm_ = dm.data.astype(float)  # make a copy of the distance matrix data
+    lm = _nj(dm_)
+    tree = _tree_from_linkmat(lm, taxa, rooted=False, clip_to_zero=clip_to_zero)
+    if result_constructor is not None:
+        tree = result_constructor(str(tree))
+    return tree
 
 
-def _compute_q(dm):
-    """Compute Q matrix, used to identify the next pair of nodes to join."""
-    q = np.zeros(dm.shape)
-    n = dm.shape[0]
-    big_sum = np.array([dm.data.sum(1)] * dm.shape[0])
-    big_sum_diffs = big_sum + big_sum.T
-    q = (n - 2) * dm.data - big_sum_diffs
-    np.fill_diagonal(q, 0)
-    return DistanceMatrix(q, dm.ids)
-
-
-def _compute_collapsed_dm(dm, i, j, disallow_negative_branch_length, new_node_id):
-    """Return the distance matrix resulting from joining ids i and j in a node.
-
-    If the input distance matrix has shape ``(n, n)``, the result will have
-    shape ``(n-1, n-1)`` as the ids `i` and `j` are collapsed to a single new
-    ids.
-
-    """
-    in_n = dm.shape[0]
-    out_n = in_n - 1
-    out_ids = [new_node_id]
-    out_ids.extend([e for e in dm.ids if e not in (i, j)])
-    result = np.zeros((out_n, out_n))
-    # pre-populate the result array with known distances
-    ij_indexes = [dm.index(i), dm.index(j)]
-    result[1:, 1:] = np.delete(
-        np.delete(dm.data, ij_indexes, axis=0), ij_indexes, axis=1
-    )
-    # calculate the new distances from the current DistanceMatrix
-    k_to_u = 0.5 * (dm[i] + dm[j] - dm[i, j])
-    # set negative branches to 0 if specified
-    if disallow_negative_branch_length:
-        k_to_u[k_to_u < 0] = 0
-    # drop nodes being joined
-    k_to_u = np.delete(k_to_u, ij_indexes)
-    # assign the distances to the result array
-    result[0] = result[:, 0] = np.concatenate([[0], k_to_u])
-    return DistanceMatrix(result, out_ids)
-
-
-def _lowest_index(dm):
-    """Return the index of the lowest value in the input distance matrix.
-
-    If there are ties for the lowest value, the index of top-left most
-    occurrence of that value will be returned.
-
-    This should be ultimately be replaced with a new DistanceMatrix object
-    method (#228).
-
-    """
-    # get the positions of the lowest value
-    results = np.vstack(np.where(dm.data == np.amin(dm.condensed_form()))).T
-    # select results in the bottom-left of the array
-    results = results[results[:, 0] > results[:, 1]]
-    # calculate the distances of the results to [0, 0]
-    res_distances = np.sqrt(results[:, 0] ** 2 + results[:, 1] ** 2)
-    # detect distance ties & return the point which would have
-    # been produced by the original function
-    if np.count_nonzero(res_distances == np.amin(res_distances)) > 1:
-        eqdistres = results[res_distances == np.amin(res_distances)]
-        res_coords = eqdistres[np.argmin([r[0] for r in eqdistres])]
-    else:
-        res_coords = results[np.argmin(res_distances)]
-
-    return tuple([res_coords[0], res_coords[1]])
-
-
-def _pair_members_to_new_node(dm, i, j, disallow_negative_branch_length):
-    """Return the distance between a new node and descendants of that new node.
+def _nj(dm):
+    r"""Perform neighbor joining (NJ) for phylogenetic reconstruction.
 
     Parameters
     ----------
-    dm : skbio.DistanceMatrix
-        The input distance matrix.
-    i, j : str
-        Identifiers of entries in the distance matrix to be collapsed (i.e.,
-        the descendants of the new node, which is internally represented as
-        `u`).
-    disallow_negative_branch_length : bool
-        Neighbor joining can result in negative branch lengths, which don't
-        make sense in an evolutionary context. If `True`, negative branch
-        lengths will be returned as zero, a common strategy for handling this
-        issue that was proposed by the original developers of the algorithm.
+    dm : (N, N) ndarray
+        Input distance matrix.
+
+    Returns
+    -------
+    ndarray of shape (N - 1, 4)
+        Linkage matrix representing the tree.
+
+    Notes
+    -----
+    This function manipulates the distance matrix in-place. Therefore, one should make
+    a copy prior to running the function if the original distance matrix needs to be
+    preserved.
 
     """
-    n = dm.shape[0]
-    i_to_j = dm[i, j]
-    i_to_u = (0.5 * i_to_j) + ((dm[i].sum() - dm[j].sum()) / (2 * (n - 2)))
+    # This function re-uses the original array space during iteration, without creating
+    # additional intermediate arrays. Therefore, it is memory-efficient, and avoids the
+    # time overhead of allocating new memory space.
 
-    if disallow_negative_branch_length and i_to_u < 0:
-        i_to_u = 0
+    # This function only operates on arrays of numbers, therefore it can be further
+    # Cythonized. However, Cythonization did not bring significant performance gain in
+    # tests, likely because all operations already utilize NumPy APIs. That being said,
+    # Further optimization and testing should be convenient.
 
-    j_to_u = i_to_j - i_to_u
+    N = n = dm.shape[0]  # dimension
+    sums = dm.sum(axis=0)  # distance sums
+    idxs = np.arange(N)  # cluster indices
+    lm = np.empty((N - 1, 4))  # linkage matrix
 
-    if disallow_negative_branch_length and j_to_u < 0:
-        j_to_u = 0
+    # Iteratively merge taxa until there are three left.
+    while n > 3:
+        # Find the minimum value of the Q-matrix and return its position (i, j).
+        #   Q(i, j) = (n - 2) d(i, j) - \sum d(i) - \sum d(j)
+        # The function call avoids constructing the entire Q-matrix, but instead
+        # computes values and finds the minimum as the computation goes.
+        i, j = nj_minq_cy(dm[:n, :n], sums[:n])
 
-    return i_to_u, j_to_u
+        # Get half of the original distance at (i, j).
+        d_ij_ = dm[i, j] / 2
+
+        # Taxa i and j will be merged into a cluster, therefore the values in rows
+        # and columns i and j are no longer needed, and their memory space can be
+        # utilized.
+
+        # The updated distance from cluster {i, j} to any other taxon k is:
+        #   d({i, j}, k) = (d(i, k) + d(j, k) - d(i, j)) / 2
+        # We first compute (d(i, k) + d(j, k)) / 2 and save the results in row i.
+        dm[i, :n] += dm[j, :n]
+        dm[i, :n] /= 2
+
+        # Compute branch lengths of taxa i and j.
+        #   \delta = (\sum d(i) - \sum d(j)) / (2(n - 2))
+        #   L(i) = d(i, j) / 2 + \delta
+        #   L(j) = d(i, j) / 2 - \delta
+        delta_ = (sums[i] - sums[j]) / (2 * n - 4)
+        L_i = d_ij_ + delta_
+        L_j = d_ij_ - delta_
+
+        # The previously calculated sums can be re-used, but they need to be updated.
+        # For taxon k, there is:
+        #   new sum = old sum - d(i, k) - d(j, k) + d({i, j}, k)
+        #           = old sum - d(i, k) - d(j, k) + (d(i, k) + d(j, k) - d(i, j)) / 2
+        #           = old sum - (d(i, k) + d(j, k)) / 2 - d(i, j) / 2
+        # We already have (d(i, k) + d(j, k)) / 2 stored in row i, therefore:
+        sums[:n] -= dm[i, :n]
+        sums[:n] -= d_ij_
+
+        # Now complete the calculation of the updated distances d({i, j}, k).
+        dm[i, :n] -= d_ij_
+
+        # Because two taxa have been merged into one cluster, we will shrink the
+        # distance matrix from (n, n) to (n - 1, n - 1). Specifically, we will delete
+        # row/column j, and update row/column i.
+
+        # Every row/column beyond j will be moved -1 position. This involves moving
+        # the right block leftward, moving the bottom block upward, and moving the
+        # bottom-right block upleftward.
+        dm[j : n - 1, :j] = dm[j + 1 : n, :j]
+        dm[:j, j : n - 1] = dm[:j, j + 1 : n]
+        dm[j : n - 1, j : n - 1] = dm[j + 1 : n, j + 1 : n]
+
+        # Also move the sums beyond j leftward.
+        sums[j : n - 1] = sums[j + 1 : n]
+
+        # Then update row/column i. Because the updated distances were already stored
+        # in row i, we only need to update column i.
+        dm[: n - 1, i] = dm[i, : n - 1]
+
+        # Then calculate the updated sum at i (now cluster {i, j}), which is the sum
+        # of updated distances.
+        sums[i] = dm[i, : n - 1].sum()
+
+        # Store the taxa and branch lengths to the linkage matrix.
+        lm[N - n] = idxs[i], idxs[j], L_i, L_j
+
+        # Update cluster indices. Specifically, position i will have the new cluster
+        # index. Meanwhile, indices beyond j will be moved leftward.
+        idxs[i] = 2 * N - n
+        idxs[j : n - 1] = idxs[j + 1 : n]
+
+        n -= 1
+
+    # Perform final calculation on the three remaining taxa. They will become children
+    # of the root node, and the entire tree is unrooted.
+    L_0 = (dm[0, 1] + dm[0, 2] - dm[1, 2]) / 2
+    lm[N - 3] = idxs[1], idxs[2], dm[0, 1] - L_0, dm[0, 2] - L_0
+    lm[N - 2] = idxs[0], 2 * N - 3, L_0, 0
+
+    return lm
+
+
+def _tree_from_linkmat(lm, taxa, rooted=True, clip_to_zero=True):
+    r"""Convert a linkage matrix into a tree structure.
+
+    Parameters
+    ----------
+    lm : (N, 4) array_like
+        Linkage matrix.
+    taxa : list of str
+        Taxon names.
+    rooted : bool, optional
+        If True (default), will generate a rooted binary tree, with two children
+        attached to the root node. If False, will generate an unrooted tree with
+        three children attached to the root node.
+    clip_to_zero : bool, optional
+        Convert negative branch lengths to zero.
+
+    Returns
+    -------
+    TreeNode
+        Converted phylogenetic tree.
+
+    Notes
+    -----
+    The linkage matrix data structure resembles that used in SciPy's hierarchical
+    clustering, but also stores the branch lengths of both children, which could be
+    unequal in a phylogenetic tree.
+
+    In SciPy's linkage matrix, the four elements per row are (see:
+    https://stackoverflow.com/questions/9838861/):
+
+        taxon1, taxon2, length1+2, # original taxa
+
+    In the current data structure, they are:
+
+        taxon1, taxon2, length1, length2
+
+    """
+    nodes = [TreeNode(name=x) for x in taxa] + [TreeNode() for _ in range(len(lm))]
+    idx = len(taxa)
+    for c1, c2, l1, l2 in lm:
+        c1, c2 = nodes[int(c1)], nodes[int(c2)]
+        if clip_to_zero:
+            c1.length = l1 if l1 >= 0 else 0.0
+            c2.length = l2 if l2 >= 0 else 0.0
+        else:
+            c1.length, c2.length = l1, l2
+        nodes[idx].extend([c1, c2], uncache=False)
+        idx += 1
+    tree = nodes[-1]
+    if not rooted:
+        tree.unroot(uncache=False)
+    return tree

--- a/skbio/tree/tests/test_nj.py
+++ b/skbio/tree/tests/test_nj.py
@@ -9,10 +9,8 @@
 import io
 from unittest import TestCase, main
 
-from skbio import DistanceMatrix, TreeNode, nj
-from skbio.tree._nj import (
-    _compute_q, _compute_collapsed_dm, _lowest_index,
-    _pair_members_to_new_node)
+from skbio import DistanceMatrix, TreeNode
+from skbio.tree._nj import nj, _tree_from_linkmat
 
 
 class NjTests(TestCase):
@@ -76,13 +74,9 @@ class NjTests(TestCase):
         self.dm4 = DistanceMatrix(data4, ids4)
 
     def test_nj_dm1(self):
-        self.assertEqual(nj(self.dm1, result_constructor=str),
-                         self.expected1_str)
-        # what is the correct way to compare TreeNode objects for equality?
         actual_TreeNode = nj(self.dm1)
-        # precision error on ARM: 1.6653345369377348e-16 != 0.0
         self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
-            self.expected1_TreeNode), 0.0, places=10)
+            self.expected1_TreeNode), 0.0)
 
     def test_nj_dm2(self):
         actual_TreeNode = nj(self.dm2)
@@ -103,20 +97,27 @@ class NjTests(TestCase):
         # only tips associated with the large distance in the input
         # have positive branch lengths when we allow negative branch
         # length
-        tree = nj(self.dm4, False)
+        tree = nj(self.dm4, clip_to_zero=False)
         self.assertTrue(tree.find('a').length > 0)
         self.assertTrue(tree.find('b').length < 0)
         self.assertTrue(tree.find('c').length < 0)
         self.assertTrue(tree.find('d').length < 0)
         self.assertTrue(tree.find('e').length > 0)
 
+        # deprecated functionality
+        t2 = nj(self.dm4, disallow_negative_branch_length=False)
+        self.assertAlmostEqual(tree.compare_tip_distances(t2), 0.0)
+
     def test_nj_trivial(self):
         data = [[0, 3, 2],
                 [3, 0, 3],
                 [2, 3, 0]]
         dm = DistanceMatrix(data, list('abc'))
-        expected_str = "(b:2.000000, a:1.000000, c:1.000000);"
-        self.assertEqual(nj(dm, result_constructor=str), expected_str)
+        exp = TreeNode.read(["(b:2.000000, a:1.000000, c:1.000000);"])
+        self.assertAlmostEqual(nj(dm).compare_tip_distances(exp), 0.0)
+
+        # deprecated functionality
+        self.assertEqual(nj(dm, result_constructor=str), "(a:1.0,b:2.0,c:1.0);\n")
 
     def test_nj_error(self):
         data = [[0, 3],
@@ -124,72 +125,26 @@ class NjTests(TestCase):
         dm = DistanceMatrix(data, list('ab'))
         self.assertRaises(ValueError, nj, dm)
 
-    def test_compute_q(self):
-        expected_data = [[0, -50, -38, -34, -34],
-                         [-50,   0, -38, -34, -34],
-                         [-38, -38,   0, -40, -40],
-                         [-34, -34, -40,   0, -48],
-                         [-34, -34, -40, -48,   0]]
-        expected_ids = list('abcde')
-        expected = DistanceMatrix(expected_data, expected_ids)
-        self.assertEqual(_compute_q(self.dm1), expected)
-
-        data = [[0, 3, 2],
-                [3, 0, 3],
-                [2, 3, 0]]
-        dm = DistanceMatrix(data, list('abc'))
-        # computed this manually
-        expected_data = [[0, -8, -8],
-                         [-8,  0, -8],
-                         [-8, -8,  0]]
-        expected = DistanceMatrix(expected_data, list('abc'))
-        self.assertEqual(_compute_q(dm), expected)
-
-    def test_compute_collapsed_dm(self):
-        expected_data = [[0,  7,  7,  6],
-                         [7,  0,  8,  7],
-                         [7,  8,  0,  3],
-                         [6,  7,  3,  0]]
-        expected_ids = ['x', 'c', 'd', 'e']
-        expected1 = DistanceMatrix(expected_data, expected_ids)
-        self.assertEqual(_compute_collapsed_dm(self.dm1, 'a', 'b', True, 'x'),
-                         expected1)
-
-        # computed manually
-        expected_data = [[0, 4, 3],
-                         [4, 0, 3],
-                         [3, 3, 0]]
-        expected_ids = ['yy', 'd', 'e']
-        expected2 = DistanceMatrix(expected_data, expected_ids)
-        self.assertEqual(
-            _compute_collapsed_dm(expected1, 'x', 'c', True, 'yy'), expected2)
-
-    def test_lowest_index(self):
-        self.assertEqual(_lowest_index(self.dm1), (4, 3))
-        self.assertEqual(_lowest_index(_compute_q(self.dm1)), (1, 0))
-
-    def test_pair_members_to_new_node(self):
-        self.assertEqual(_pair_members_to_new_node(self.dm1, 'a', 'b', True),
-                         (2, 3))
-        self.assertEqual(_pair_members_to_new_node(self.dm1, 'a', 'c', True),
-                         (4, 5))
-        self.assertEqual(_pair_members_to_new_node(self.dm1, 'd', 'e', True),
-                         (2, 1))
-
-    def test_pair_members_to_new_node_zero_branch_length(self):
-        # the values in this example don't really make sense
-        # (I'm not sure how you end up with these distances between
-        # three sequences), but that doesn't really matter for the sake
-        # of this test
-        data = [[0, 4, 2],
-                [4, 0, 38],
-                [2, 38, 0]]
-        ids = ['a', 'b', 'c']
-        dm = DistanceMatrix(data, ids)
-        self.assertEqual(_pair_members_to_new_node(dm, 'a', 'b', True), (0, 4))
-        # this makes it clear why negative branch lengths don't make sense...
-        self.assertEqual(
-            _pair_members_to_new_node(dm, 'a', 'b', False), (-16, 20))
+    def test_tree_from_linkmat(self):
+        taxa = ['human', 'chimp', 'monkey', 'pig', 'mouse', 'rat', 'chicken']
+        lm = [
+            [5, 4, 0.065041, 0.060976],   # rat, mouse
+            [6, 7, 0.457317, 0.229675],   # chicken, rat-mouse
+            [3, 8, 0.161924, 0.050474],   # pig, chicken-rat-mouse
+            [2, 9, 0.018293, 0.162602],   # monkey, pig-...-mouse
+            [10, 1, 0.006098, 0.001016],  # chimp, monkey-...-mouse
+            [0, 11, 0.003049, 0.0],       # human, chimp-...-mouse
+        ]
+        obs = str(_tree_from_linkmat(lm, taxa, rooted=True))
+        exp = ("(human:0.003049,((monkey:0.018293,(pig:0.161924,(chicken:0.457317,"
+               "(rat:0.065041,mouse:0.060976):0.229675):0.050474):0.162602):0.006098,"
+               "chimp:0.001016):0.0);\n")
+        self.assertEqual(str(obs), exp)
+        obs = str(_tree_from_linkmat(lm, taxa, rooted=False))
+        exp = ("(human:0.003049,(monkey:0.018293,(pig:0.161924,(chicken:0.457317,"
+               "(rat:0.065041,mouse:0.060976):0.229675):0.050474):0.162602):0.006098,"
+               "chimp:0.001016);\n")
+        self.assertEqual(str(obs), exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR optimizes [**neighbor joining (NJ)**](https://en.wikipedia.org/wiki/Neighbor_joining), a classical algorithm for phylogenetic tree building based on a distance matrix among taxa. The new algorithm is 20-30x faster than the old one, and is competitive when compared with popular implementations in the community.

FYI @christapo @RaeedA 

The old implementation was already quite efficient, due to the use of NumPy vectorization throughout the algorithm. The new algorithm further achieves performance gain because of:

1. The agglomerative clustering process does not create intermediate matrices and arrays during each iteration. Instead, it re-uses the same block of memory space over and over. This not only improves memory efficiency but also reduces the time overheads of allocating new memory space.
2. One time-consuming step: Building a "Q-matrix" and finding the minimum value, is Cythonized. It is possible to use NumPy to find the minimum non-diagonal value in a distance matrix, but the process is quite convoluted. The Cython code is more efficient in this.
3. Instead of building a Newick string incrementally during iteration, the new code builds a linkage matrix, which is purely numeric and can be pre-allocated. The linkage matrix data structure resembles [that of SciPy's](https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html), but with some differences to reflect the unequal branch lengths of the left and right children.
5. Multiple other tweaks of the math.

Note: The entire function works with numbers only, and can be completely Cythonized. However, Cythonization does not deliver much performance gain in the test (roughly 5-20%), likely because the code already uses NumPy in every line. But the code may be further optimized given its independence from any Pythonic operations.

Another potentional major optimization is to directly manipulate the input distance matrix rather than making a copy of it. This will be useful when working with extremely large distance matrices. However, this will destroy the input distance matrix, therefore requires more thoughts on the `DistanceMatrix` data structure before implementing.

***

Benchmarks on a distance matrix of **485** taxa, derived from real-world 16S rRNA sequences.

- scikit-bio (old): runtime = 0.441 sec, memory = 12,580 KB
- scikit-bio (new): runtime = 0.0161 sec, memory = 2,220 KB

Additional benchmarks were performed on Xeon Platinum 8358 CPUs:

485 taxa:

| Program | Runtime (sec) |
| --- | ---: |
| scikit-bio (new) | 0.03833 |
| scikit-bio (old) | 0.76472 |
| DendroPy 5.0.1 | 3.92156 |
| Biotite 1.0.1 | 0.13615 |
| BioPython 1.84 | 43.41698 |
| QuickTree 2.5 | 0.07855 |
| RapidNJ 2.3.3 | 0.05281 |

9232 taxa:

| Program | Runtime (sec) |
| --- | ---: |
| scikit-bio (new) | 140.638 |
| scikit-bio (old) | 7409.659 |
| Biotite 1.0.1 | 1209.335 |
| QuickTree 2.5 | 256.255 |
| RapidNJ 2.3.3 | 10.226 |

Notes:

- Runtime for Python libraries scikit-bio, DendroPy, Biotite and BioPython only includes the execution of the NJ algorithm, whereas runtime for command-line tools QuickTree and RapidNJ also include file input / output. Therefore, the benchmark is unfair to the latter category, especially the smaller test. scikit-bio isn't fast in reading a big distance matrix from a file. This needs further improvement.
- If I understand correctly, RapidNJ is heuristic, wheras others are optimal (NJ itself is heuristic for minimum evolution, but it is another story).
- I couldn't figure out how to install DecentTree, which is a very recent and performant NJ package.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
