### PR TITLE
Optimized the calculation of total branch lengths of a clade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Supported Robinson-Foulds distance calculation (`TreeNode.compare_rfd`) based on bipartitions (equivalent to `compare_biparts`). This is automatically enabled when the input tree is unrooted. Otherwise the calculation is still based on subsets (equivalent to `compare_subsets`). The user can override this behavior using the `rooted` parameter ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Re-wrote the underlying algorithm of `TreeNode.compare_subsets` because it is equivalent to the Robinson-Foulds distance on rooted trees. Added parameter `proportion`. Renamed parameter `exclude_absent_taxa` as `shared_only` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
 * Added parameter `include_self` to `TreeNode.subset`. Added parameters `within`, `include_full` and `include_single` to `TreeNode.subsets` ([#2144](https://github.com/scikit-bio/scikit-bio/pull/2144)).
+* Improved the performance and customizability of `TreeNode.total_length` (renamed from `descending_branch_length`). Added parameters `include_stem` and `include_self`.
 * Improved the performance of `TreeNode.lowest_common_ancestor` ([#2132](https://github.com/scikit-bio/scikit-bio/pull/2132)).
 * Improved the performance of `TreeNode` methods: `ancestors`, `siblings`, and `neighbors` ([#2133](https://github.com/scikit-bio/scikit-bio/pull/2133), [#2135](https://github.com/scikit-bio/scikit-bio/pull/2135)).
 * Improved the performance of tree traversal algorithms ([#2093](https://github.com/scikit-bio/scikit-bio/pull/2093)).
@@ -61,6 +62,7 @@
 * Remodeled documentation. Special methods (previously referred to as built-in methods) and inherited methods of a class no longer have separate stub pages. This significantly reduced the total number of webpages in the documentation ([#2110](https://github.com/scikit-bio/scikit-bio/pull/2110)).
 * Renamed `TreeNode.invalidate_caches` as `clear_caches`, because the caches are indeed deleted rather than marked as obsolete. The old name is preserved as an alias ([#2099](https://github.com/scikit-bio/scikit-bio/pull/2099)).
 * Renamed `TreeNode.remove_deleted` as `remove_by_func`. The old name is preserved as an alias ([#2103](https://github.com/scikit-bio/scikit-bio/pull/2103)).
+* Renamed `TreeNode.descending_branch_length` as `total_length`. The old name is preserved as an alias.
 
 ### Deprecated functionality
 

--- a/doc/source/_templates/TreeNode.rst
+++ b/doc/source/_templates/TreeNode.rst
@@ -113,6 +113,7 @@
       ~{{ name }}.is_bifurcating
       ~{{ name }}.observed_node_counts
       ~{{ name }}.accumulate_to_ancestor
+      ~{{ name }}.total_length
       ~{{ name }}.descending_branch_length
       ~{{ name }}.distance
       ~{{ name }}.get_max_distance

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -591,7 +591,7 @@ class TreeNode(SkbioObject):
         root
 
         """
-        if kwargs and "tipnames" in kwargs:
+        if nodes is None and kwargs and "tipnames" in kwargs:
             nodes = kwargs["tipnames"]
         if not nodes:
             raise ValueError("No node is specified.")
@@ -3900,7 +3900,7 @@ class TreeNode(SkbioObject):
         6.3
 
         """
-        if kwargs and "tip_subset" in kwargs:
+        if nodes is None and kwargs and "tip_subset" in kwargs:
             nodes = kwargs["tip_subset"]
 
         ## shortcut for the entire subtree
@@ -3933,7 +3933,7 @@ class TreeNode(SkbioObject):
                 curr = curr.parent
             curr._unique = False
 
-        # Iterative the first path in reverse order (from root to starting node) and
+        # Iterate over the first path in reverse order (from root to starting node) and
         # find the indices of self and LCA.
         i_self, i_lca = None, 0
         for i in reversed(range(len(first_path))):
@@ -3955,7 +3955,7 @@ class TreeNode(SkbioObject):
             raise MissingNodeError("Some nodes are not descendants of self.")
 
         # Identify the range of nodes to be included in calculation depending on the
-        # parameter setting
+        # parameter setting.
         stop = (i_self if include_stem else i_lca) + include_self
 
         # sum up branch lengths

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -604,11 +604,11 @@ class TreeNode(SkbioObject):
         # Path of the first node to root. LCA must be in this path.
         # A temporary attribute "prev" will be assigned to visited nodes. It represents
         # the previous node in the upward path.
-        curr = nodes[0]
+        curr = next(nodes := iter(nodes))
         prev = None
         while curr is not None:
-            curr._prev = prev
             visited_append(curr)
+            curr._prev = prev
             prev = curr
             curr = curr.parent
 
@@ -617,21 +617,19 @@ class TreeNode(SkbioObject):
         # uniformly set as None. When the path hits a previously visited node, it will
         # stop. If the node is in the first path, its prev becomes None, indicating
         # that it has been visited more than once.
-        for curr in nodes[1:]:
-            while curr is not None:
-                if hasattr(curr, "_prev"):
-                    curr._prev = None
-                    break
-                curr._prev = None
+        for curr in nodes:
+            while not hasattr(curr, "_prev"):
                 visited_append(curr)
+                curr._prev = None
                 curr = curr.parent
+            curr._prev = None
 
         # walk down the tree until last node with prev is None
         curr = self.root()
         while (prev := curr._prev) is not None:
             curr = prev
 
-        # clean up temporary attribute prev
+        # clear temporary attribute
         for node in visited:
             del node._prev
 
@@ -3811,69 +3809,158 @@ class TreeNode(SkbioObject):
 
         return accum
 
-    def descending_branch_length(self, tip_subset=None):
-        r"""Find total descending branch length from self to a set of tips.
+    def total_length(
+        self, nodes=None, include_stem=False, include_root=False, **kwargs
+    ):
+        r"""Find the total length of branches descending from self.
+
+        .. versionchanged:: 0.6.3
+            Renamed from ``descending_branch_length``. The old name is kept as an alias.
 
         Parameters
         ----------
-        tip_subset : iterable of str, optional
-            If None, the total descending branch length for all tips in the tree will
-            be returned. If a list of tip names is provided then only the total
-            descending branch length associated with those tips will be returned.
+        nodes : iterable of TreeNode or str, optional
+            Instances or names of a subset of descending nodes to refine the result.
+            If provided, the total length of branches connecting these nodes will be
+            returned. Otherwise, the total branch length of the tree will be returned.
+
+            .. versionchanged:: 0.6.3
+                Renamed from ``tip_subset``. The old name is kept as an alias.
+                Can accept TreeNode instances in addition to names.
+                Can accept internal nodes in addition to tips.
+
+        include_stem : bool, optional
+            Whether to include the path from the lowest common ancestor (LCA) of the
+            subset of nodes to self. Applicable when ``nodes`` is specified. Default is
+            False.
+
+            .. versionadded:: 0.6.3
+
+        include_root : bool, optional
+            Whether to include the length of the root node of relevant nodes. When
+            ``nodes`` is provided and ``include_stem`` is False, this node is the LCA
+            of the subset of nodes. Otherwise, this node is self. Default is False.
+
+            .. versionadded:: 0.6.3
 
         Returns
         -------
         float
-            The total descending branch length for the specified set of tips.
+            The total descending branch length.
 
         Raises
         ------
-        ValueError
-            If ``tip_subset`` contains internal nodes or non-tips.
+        MissingNodeError
+            If some nodes are not found in the tree or are not descendants of self.
 
         Notes
         -----
-        This function replicates cogent's totalDescendingBranch Length method
-        and extends that method to allow the calculation of total descending
-        branch length of a subset of the tips if requested. The postorder
-        guarantees that the function will always be able to add the descending
-        branch length if the node is not a tip.
+        The metric quantifies the total amount of evolutionary change across all
+        lineages in the (sub)tree.
 
-        Nodes with no length will have their length set to 0. The root length
-        (if it exists) is ignored.
+        This metric is closely related to phylogenetic diversity (PD) in community
+        ecology. When ``include_stem`` is True, it is equivalent to Faith's PD (see
+        :func:`~skbio.diversity.alpha.faith_pd`). However, this method is optimized
+        to handle a single set of nodes, whereas the referred function is optimized
+        to simultaneously calculate for multiple taxon sets (i.e., communities).
+
+        Missing branch lengths will be replaced with 0.
 
         Examples
         --------
         >>> from skbio import TreeNode
-        >>> tr = TreeNode.read(["(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,"
-        ...                     "(H:.4,I:.5)J:1.3)K;"])
-        >>> tdbl = tr.descending_branch_length()
-        >>> sdbl = tr.descending_branch_length(['A', 'E'])
-        >>> print(round(tdbl, 1), round(sdbl, 1))
-        8.9 2.2
+        >>> tree = TreeNode.read([
+        ...     "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
+        >>> print(tree.ascii_art())
+                                      /-A
+                            /C-------|
+                           |          \-B
+                  /G-------|
+                 |         |          /-D
+                 |          \F-------|
+        -K-------|                    \-E
+                 |
+                 |          /-H
+                  \J-------|
+                            \-I
+
+        Calculate the total branch length of the tree.
+
+        >>> L = tree.total_length()
+        >>> print(round(L, 1))
+        8.9
+
+        Calculate the total branch length connecting three taxa.
+
+        >>> L = tree.total_length(['A', 'E', 'H'])
+        >>> print(round(L, 1))
+        6.3
 
         """
-        self.assign_ids()
-        if tip_subset is not None:
-            all_tips = self.subset()
-            if not set(tip_subset).issubset(all_tips):
-                raise ValueError("tip_subset contains ids that aren't tip " "names.")
+        if kwargs and "tip_subset" in kwargs:
+            nodes = kwargs["tip_subset"]
 
-            lca = self.lowest_common_ancestor(tip_subset)
-            ancestors = {}
-            for tip in tip_subset:
-                curr = self.find(tip)
-                while curr is not lca:
-                    ancestors[curr.id] = curr.length if curr.length is not None else 0.0
-                    curr = curr.parent
-            return sum(ancestors.values())
-
-        else:
+        ## shortcut for the entire subtree
+        if not nodes:
             return sum(
-                n.length
-                for n in self.postorder(include_self=False)
-                if n.length is not None
+                n.length or 0.0 for n in self.postorder(include_self=include_root)
             )
+
+        nodes = [self.find(x) for x in nodes]
+
+        # Identify all nodes that need to be visited during the navigation from all
+        # tips to the root. This algorithm resembles that of `lca`. However, we will
+        # separate the visited nodes of the first path and all other paths. Also, we
+        # don't need to record the previous node. All we need is whether each node is
+        # unique in all paths.
+        first_path = []
+        first_path_append = first_path.append
+        curr = next(nodes := iter(nodes))
+        while curr is not None:
+            first_path_append(curr)
+            curr._unique = True
+            curr = curr.parent
+
+        other_paths = []
+        other_paths_append = other_paths.append
+        for curr in nodes:
+            while not hasattr(curr, "_unique"):
+                other_paths_append(curr)
+                curr._unique = True
+                curr = curr.parent
+            curr._unique = False
+
+        # Iterative the first path in reverse order (from root to starting node) and
+        # find the indices of self and LCA.
+        i_self, i_lca = None, 0
+        for i in reversed(range(len(first_path))):
+            if (node := first_path[i]) is self:
+                i_self = i
+            if node._unique is False:
+                i_lca = i
+                break
+
+        # clear temporary attribute
+        for node in first_path:
+            del node._unique
+        for node in other_paths:
+            del node._unique
+
+        # If all nodes are descendants of self, LCA must also be self or one of its
+        # descendants, and self must be identified when iterating the first path.
+        if i_self is None:
+            raise MissingNodeError("Some nodes are not descendants of self.")
+
+        # Identify the range of nodes to be included in calculation depending on the
+        # parameter setting
+        stop = (i_self if include_stem else i_lca) + include_root
+
+        # sum up branch lengths
+        return (
+            sum(n.length or 0.0 for n in chain(first_path[:stop], other_paths)) or 0.0
+        )
+
+    descending_branch_length = total_length
 
     def distance(self, other, use_length=True, missing_as_zero=False):
         r"""Calculate the distance between self and another node.

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -315,6 +315,13 @@ class TreeTests(TestCase):
         obs = t_root.lowest_common_ancestor(["a", "c"])
         self.assertIs(obs, t_root)
 
+        # nested nodes
+        t_sub = t1.copy()
+        obs = t_sub.lowest_common_ancestor(["b", "d", "g", "i"])
+        self.assertIs(obs, t_sub)
+        obs = t_sub.lowest_common_ancestor(["e", "b", "d", "h"])
+        self.assertIs(obs, t_sub)
+
         # empty case
         with self.assertRaises(ValueError):
             t1.lowest_common_ancestor([])
@@ -1807,7 +1814,7 @@ class TreeTests(TestCase):
         sdbl = tr.total_length([tr.find("A"), tr.find("E")])
         self.assertAlmostEqual(sdbl, 2.2)
 
-        # old parameter name
+        # parameter alias
         sdbl = tr.total_length(tip_subset="AE")
         self.assertAlmostEqual(sdbl, 2.2)
 
@@ -1858,7 +1865,7 @@ class TreeTests(TestCase):
         self.assertAlmostEqual(tdbl, 8.9)
 
         # include root length
-        tdbl = tr.total_length(include_root=True)
+        tdbl = tr.total_length(include_self=True)
         self.assertAlmostEqual(tdbl, 9.9)
 
         # internal nodes
@@ -1870,7 +1877,7 @@ class TreeTests(TestCase):
         self.assertEqual(tdbl, 0.0)
         self.assertIsInstance(tdbl, float)
 
-        tdbl = tr.total_length("B", include_root=True)
+        tdbl = tr.total_length("B", include_self=True)
         self.assertAlmostEqual(tdbl, 1.2)
 
     def test_total_length_subtree(self):
@@ -1881,7 +1888,7 @@ class TreeTests(TestCase):
         obs = tsub.total_length()
         self.assertAlmostEqual(obs, 4.2)
 
-        obs = tsub.total_length(include_root=True)
+        obs = tsub.total_length(include_self=True)
         self.assertAlmostEqual(obs, 6.6)
 
         obs = tsub.total_length(["D", "E"])
@@ -1890,10 +1897,10 @@ class TreeTests(TestCase):
         obs = tsub.total_length(["D", "E"], include_stem=True)
         self.assertAlmostEqual(obs, 2.4)
 
-        obs = tsub.total_length(["D", "E"], include_root=True)
+        obs = tsub.total_length(["D", "E"], include_self=True)
         self.assertAlmostEqual(obs, 2.4)
 
-        obs = tsub.total_length(["D", "E"], include_stem=True, include_root=True)
+        obs = tsub.total_length(["D", "E"], include_stem=True, include_self=True)
         self.assertAlmostEqual(obs, 4.8)
 
         # node outside subtree

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -286,6 +286,10 @@ class TreeTests(TestCase):
         self.assertEqual(obs4, exp4)
         self.assertEqual(obs5, exp5)
 
+        # parameter alias
+        self.assertEqual(t1.lowest_common_ancestor(nodes=input1), exp1)
+        self.assertEqual(t1.lowest_common_ancestor(tipnames=input1), exp1)
+
         # verify multiple calls work
         t_mul = t1.copy()
         exp_1 = t_mul.find("d")
@@ -301,6 +305,11 @@ class TreeTests(TestCase):
         exp = t_sub.find("d")
         self.assertEqual(obs, exp)
 
+        # lca outside subtree
+        obs = t_sub.find("e").lowest_common_ancestor(["b", "g"])
+        exp = t_sub
+        self.assertEqual(obs, exp)
+
         # root included
         t_root = TreeNode.read(["(a,b)c;"])
         obs = t_root.lowest_common_ancestor(["a", "c"])
@@ -309,6 +318,8 @@ class TreeTests(TestCase):
         # empty case
         with self.assertRaises(ValueError):
             t1.lowest_common_ancestor([])
+        with self.assertRaises(ValueError):
+            t1.lowest_common_ancestor()
 
     def test_path(self):
         """List of TreeNode objects in path between nodes."""

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -1790,50 +1790,114 @@ class TreeTests(TestCase):
         with self.assertRaises(NoParentError):
             a.accumulate_to_ancestor(b)
 
-    def test_descending_branch_length(self):
-        """Calculate descending branch_length"""
+    def test_total_length(self):
+        """Calculate total branch length descending from self."""
         tr = TreeNode.read([
             "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
-        tdbl = tr.descending_branch_length()
-        sdbl = tr.descending_branch_length(["A", "E"])
+        tdbl = tr.total_length()
         self.assertAlmostEqual(tdbl, 8.9)
+
+        # specify nodes
+        sdbl = tr.total_length(["A", "E"])
         self.assertAlmostEqual(sdbl, 2.2)
-        self.assertRaises(ValueError, tr.descending_branch_length,
-                          ["A", "DNE"])
-        self.assertRaises(ValueError, tr.descending_branch_length, ["A", "C"])
+
+        sdbl = tr.total_length("AE")
+        self.assertAlmostEqual(sdbl, 2.2)
+
+        sdbl = tr.total_length([tr.find("A"), tr.find("E")])
+        self.assertAlmostEqual(sdbl, 2.2)
+
+        # old parameter name
+        sdbl = tr.total_length(tip_subset="AE")
+        self.assertAlmostEqual(sdbl, 2.2)
+
+        # missing node
+        self.assertRaises(MissingNodeError, tr.total_length, ["A", "DNE"])
 
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
-        tdbl = tr.descending_branch_length()
+        tdbl = tr.total_length()
         self.assertAlmostEqual(tdbl, 8.8)
 
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
-        tdbl = tr.descending_branch_length()
+        tdbl = tr.total_length()
         self.assertAlmostEqual(tdbl, 7.9)
 
+        # nodes whose LCA is not root
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F)G:2.4,(H:.4,I:.5)J:1.3)K;"])
-        tdbl = tr.descending_branch_length(["A", "D", "E"])
+        tdbl = tr.total_length(["A", "D", "E"])
         self.assertAlmostEqual(tdbl, 2.1)
 
+        # include stem length
+        tdbl = tr.total_length(["A", "D", "E"], include_stem=True)
+        self.assertAlmostEqual(tdbl, 4.5)
+
+        # nodes whose LCA is root
         tr = TreeNode.read([
             "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
-        tdbl = tr.descending_branch_length(["I", "D", "E"])
+        tdbl = tr.total_length(["I", "D", "E"])
+        self.assertAlmostEqual(tdbl, 6.6)
+
+        # there is no stem to add
+        tdbl = tr.total_length(["I", "D", "E"], include_stem=True)
         self.assertAlmostEqual(tdbl, 6.6)
 
         # test with a situation where we have unnamed internal nodes
         tr = TreeNode.read([
             "(((A,B:1.2):.6,(D:.9,E:.6)F):2.4,(H:.4,I:.5)J:1.3);"])
-        tdbl = tr.descending_branch_length()
+        tdbl = tr.total_length()
         self.assertAlmostEqual(tdbl, 7.9)
 
-        # issue 1847
+        # issue 1847 (ignoring root length)
         tr = TreeNode.read([
             "(((A:.1,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
         tr.length = 1
-        tdbl = tr.descending_branch_length()
+        tdbl = tr.total_length()
         self.assertAlmostEqual(tdbl, 8.9)
+
+        # include root length
+        tdbl = tr.total_length(include_root=True)
+        self.assertAlmostEqual(tdbl, 9.9)
+
+        # internal nodes
+        tdbl = tr.total_length(["C", "F", "J"])
+        self.assertAlmostEqual(tdbl, 5.2)
+
+        # only one node
+        tdbl = tr.total_length("B")
+        self.assertEqual(tdbl, 0.0)
+        self.assertIsInstance(tdbl, float)
+
+        tdbl = tr.total_length("B", include_root=True)
+        self.assertAlmostEqual(tdbl, 1.2)
+
+    def test_total_length_subtree(self):
+        """Calculate total branch length of a subtree."""
+        tr = TreeNode.read([
+            "(((A,B:1.2)C:.6,(D:.9,E:.6)F:.9)G:2.4,(H:.4,I:.5)J:1.3)K;"])
+        tsub = tr.children[0]
+        obs = tsub.total_length()
+        self.assertAlmostEqual(obs, 4.2)
+
+        obs = tsub.total_length(include_root=True)
+        self.assertAlmostEqual(obs, 6.6)
+
+        obs = tsub.total_length(["D", "E"])
+        self.assertAlmostEqual(obs, 1.5)
+
+        obs = tsub.total_length(["D", "E"], include_stem=True)
+        self.assertAlmostEqual(obs, 2.4)
+
+        obs = tsub.total_length(["D", "E"], include_root=True)
+        self.assertAlmostEqual(obs, 2.4)
+
+        obs = tsub.total_length(["D", "E"], include_stem=True, include_root=True)
+        self.assertAlmostEqual(obs, 4.8)
+
+        # node outside subtree
+        self.assertRaises(MissingNodeError, tsub.total_length, ["A", "I"])
 
     def test_distance_nontip(self):
         # example derived from issue #807, credit @wwood
@@ -2248,19 +2312,19 @@ class TreeTests(TestCase):
 
         # delete individual attribute caches
         t.cache_attr(lambda n: 1, "node_count", sum)
-        t.cache_attr(lambda n: n.length or 0.0, "total_length", sum)
+        t.cache_attr(lambda n: n.length or 0.0, "length_sum", sum)
         t.clear_caches(attr="node_count")
         self.assertTrue(hasattr(t, "_registered_caches"))
         self.assertNotIn("node_count", t._registered_caches)
-        self.assertIn("total_length", t._registered_caches)
+        self.assertIn("length_sum", t._registered_caches)
         for node in t.traverse(include_self=True):
             self.assertFalse(hasattr(node, "node_count"))
-            self.assertTrue(hasattr(node, "total_length"))
-        delattr(t.children[1], "total_length")
-        t.clear_caches(attr="total_length")
+            self.assertTrue(hasattr(node, "length_sum"))
+        delattr(t.children[1], "length_sum")
+        t.clear_caches(attr="length_sum")
         self.assertFalse(hasattr(t, "_registered_caches"))
         for node in t.traverse(include_self=True):
-            self.assertFalse(hasattr(node, "total_length"))
+            self.assertFalse(hasattr(node, "length_sum"))
 
     def test_cache_attr(self):
         # cache names of all descending tips


### PR DESCRIPTION
This PR improves the performance and customizability of `TreeNode.total_length` (renamed from `descending_branch_length`; old name kept as an alias). Test on a tree with 16k tips:

Entire tree:
- Before: 23.8 ms ± 474 μs
- After: 10.9 ms ± 404 μs

5000 tips
- Before: 56.8 ms ± 2.09 ms
- After: 10.7 ms ± 724 μs

2000 tips
- Before: 38.7 ms ± 809 μs
- After: 4.79 ms ± 118 μs

1000 tips
- Before: 32.5 ms ± 1.09 ms
- After: 2.81 ms ± 47.9 μs

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
