### PR TITLE
Fixed a `TreeNode.find` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Bug fixes
 
+* Fixed a bug in `TreeNode.find` which returns the input node object even if it's not in the current tree ([#2153](https://github.com/scikit-bio/scikit-bio/pull/2153)).
 * Fixed a bug in `TreeNode.get_max_distance` which returns tip names instead of tip instances when there are single-child nodes in the tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed an issue in `subsets` and `tip_tip_distances` of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.compare_rfd` which raises an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -5290,7 +5290,7 @@ class TreeNode(SkbioObject):
         ----------
         name : TreeNode or str
             The name of the node to find. If a ``TreeNode`` object is provided,
-            then it is simply returned.
+            will find this particular node in the tree.
 
         Returns
         -------
@@ -5300,7 +5300,7 @@ class TreeNode(SkbioObject):
         Raises
         ------
         MissingNodeError
-            If the node to be searched for is not found.
+            If the node to be searched for is not found in the current tree.
 
         See Also
         --------
@@ -5321,34 +5321,44 @@ class TreeNode(SkbioObject):
         assumption that additional calls to ``find`` will be made. See
         :meth:`details <has_caches>`.
 
+        This method searches within the entire tree where self is located, regardless
+        if self is the root node.
+
         Examples
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a,b)c,(d,e)f);"])
-        >>> print(tree.find('c').name)
-        c
+        >>> node = tree.find('c')
+        >>> node.name
+        'c'
 
         """
         tree = self.root()
 
-        # if what is being passed in looks like a node, just return it
-        if isinstance(name, tree.__class__):
-            return name
-
         # create lookup table if not already
         tree.create_caches()
 
+        # if input is a node, get its name
+        name_is_node = isinstance(name, tree.__class__)
+        name_ = name.name if name_is_node else name
+
         # look up name in tips
-        node = tree._tip_cache.get(name, None)
+        node = tree._tip_cache.get(name_, None)
         if node is not None:
-            return node
+            if not name_is_node or node is name:
+                return node
 
         # look up name in non-tips
-        node = tree._non_tip_cache.get(name, [None])[0]
-        if node is not None:
-            return node
+        nodes = tree._non_tip_cache.get(name_, None)
+        if nodes is not None:
+            if name_is_node:
+                for node in nodes:
+                    if node is name:
+                        return node
+            else:
+                return nodes[0]
 
-        raise MissingNodeError(f"Node '{name}' is not found.")
+        raise MissingNodeError(f"Node '{name_}' is not found in the tree.")
 
     def find_all(self, name):
         r"""Find all nodes that match a given name.
@@ -5383,6 +5393,9 @@ class TreeNode(SkbioObject):
         The first call to ``find_all`` will cache a node lookup table in the tree on
         the assumption that additional calls to ``find_all`` will be made. See
         :meth:`details <has_caches>`.
+
+        This method searches within the entire tree where self is located, regardless
+        if self is the root node.
 
         Examples
         --------
@@ -5451,7 +5464,8 @@ class TreeNode(SkbioObject):
 
         Notes
         -----
-        This search method is based from the root of the tree.
+        This method searches within the subtree under the current node. But the IDs
+        are assigned from the root of the entire tree.
 
         This method does not cache ID associations. A full traversal of the
         tree is performed to find a node by an ID on every call.

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -2431,19 +2431,37 @@ class TreeTests(TestCase):
         obs = t.find("c")
         self.assertEqual(obs, exp)
 
+        # input is node object
+        obs = t.find(exp)
+        self.assertIs(obs, exp)
+
         # find a tip
         exp = t.children[0].children[1]
         obs = t.find("b")
         self.assertEqual(obs, exp)
 
-        # input is node
+        # input is tip object
         obs = t.find(exp)
-        self.assertIs(obs, exp)
+        self.assertEqual(obs, exp)
 
         # name not found
-        msg = "Node 'missing' is not found."
+        msg = "Node 'missing' is not found in the tree."
         with self.assertRaisesRegex(MissingNodeError, msg):
             t.find("missing")
+
+        # input is a node but not in current tree
+        with self.assertRaisesRegex(MissingNodeError, msg):
+            t.find(TreeNode("missing"))
+
+        # input node name matches a tip but it's not in the current tree
+        msg = "Node 'a' is not found in the tree."
+        with self.assertRaisesRegex(MissingNodeError, msg):
+            t.find(TreeNode("a"))
+
+        # input node name matches a non-tip but it's not in the current tree
+        msg = "Node 'c' is not found in the tree."
+        with self.assertRaisesRegex(MissingNodeError, msg):
+            t.find(TreeNode("c"))
 
     def test_find_all(self):
         t = TreeNode.read(["((a,b)c,((d,e)c)c,(f,(g,h)c)a)root;"])


### PR DESCRIPTION
The bug is that when a `TreeNode` object is provided to the `TreeNode.find` method, it will be returned directly, even if the node is not present in the current tree (e.g., in another tree). This PR fixed it.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
