### PR TITLE
Renamed tip-tip distance as cophenetic distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Performance enhancements
 
 * Significantly improved the performance of the neighbor joining (NJ) algorithm for phylogenetic reconstruction (`nj`) ([#2147](https://github.com/scikit-bio/scikit-bio/pull/2147)).
-* Significantly improved the performance of `TreeNode.tip_tip_distances` for computing a patristic distance matrix among all or selected tips of a tree ([#2152](https://github.com/scikit-bio/scikit-bio/pull/2152)).
+* Significantly improved the performance of `TreeNode.cophenet` (renamed from `tip_tip_distances`) for computing a patristic distance matrix among all or selected tips of a tree ([#2152](https://github.com/scikit-bio/scikit-bio/pull/2152)).
 * Supported Robinson-Foulds distance calculation (`TreeNode.compare_rfd`) based on bipartitions (equivalent to `compare_biparts`). This is automatically enabled when the input tree is unrooted. Otherwise the calculation is still based on subsets (equivalent to `compare_subsets`). The user can override this behavior using the `rooted` parameter ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Re-wrote the underlying algorithm of `TreeNode.compare_subsets` because it is equivalent to the Robinson-Foulds distance on rooted trees. Added parameter `proportion`. Renamed parameter `exclude_absent_taxa` as `shared_only` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Added parameter `include_self` to `TreeNode.subset`. Added parameters `within`, `include_full` and `include_single` to `TreeNode.subsets` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
@@ -33,7 +33,7 @@
 * Added parameter `strict` to `TreeNode.shear` ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added parameter `exclude_attrs` to `TreeNode.unrooted_copy` ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
 * Added support for legacy random generator to `get_rng`, such that outputs of scikit-bio functions become reproducible with code that starts with `np.random.seed` or uses `RandomState` ([#2130](https://github.com/scikit-bio/scikit-bio/pull/2130)).
-* Allowed `shuffle` and `compare_tip_distances` of `TreeNode` to accept a random seed or random generator to generate the shuffling function, which ensures output reproducibility ([#2118](https://github.com/scikit-bio/scikit-bio/pull/2118)).
+* Allowed `shuffle` and `compare_cophenet` (renamed from `compare_tip_distances`) of `TreeNode` to accept a random seed or random generator to generate the shuffling function, which ensures output reproducibility ([#2118](https://github.com/scikit-bio/scikit-bio/pull/2118)).
 * Added beta diversity metric `jensenshannon`, which calculates Jensen-Shannon distance. Thank @quliping for suggesting this in [#2125](https://github.com/scikit-bio/scikit-bio/pull/2125).
 * Added parameter `include_self` to `TreeNode.ancestors` to optionally include the initial node in the path (default: False) ([#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Added parameter `seed` to functions `pcoa`, `anosim`, `permanova`, `permdisp`, `randdm`, `lladser_pe`, `lladser_ci`, `isubsample`, `subsample_power`, `subsample_paired_power`, `paired_subsamples` and `hommola_cospeciation` to accept a random seed or random generator to ensure output reproducibility ([#2120](https://github.com/scikit-bio/scikit-bio/pull/2120) and [#2129](https://github.com/scikit-bio/scikit-bio/pull/2129)).
@@ -44,7 +44,7 @@
 
 * Fixed a bug in `TreeNode.find` which returns the input node object even if it's not in the current tree ([#2153](https://github.com/scikit-bio/scikit-bio/pull/2153)).
 * Fixed a bug in `TreeNode.get_max_distance` which returns tip names instead of tip instances when there are single-child nodes in the tree ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
-* Fixed an issue in `subsets` and `tip_tip_distances` of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Fixed an issue in `subsets` and `cophenet` (renamed from `tip_tip_distances`) of `TreeNode` which leaves remnant attributes at each node after execution ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.compare_rfd` which raises an error if taxa of the two trees are not subsets of each other ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.compare_subsets` which includes the full set (not a subset) of shared taxa between two trees if a basal clade of either tree consists of entirely unshared taxa ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Fixed a bug in `TreeNode.lowest_common_ancestor` which returns the parent of input node X instead of X itself if X is ancestral to other input nodes ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
@@ -61,6 +61,7 @@
 * Remodeled documentation. Special methods (previously referred to as built-in methods) and inherited methods of a class no longer have separate stub pages. This significantly reduced the total number of webpages in the documentation ([#2110](https://github.com/scikit-bio/scikit-bio/pull/2110)).
 * Renamed `TreeNode.invalidate_caches` as `clear_caches`, because the caches are indeed deleted rather than marked as obsolete. The old name is preserved as an alias ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Renamed `TreeNode.remove_deleted` as `remove_by_func`. The old name is preserved as an alias ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
+* Renamed `get_max_distance` as `maxdist`. Renamed `tip_tip_distances` as `cophenet`. Renamed `compare_tip_distances` as `compare_cophenet`. The new names are consistent with SciPy's relevant functions and the main body of the literature. The old names are preserved as aliases.
 
 ### Deprecated functionality
 

--- a/doc/source/_templates/TreeNode.rst
+++ b/doc/source/_templates/TreeNode.rst
@@ -115,12 +115,15 @@
       ~{{ name }}.accumulate_to_ancestor
       ~{{ name }}.descending_branch_length
       ~{{ name }}.distance
+      ~{{ name }}.maxdist
       ~{{ name }}.get_max_distance
+      ~{{ name }}.cophenet
       ~{{ name }}.tip_tip_distances
       ~{{ name }}.compare_rfd
       ~{{ name }}.compare_wrfd
       ~{{ name }}.compare_subsets
       ~{{ name }}.compare_biparts
+      ~{{ name }}.compare_cophenet
       ~{{ name }}.compare_tip_distances
 
    .. rubric:: Tree visualization

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -644,6 +644,8 @@ class TreeNode(SkbioObject):
     def path(self, other, include_ends=False):
         r"""Return the list of nodes in the path from self to another node.
 
+        .. versionadded:: 0.6.3
+
         Parameters
         ----------
         other : TreeNode
@@ -1493,7 +1495,8 @@ class TreeNode(SkbioObject):
         r"""Remove nodes of a tree that meet certain criteria.
 
         .. versionchanged:: 0.6.3
-            This method was renamed from ``remove_deleted``.
+            Renamed from ``remove_deleted``. The old name is kept as an alias. But it
+            may be removed in a future version.
 
         Parameters
         ----------
@@ -2808,7 +2811,7 @@ class TreeNode(SkbioObject):
         if reset:
             tree.unroot(uncache=False)
 
-        max_dist, tips = tree.get_max_distance()
+        max_dist, tips = tree.maxdist()
         half_max_dist = max_dist / 2.0
 
         if max_dist == 0.0:
@@ -3889,10 +3892,10 @@ class TreeNode(SkbioObject):
         See Also
         --------
         path
-        tip_tip_distances
+        cophenet
         accumulate_to_ancestor
-        compare_tip_distances
-        get_max_distance
+        compare_cophenet
+        maxdist
 
         Notes
         -----
@@ -3903,7 +3906,7 @@ class TreeNode(SkbioObject):
 
         This method can be used to compute the distance between two given nodes.
         However, it is not optimized for computing all pairwise tip distances. Use
-        :meth:`tip_tip_distances` instead for that purpose.
+        :meth:`cophenet` instead for that purpose.
 
         References
         ----------
@@ -3933,10 +3936,13 @@ class TreeNode(SkbioObject):
         except TypeError:
             raise NoLengthError("Nodes without branch length are encountered.")
 
-    def get_max_distance(self, use_length=True):
-        r"""Return the maximum path distance between any pair of tips.
+    def maxdist(self, use_length=True):
+        r"""Return the maximum distance between any pair of tips in the tree.
 
-        This is also referred to as the diameter of a tree.
+        .. versionchanged:: 0.6.3
+            Renamed from ``get_max_distance``. The old name is kept as an alias.
+
+        This measure is also referred to as the **diameter** of a tree.
 
         Parameters
         ----------
@@ -3956,21 +3962,26 @@ class TreeNode(SkbioObject):
         See Also
         --------
         distance
-        tip_tip_distances
-        compare_tip_distances
+        cophenet
+        scipy.cluster.hierarchy.maxdists
 
         Notes
         -----
-        If a node does not have an associated branch length, 0 will be used.
+        This method identifies the two furthest apart tips in a tree, as measured by
+        the sum of branch lengths (i.e., patristic distance) connecting them. Missing
+        branch lengths will be replaced with 0. When ``use_length=False``, the number
+        of branches connecting two tips will be considered instead.
 
         When a tie is observed among more than one pair of tips, only one pair will be
-        returned. The choice is stable. This often happens when `use_length=False`.
+        returned. The choice is stable. This often happens when ``use_length=False``.
+
+        This method operates on the subtree below the current node.
 
         Examples
         --------
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a:1,b:2)c:3,(d:4,e:5)f:6)root;"])
-        >>> dist, tips = tree.get_max_distance()
+        >>> dist, tips = tree.maxdist()
         >>> dist
         16.0
         >>> [n.name for n in tips]
@@ -4027,8 +4038,13 @@ class TreeNode(SkbioObject):
             max_dist = float(max_dist)
         return max_dist, (max_tip1, max_tip2)
 
-    def tip_tip_distances(self, endpoints=None, use_length=True):
-        r"""Return a distance matrix between pairs of tips.
+    get_max_distance = maxdist
+
+    def cophenet(self, endpoints=None, use_length=True):
+        r"""Return a distance matrix between each pair of tips in the tree.
+
+        .. versionchanged:: 0.6.3
+            Renamed from ``tip_tip_distances``. The old name is kept as an alias.
 
         Parameters
         ----------
@@ -4045,7 +4061,7 @@ class TreeNode(SkbioObject):
         Returns
         -------
         DistanceMatrix
-            The distance matrix.
+            The cophenetic distance matrix.
 
         Raises
         ------
@@ -4059,22 +4075,42 @@ class TreeNode(SkbioObject):
         See Also
         --------
         distance
-        compare_tip_distances
+        compare_cophenet
+        scipy.cluster.hierarchy.cophenet
 
         Notes
         -----
-        This method calculates the sum of branch lengths connecting each pair of tips.
-        It is also known as the patristic distance [1]_. If a node does not have an
-        associated branch length, 0 will be used.
+        The cophenetic distance [1]_ between a pair of tips is essentially the sum of
+        branch lengths connecting them (i.e., patristic distance [2]_, see
+        :meth:`distance`). It measures the divergence between two taxa in evolution.
 
-        If ``use_length`` is False, the method instead calculates the number of
-        branches connecting each pair of tips.
+        This method calculates the cophenetic distances between all pairs of tips in a
+        tree and returns a distance matrix. Missing branch lengths will be replaced with
+        0's. If ``use_length`` is False, the method instead calculates the number of
+        branches connecting each pair of tips. This method operates on the subtree below
+        the current node.
 
-        This method operates on the subtree below the current node.
+        In hierarchical clustering, the cophenetic distance is commonly used to measure
+        the dissimilarity between two objects before they are joined in a dendrogram.
+        In that context, it is also defined as the height of the lowest common ancestor
+        (LCA) from the surface of the tree. However, phylogenetic trees are usually
+        non-ultrametric (e.g., :func:`~skbio.tree.nj`), and the two child clades of a
+        node may have different heights. Therefore, the cophenetic distance is instead
+        defined as the patristic distance between the two tips. For ultrametric trees
+        (e.g., :func:`~skbio.tree.upgma`), this method's result should match SciPy's
+        :func:`~scipy.cluster.hierarchy.cophenet`.
+
+        One should also distinguish cophenetic distance from a related metric:
+        cophenetic value [1]_, which is the patristic distance between the LCA of two
+        tips and the root of the tree. It quantifies the shared evolutionary history
+        between two taxa, as in contrast to the cophenetic distance.
 
         References
         ----------
-        .. [1] Fourment, M., & Gibbs, M. J. (2006). PATRISTIC: a program for
+        .. [1] Sokal, R. R., & Rohlf, F. J. (1962). The comparison of dendrograms by
+           objective methods. Taxon, 33-40.
+
+        .. [2] Fourment, M., & Gibbs, M. J. (2006). PATRISTIC: a program for
            calculating patristic distances and graphically comparing the components of
            genetic change. BMC evolutionary biology, 6, 1-5.
 
@@ -4083,9 +4119,10 @@ class TreeNode(SkbioObject):
         >>> from skbio import TreeNode
         >>> tree = TreeNode.read(["((a:1,b:2)c:3,(d:4,e:5)f:6)root;"])
 
-        Calculate path length distances (patristic distances).
+        Calculate cophenetic distances as the sum of branch lengths (i.e., patristic
+        distance).
 
-        >>> mat = tree.tip_tip_distances()
+        >>> mat = tree.cophenet()
         >>> print(mat)
         4x4 distance matrix
         IDs:
@@ -4096,9 +4133,9 @@ class TreeNode(SkbioObject):
          [ 14.  15.   0.   9.]
          [ 15.  16.   9.   0.]]
 
-        Calculate path distances (branch counts).
+        Calculate cophenetic distances as the number of branches.
 
-        >>> mat = tree.tip_tip_distances(use_length=False)
+        >>> mat = tree.cophenet(use_length=False)
         >>> print(mat)
         4x4 distance matrix
         IDs:
@@ -4200,6 +4237,8 @@ class TreeNode(SkbioObject):
 
         # Skip validation as all items to validate are guaranteed.
         return DistanceMatrix(result, taxa, validate=False)
+
+    tip_tip_distances = cophenet
 
     def _compare_topology(
         self,
@@ -4467,7 +4506,7 @@ class TreeNode(SkbioObject):
         compare_wrfd
         compare_subsets
         compare_biparts
-        compare_tip_distances
+        compare_cophenet
 
         References
         ----------
@@ -4599,7 +4638,7 @@ class TreeNode(SkbioObject):
         See Also
         --------
         compare_rfd
-        compare_tip_distances
+        compare_cophenet
 
         References
         ----------
@@ -4680,7 +4719,7 @@ class TreeNode(SkbioObject):
             result *= 0.5
         return result
 
-    def compare_tip_distances(
+    def compare_cophenet(
         self,
         other,
         sample=None,
@@ -4691,7 +4730,10 @@ class TreeNode(SkbioObject):
         dist_f=None,
         shuffle_f=None,
     ):
-        r"""Calculate the distance between two trees based on tip-to-tip distances.
+        r"""Calculate the distance between two trees based on cophenetic distances.
+
+        .. versionchanged:: 0.6.3
+            Renamed from ``compare_tip_distances``. The old name is kept as an alias.
 
         Parameters
         ----------
@@ -4770,24 +4812,28 @@ class TreeNode(SkbioObject):
 
         See Also
         --------
-        tip_tip_distances
+        cophenet
         compare_rfd
         compare_wrfd
 
         Notes
         -----
-        This method calculates the dissimilarity between the tip-to-tip distance
-        matrices of two trees. Tips are identified by their names (i.e., taxa). Only
-        tips shared between the two trees are considered. Tips unique to either tree
-        are excluded from the calculation.
+        This method calculates the dissimilarity between the cophenetic distance [1]_
+        (i.e., tip-to-tip distance) matrices of two trees. Tips are identified by
+        their names (i.e., taxa). Only tips shared between the trees are considered.
+        Tips unique to either tree are excluded from the calculation.
 
         The default behavior returns a unit correlation distance (range: [0, 1]),
         measuring the dissimilarity between the relative evolutionary distances among
         taxa, regardless of the tree scale (i.e., multiply all branch lengths in one
-        tree by a factor and the result remains the same).
+        tree by a factor and the result remains the same). This measure is closely
+        related to **cophenetic correlation**, which measures the similarity (instead
+        of dissimilarity) between two cophenetic distance matrices, or between a
+        cophenetic distance matrix and the original distance matrix among taxa on
+        which hierarchical clustering was performed.
 
         When the metric is Euclidean and lengths are used, it returns the **path-length
-        distance** [1]_, which is the square root of the sum of squared differences of
+        distance** [2]_, which is the square root of the sum of squared differences of
         path lengths among all pairs of taxa.
 
         .. math::
@@ -4799,15 +4845,18 @@ class TreeNode(SkbioObject):
         respectively.
 
         When the metric is Euclidean and lengths are not used, it returns the **path
-        distance** [2]_, which insteads considers the number of edges in the path.
+        distance** [3]_, which insteads considers the number of edges in the path.
 
         References
         ----------
-        .. [1] Lapointe, F. J., & Cucumel, G. (1997). The average consensus procedure:
+        .. [1] Sokal, R. R., & Rohlf, F. J. (1962). The comparison of dendrograms by
+           objective methods. Taxon, 33-40.
+
+        .. [2] Lapointe, F. J., & Cucumel, G. (1997). The average consensus procedure:
            combination of weighted trees containing identical or overlapping sets of
            taxa. Systematic Biology, 46(2), 306-312.
 
-        .. [2] Steel, M. A., & Penny, D. (1993). Distributions of tree comparison
+        .. [3] Steel, M. A., & Penny, D. (1993). Distributions of tree comparison
            metrics—some new results. Systematic Biology, 42(2), 126-141.
 
         Examples
@@ -4843,31 +4892,31 @@ class TreeNode(SkbioObject):
 
         Calculate the unit correlation distance between the two trees.
 
-        >>> d = tree1.compare_tip_distances(tree2, ignore_self=True)
+        >>> d = tree1.compare_cophenet(tree2, ignore_self=True)
         >>> print(round(d, 5))
         0.14131
 
         Calculate the path-length distance between the two trees.
 
-        >>> d = tree1.compare_tip_distances(tree2, metric="euclidean",
+        >>> d = tree1.compare_cophenet(tree2, metric="euclidean",
         ...                                 ignore_self=True)
         >>> print(round(d, 5))
         13.71131
 
         Calculate the path distance between the two trees.
 
-        >>> tree1.compare_tip_distances(
+        >>> tree1.compare_cophenet(
         ...     tree2, metric="euclidean", use_length=False, ignore_self=True)
         4.0
 
         """
         # future warning
         if ignore_self is False:
-            func = self.__class__.compare_tip_distances
+            func = self.__class__.compare_cophenet
             if not hasattr(func, "warned"):
                 simplefilter("once", FutureWarning)
                 warn(
-                    "The default behavior of `compare_tip_distances` is subject to "
+                    "The default behavior of `compare_cophenet` is subject to "
                     "change in 0.7.0. The new default behavior can be achieved by "
                     "specifying `ignore_self=True`.",
                     FutureWarning,
@@ -4894,8 +4943,8 @@ class TreeNode(SkbioObject):
         tips1 = [tipmap1[x] for x in shared]
         tips2 = [tipmap2[x] for x in shared]
 
-        dm1 = self.tip_tip_distances(endpoints=tips1, use_length=use_length)
-        dm2 = other.tip_tip_distances(endpoints=tips2, use_length=use_length)
+        dm1 = self.cophenet(endpoints=tips1, use_length=use_length)
+        dm2 = other.cophenet(endpoints=tips2, use_length=use_length)
 
         if ignore_self:
             dm1 = dm1.condensed_form()
@@ -4915,6 +4964,8 @@ class TreeNode(SkbioObject):
             result *= 0.5
 
         return result
+
+    compare_tip_distances = compare_cophenet
 
     # ------------------------------------------------
     # Tree indexing and searching

--- a/skbio/tree/tests/test_bme.py
+++ b/skbio/tree/tests/test_bme.py
@@ -79,17 +79,17 @@ class BmeTests(TestCase):
 
     def test_bme_dm1(self):
         actual_TreeNode = bme(self.dm1)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected1_TreeNode), 0.0)
 
     def test_bme_dm2(self):
         actual_TreeNode = bme(self.dm2)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected2_TreeNode), 0.0)
 
     def test_bme_dm3(self):
         actual_TreeNode = bme(self.dm3)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected3_TreeNode), 0.0)
 
     def test_bme_zero_branch_length(self):
@@ -174,7 +174,7 @@ class BmeTests(TestCase):
         actual_TreeNode = TreeNode.read(io.StringIO(pre_estimation_str))
         _bal_ols_edge(actual_TreeNode, dm)
         expected_TreeNode = TreeNode.read(io.StringIO(expected_str))
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             expected_TreeNode), 0.0, places=10)
 
 if __name__ == "__main__":

--- a/skbio/tree/tests/test_gme.py
+++ b/skbio/tree/tests/test_gme.py
@@ -84,17 +84,17 @@ class GmeTests(TestCase):
 
     def test_gme_dm1(self):
         actual_TreeNode = gme(self.dm1)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected1_TreeNode), 0.0, places=10)
 
     def test_gme_dm2(self):
         actual_TreeNode = gme(self.dm2)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected2_TreeNode), 0.0, places=10)
 
     def test_gme_dm3(self):
         actual_TreeNode = gme(self.dm3)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected3_TreeNode), 0.0, places=10)
 
     def test_gme_zero_branch_length(self):
@@ -245,7 +245,7 @@ class GmeTests(TestCase):
         actual_TreeNode = TreeNode.read(io.StringIO(pre_estimation_str))
         _ols_edge(actual_TreeNode, dm)
         expected_TreeNode = TreeNode.read(io.StringIO(expected_str))
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             expected_TreeNode), 0.0, places=10)
 
 if __name__ == "__main__":

--- a/skbio/tree/tests/test_nj.py
+++ b/skbio/tree/tests/test_nj.py
@@ -77,28 +77,28 @@ class NjTests(TestCase):
 
     def test_nj_dm1(self):
         actual_TreeNode = nj(self.dm1)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected1_TreeNode), 0.0)
 
     def test_nj_dm2(self):
         actual_TreeNode = nj(self.dm2)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected2_TreeNode), 0.0)
 
     def test_nj_dm3(self):
         actual_TreeNode = nj(self.dm3)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected3_TreeNode), 0.0)
 
     def test_nj_inplace(self):
         dm = self.dm3.copy()
         obs = nj(dm)
         exp = self.expected3_TreeNode
-        self.assertAlmostEqual(obs.compare_tip_distances(exp), 0.0)
+        self.assertAlmostEqual(obs.compare_cophenet(exp), 0.0)
         npt.assert_almost_equal(dm.data, self.dm3.data)
 
         obs = nj(dm, inplace=True)
-        self.assertAlmostEqual(obs.compare_tip_distances(exp), 0.0)
+        self.assertAlmostEqual(obs.compare_cophenet(exp), 0.0)
         with self.assertRaises(AssertionError):
             npt.assert_almost_equal(dm.data, self.dm3.data)
 
@@ -120,7 +120,7 @@ class NjTests(TestCase):
 
         # deprecated functionality
         t2 = nj(self.dm4, disallow_negative_branch_length=False)
-        self.assertAlmostEqual(tree.compare_tip_distances(t2), 0.0)
+        self.assertAlmostEqual(tree.compare_cophenet(t2), 0.0)
 
     def test_nj_trivial(self):
         data = [[0, 3, 2],
@@ -128,7 +128,7 @@ class NjTests(TestCase):
                 [2, 3, 0]]
         dm = DistanceMatrix(data, list('abc'))
         exp = TreeNode.read(["(b:2.000000, a:1.000000, c:1.000000);"])
-        self.assertAlmostEqual(nj(dm).compare_tip_distances(exp), 0.0)
+        self.assertAlmostEqual(nj(dm).compare_cophenet(exp), 0.0)
 
         # deprecated functionality
         self.assertEqual(nj(dm, result_constructor=str), "(a:1.0,b:2.0,c:1.0);\n")

--- a/skbio/tree/tests/test_nni.py
+++ b/skbio/tree/tests/test_nni.py
@@ -95,19 +95,19 @@ class NniTests(TestCase):
 
     def test_nni_dm1(self):
         actual_TreeNode = nni(self.pre1_nni_TreeNode, self.dm1, inplace=False, balanced=False)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.post1_nni_TreeNode), 0.0, places=10)
 
     def test_nni_dm2(self):
         # Resulting tree topology is equivalent to result from nj, however,
         # resulting edge lengths are almost equal to 2 places.
         actual_TreeNode = nni(self.pre2_nni_TreeNode, self.dm2, inplace=False, balanced=False)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.post2_nni_TreeNode), 0.0)
 
     def test_nni_dm3(self):
         actual_TreeNode = nni(self.pre3_nni_TreeNode, self.dm3, inplace=False, balanced=False)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.post3_nni_TreeNode), 0.0)
         
     def test_nni_trivial(self):

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1302,15 +1302,15 @@ class TreeTests(TestCase):
         result = t.root_at_midpoint()
         self.assertEqual(result.distance(result.find("e")), 1.5)
         self.assertEqual(result.distance(result.find("g")), 2.5)
-        exp_dist = t.tip_tip_distances()
-        obs_dist = result.tip_tip_distances()
+        exp_dist = t.cophenet()
+        obs_dist = result.cophenet()
         self.assertEqual(obs_dist, exp_dist)
 
         # in-place rerooting
         b = t.find("b")
         result = t.root_at_midpoint(inplace=True)
         self.assertIs(b.parent, result)
-        self.assertEqual(result.tip_tip_distances(), exp_dist)
+        self.assertEqual(result.cophenet(), exp_dist)
 
     def test_root_at_midpoint_no_lengths(self):
         # should get same tree back (a copy)
@@ -1876,31 +1876,31 @@ class TreeTests(TestCase):
         self.assertEqual(tips[2].distance(tips[2], False), 0)
         self.assertEqual(tips[2].distance(tips[3], False), 2)
 
-    def test_get_max_distance(self):
+    def test_maxdist(self):
         """Get maximum tip-to-tip distance across tree. """
         # regular case
         tree = TreeNode.read([
             "((a:0.1,b:0.2)c:0.3,(d:0.4,e:0.5)f:0.6)root;"])
-        dist, nodes = tree.get_max_distance()
+        dist, nodes = tree.maxdist()
         self.assertAlmostEqual(dist, 1.6)
         self.assertListEqual([n.name for n in nodes], ["e", "b"])
 
         # number of branches
-        dist, nodes = tree.get_max_distance(use_length=False)
+        dist, nodes = tree.maxdist(use_length=False)
         self.assertEqual(dist, 4)
         self.assertListEqual([n.name for n in nodes], ["a", "d"])
 
         # tree with a single-child node and missing lengths
         tree = TreeNode.read(["((a:1,b:2),c:4,(((d:4,e:5):2):3,f:6));"])
-        dist, nodes = tree.get_max_distance()
+        dist, nodes = tree.maxdist()
         self.assertAlmostEqual(dist, 16)
         self.assertListEqual([n.name for n in nodes], ["e", "f"])
 
-        dist, nodes = tree.get_max_distance(use_length=False)
+        dist, nodes = tree.maxdist(use_length=False)
         self.assertEqual(dist, 6)
         self.assertListEqual([n.name for n in nodes], ["d", "a"])
 
-    def test_tip_tip_distances_endpoints(self):
+    def test_cophenet_endpoints(self):
         """Get a tip-to-tip distance matrix."""
         t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
         nodes = [t.find("H"), t.find("G"), t.find("M")]
@@ -1909,17 +1909,17 @@ class TreeTests(TestCase):
                                        [2.0, 0, 6.7],
                                        [6.7, 6.7, 0.0]]), ["H", "G", "M"])
 
-        obs = t.tip_tip_distances(endpoints=names)
+        obs = t.cophenet(endpoints=names)
         self.assertEqual(obs, exp)
 
-        obs = t.tip_tip_distances(endpoints=nodes)
+        obs = t.cophenet(endpoints=nodes)
         self.assertEqual(obs, exp)
 
         for node in t.traverse(include_self=True):
             assert not hasattr(node, '_start')
             assert not hasattr(node, '_stop')
 
-    def test_tip_tip_distances_counts(self):
+    def test_cophenet_counts(self):
         """Get a tip-to-tip distance matrix in counts."""
         t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
         nodes = [t.find("H"), t.find("G"), t.find("M")]
@@ -1928,45 +1928,45 @@ class TreeTests(TestCase):
                                        [2, 0, 4],
                                        [4, 4, 0]]), ["H", "G", "M"])
 
-        obs = t.tip_tip_distances(endpoints=names, use_length=False)
+        obs = t.cophenet(endpoints=names, use_length=False)
         self.assertEqual(obs, exp)
 
-        obs = t.tip_tip_distances(endpoints=nodes, use_length=False)
+        obs = t.cophenet(endpoints=nodes, use_length=False)
         self.assertEqual(obs, exp)
 
         for node in t.traverse(include_self=True):
             assert not hasattr(node, '_start')
             assert not hasattr(node, '_stop')
 
-    def test_tip_tip_distances_bad_endpoints(self):
+    def test_cophenet_bad_endpoints(self):
         t = TreeNode.read(["((H:1,G:1)foo:2,(R:0.5,M:0.7):3);"])
         with self.assertRaises(ValueError):
-            t.tip_tip_distances(endpoints=["foo"])
+            t.cophenet(endpoints=["foo"])
         with self.assertRaises(MissingNodeError):
-            t.tip_tip_distances(endpoints=["bar"])
+            t.cophenet(endpoints=["bar"])
 
         with self.assertRaises(DuplicateNodeError):
-            t.tip_tip_distances(endpoints=["H", "R", "H"])
+            t.cophenet(endpoints=["H", "R", "H"])
 
-    def test_tip_tip_distances_duplicate_tips(self):
+    def test_cophenet_duplicate_tips(self):
         t = TreeNode.read(["((H:1,G:1):2,(R:0.5,H:0.7):3);"])
         with self.assertRaises(DuplicateNodeError):
-            t.tip_tip_distances()
+            t.cophenet()
         with self.assertRaises(DuplicateNodeError):
-            t.tip_tip_distances(endpoints=["H", "R", "H"])
+            t.cophenet(endpoints=["H", "R", "H"])
 
-    def test_tip_tip_distances_no_length(self):
+    def test_cophenet_no_length(self):
         t = TreeNode.read(["((a,b)c,(d,e)f);"])
         exp_t = TreeNode.read(["((a:0,b:0)c:0,(d:0,e:0)f:0);"])
-        exp_t_dm = exp_t.tip_tip_distances()
-        t_dm = t.tip_tip_distances()
+        exp_t_dm = exp_t.cophenet()
+        t_dm = t.cophenet()
         self.assertEqual(t_dm, exp_t_dm)
 
-    def test_tip_tip_distances_missing_length(self):
+    def test_cophenet_missing_length(self):
         t = TreeNode.read(["((a,b:6)c:4,(d,e:0)f);"])
         exp_t = TreeNode.read(["((a:0,b:6)c:4,(d:0,e:0)f:0);"])
-        t_dm = t.tip_tip_distances()
-        exp_t_dm = exp_t.tip_tip_distances()
+        t_dm = t.cophenet()
+        exp_t_dm = exp_t.cophenet()
         self.assertEqual(t_dm, exp_t_dm)
 
     def test_compare_rfd(self):
@@ -2124,7 +2124,7 @@ class TreeTests(TestCase):
         result = TreeNode('x').compare_biparts(TreeNode('y'))
         self.assertEqual(result, 1)
 
-    def test_compare_tip_distances(self):
+    def test_compare_cophenet(self):
         """Return distance between two trees based on tip distances."""
         t = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7):3);"])
         t2 = TreeNode.read(["(((H:1,G:1,O:1):2,R:3):1,X:4);"])
@@ -2132,7 +2132,7 @@ class TreeTests(TestCase):
         # default behavior (half correlation, use length, include self)
         # note: common taxa are H, G, R (only)
         # note: version 0.7.0 will ignore self by default (see below)
-        obs = t.compare_tip_distances(t2)
+        obs = t.compare_cophenet(t2)
         m1 = np.array([[0, 2, 6.5], [2, 0, 6.5], [6.5, 6.5, 0]])
         m2 = np.array([[0, 2, 6], [2, 0, 6], [6, 6, 0]])
         r = pearsonr(m1.flat, m2.flat)[0]
@@ -2142,32 +2142,32 @@ class TreeTests(TestCase):
         # sample a subset of taxa
         # note: all common taxa are selected, despite that the default
         # shuffler function is stochastic.
-        obs = t.compare_tip_distances(t2, sample=3)
+        obs = t.compare_cophenet(t2, sample=3)
         self.assertAlmostEqual(obs, exp)
 
         # 4 common taxa, custom shuffler, still picking H, G, R
         tx = TreeNode.read(["((H:1,G:1):2,(R:0.5,M:0.7,U:5):3);"])
         t2x = TreeNode.read(["(((H:1,G:1,O:1):2,R:3,U:10):1,X:4);"])
-        obs = tx.compare_tip_distances(t2x, sample=3, shuffler=list.sort)
+        obs = tx.compare_cophenet(t2x, sample=3, shuffler=list.sort)
         self.assertAlmostEqual(obs, exp)
-        obs = tx.compare_tip_distances(t2x, sample=3, shuffle_f=list.sort)
+        obs = tx.compare_cophenet(t2x, sample=3, shuffle_f=list.sort)
         self.assertAlmostEqual(obs, exp)
 
         # no common taxa
         t3 = TreeNode.read(["(((Z:1,Y:1,X:1):2,W:3):1,V:4);"])
         with self.assertRaises(ValueError):
-            t.compare_tip_distances(t3)
+            t.compare_cophenet(t3)
 
         # single common taxon
         t4 = TreeNode.read(["(((R:1,Y:1,X:1):2,W:3):1,V:4);"])
-        self.assertTrue(np.isnan(t.compare_tip_distances(t4)))
+        self.assertTrue(np.isnan(t.compare_cophenet(t4)))
 
         # two common taxa
         t5 = TreeNode.read(["(((R:1,Y:1,X:1):2,M:3):1,V:4);"])
-        self.assertAlmostEqual(t.compare_tip_distances(t5), 0)
-        self.assertTrue(np.isnan(t.compare_tip_distances(t5, ignore_self=True)))
+        self.assertAlmostEqual(t.compare_cophenet(t5), 0)
+        self.assertTrue(np.isnan(t.compare_cophenet(t5, ignore_self=True)))
 
-    def test_compare_tip_distances_new(self):
+    def test_compare_cophenet_new(self):
         """Return distance between two trees based on tip distances."""
         # This test case is more comprehensive and reflects the new behavior
         # and options of the method.
@@ -2175,30 +2175,30 @@ class TreeTests(TestCase):
         t2 = TreeNode.read(["((a:3,(b:2,c:2):1):3,d:8,(e:5,f:6):2);"])
 
         # default behavior (old, will change in version 0.7.0)
-        obs = t1.compare_tip_distances(t2)
+        obs = t1.compare_cophenet(t2)
         self.assertAlmostEqual(obs, 0.0453512)
 
         # new default behavior
-        obs = t1.compare_tip_distances(t2, ignore_self=True)
+        obs = t1.compare_cophenet(t2, ignore_self=True)
         self.assertAlmostEqual(obs, 0.1413090)
 
         # path length distance (matches phangorn::path.dist(use.weight=TRUE))
-        obs = t1.compare_tip_distances(t2, metric="euclidean", ignore_self=True)
+        obs = t1.compare_cophenet(t2, metric="euclidean", ignore_self=True)
         self.assertAlmostEqual(obs, 13.7113092)
-        obs = t1.compare_tip_distances(t2, metric=euclidean, ignore_self=True)
+        obs = t1.compare_cophenet(t2, metric=euclidean, ignore_self=True)
         self.assertAlmostEqual(obs, 13.7113092)
-        obs = t1.compare_tip_distances(t2, dist_f=euclidean, ignore_self=True)
+        obs = t1.compare_cophenet(t2, dist_f=euclidean, ignore_self=True)
         self.assertAlmostEqual(obs, 13.7113092)
 
         # path distance (matches phangorn::path.dist)
-        obs = t1.compare_tip_distances(
+        obs = t1.compare_cophenet(
             t2, metric="euclidean", use_length=False, ignore_self=True)
         self.assertAlmostEqual(obs, 4.0)
 
         # unit correlation distance is independent of tree scale
         for node in t2.traverse(include_self=False):
             node.length *= 3
-        obs = t1.compare_tip_distances(t2, ignore_self=True)
+        obs = t1.compare_cophenet(t2, ignore_self=True)
         self.assertAlmostEqual(obs, 0.1413090)
 
     # ------------------------------------------------

--- a/skbio/tree/tests/test_upgma.py
+++ b/skbio/tree/tests/test_upgma.py
@@ -31,12 +31,12 @@ class UpgmaTests(TestCase):
 
     def test_upgma_dm(self):
         actual_TreeNode = upgma(self.dm)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected_TreeNode_upgma), 0.0, places=10)
 
     def test_wpgma_dm(self):
         actual_TreeNode = upgma(self.dm, weighted=True)
-        self.assertAlmostEqual(actual_TreeNode.compare_tip_distances(
+        self.assertAlmostEqual(actual_TreeNode.compare_cophenet(
             self.expected_TreeNode_wpgma), 0.0, places=10)
 
     def test_upgma_error(self):


### PR DESCRIPTION
The tip-to-tip distance in a phylogenetic tree may be called the [cophenetic distance](https://en.wikipedia.org/wiki/Cophenetic). The correlation between cophenetic distance matrices may be called the [cophenetic correlation](https://en.wikipedia.org/wiki/Cophenetic_correlation). These notions are commonly used in hierarchical clustering. Therefore, this PR renames `tip_tip_distances` and `compare_tip_distances` as `cophenet` and `compare_cophenet`, respectively. The old names are preserved as aliases, and will last for a while. The output of `cophenetic` is consistent with SciPy's [`cophenet`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.cophenet.html) (for ultrametric trees), ape's [`cophenetic`](https://rdrr.io/cran/ape/man/cophenetic.phylo.html), and DendroPy's [`phylogenetic_distance_matrix`](https://jeetsukumaran.github.io/DendroPy/library/treemodel.html#dendropy.datamodel.treemodel.Tree.phylogenetic_distance_matrix).

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
