### PR TITLE
Fix `[source]` linking issue in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 0.6.4-dev
 
+### Bug Fixes
+* Fixed a bug in the documentation in which the `source` button would link to decorator code, instead of the relevant function ([#2184](https://github.com/scikit-bio/scikit-bio/pull/2184)).
+
 
 ## Version 0.6.3
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -227,6 +227,10 @@ def linkcode_resolve(domain, info):
         except:
             return None
 
+    # Link to functions, not decorators
+    while hasattr(obj, "__wrapped__"):
+        obj = obj.__wrapped__
+
     try:
         fn = inspect.getsourcefile(obj)
     except:


### PR DESCRIPTION
Addresses #2181 by modifying the `linkcode_resolve` function to check if an object has a `__wrapped__` attribute. If it does, then the object becomes the wrapped function itself, instead of remaining the decorator.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
