### PR TITLE
Moved pytest conf to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,19 @@
 requires = ["setuptools", "wheel", "numpy", "cython"]
 
 [tool.pytest.ini_options]
+addopts = [
+    "--pyargs",
+    "skbio",
+    "--doctest-modules",
+    "--doctest-glob",
+    "*.pyx",
+]
 filterwarnings = [
     "ignore::skbio.util.SkbioWarning",
+]
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "IGNORE_EXCEPTION_DETAIL",
 ]
 
 [tool.check-manifest]

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -251,7 +251,7 @@ def _normalize_signs(arr1, arr2):
     flips the sign of the column as needed.
 
     """
-    # Let's convert everyting to floating point numbers (it's
+    # Let's convert everything to floating point numbers (it's
     # reasonable to assume that eigenvectors will already be floating
     # point numbers). This is necessary because np.array(1) /
     # np.array(0) != np.array(1.) / np.array(0.)
@@ -425,15 +425,5 @@ def pytestrunner():
     # import here, cause outside the eggs aren't loaded
     import pytest
 
-    args = [
-        "--pyargs",
-        "skbio",
-        "--doctest-modules",
-        "--doctest-glob",
-        "*.pyx",
-        "-o",
-        '"doctest_optionflags=NORMALIZE_WHITESPACE' ' IGNORE_EXCEPTION_DETAIL"',
-    ] + sys.argv[1:]
-
-    errno = pytest.main(args=args)
+    errno = pytest.main(args=sys.argv[1:])
     sys.exit(errno)


### PR DESCRIPTION
`pyproject.toml` is a modern way of configuring a Python package. Pytest support `pyproject.toml` configuration. This PR moves the previous command-line configurations to this file.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
