### PR TITLE
Optimized neighbor-joining (NJ) memory usage

### DIFF
--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -17,6 +17,7 @@ def nj(
     dm,
     clip_to_zero=True,
     result_constructor=None,
+    inplace=False,
     disallow_negative_branch_length=None,
 ):
     r"""Perform neighbor joining (NJ) for phylogenetic reconstruction.
@@ -36,6 +37,12 @@ def nj(
         future release.
 
         .. deprecated:: 0.6.3
+
+    inplace : bool, optional
+        If True, the input distance matrix will be manipulated in-place to reduce
+        memory consumption, at the cost of losing the original data. Default is False.
+
+        .. versionadded:: 0.6.3
 
     disallow_negative_branch_length : bool, optional
         Alias of ``clip_to_zero`` for backward compatibility. Deprecated and to be
@@ -151,8 +158,13 @@ def nj(
             "Distance matrix must be at least 3x3 to generate a neighbor joining tree."
         )
     taxa = list(dm.ids)
-    dm_ = dm.data.astype(float)  # make a copy of the distance matrix data
+
+    dm_ = dm.data
+    if not inplace:
+        dm_ = dm_.copy()
+
     lm = _nj(dm_)
+
     tree = _tree_from_linkmat(lm, taxa, rooted=False, clip_to_zero=clip_to_zero)
     if result_constructor is not None:
         tree = result_constructor(str(tree))

--- a/skbio/tree/tests/test_nj.py
+++ b/skbio/tree/tests/test_nj.py
@@ -9,6 +9,8 @@
 import io
 from unittest import TestCase, main
 
+import numpy.testing as npt
+
 from skbio import DistanceMatrix, TreeNode
 from skbio.tree._nj import nj, _tree_from_linkmat
 
@@ -87,6 +89,18 @@ class NjTests(TestCase):
         actual_TreeNode = nj(self.dm3)
         self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
             self.expected3_TreeNode), 0.0)
+
+    def test_nj_inplace(self):
+        dm = self.dm3.copy()
+        obs = nj(dm)
+        exp = self.expected3_TreeNode
+        self.assertAlmostEqual(obs.compare_tip_distances(exp), 0.0)
+        npt.assert_almost_equal(dm.data, self.dm3.data)
+
+        obs = nj(dm, inplace=True)
+        self.assertAlmostEqual(obs.compare_tip_distances(exp), 0.0)
+        with self.assertRaises(AssertionError):
+            npt.assert_almost_equal(dm.data, self.dm3.data)
 
     def test_nj_zero_branch_length(self):
         # no nodes have negative branch length when we disallow negative


### PR DESCRIPTION
Added `inplace` mode, which further reduces memory consumption by avoiding creating a copy of the distance matrix but instead manipulating the distance matrix in place. This destroys the input data though. A similar mechanism was already used in `pcoa`.

Test on 9,232 taxa:
Baseline: 819,204 KB
`inplace=False` (default): 1,488,096 KB (+668,892)
`inplace=True`: 822,284 KB (+3,080)

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
