### PR TITLE
Move arguments back into _testing.py to ship test config with binary package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = ["setuptools", "wheel", "numpy", "cython"]
 
 [tool.pytest.ini_options]
 addopts = [
-    "--pyargs",
-    "skbio",
     "--doctest-modules",
     "--doctest-glob",
     "*.pyx",

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -425,5 +425,5 @@ def pytestrunner():
     # import here, cause outside the eggs aren't loaded
     import pytest
 
-    errno = pytest.main(args=sys.argv[1:])
+    errno = pytest.main(args=["--pyargs", "skbio"] + sys.argv[1:])
     sys.exit(errno)


### PR DESCRIPTION
This PR addresses #2179, by moving `--pyargs skbio` back into `_testing.py`.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
