### PR TITLE
Alias `otu_ids` using new decorator

### DIFF
--- a/skbio/diversity/_util.py
+++ b/skbio/diversity/_util.py
@@ -250,17 +250,6 @@ def _quantitative_to_qualitative_counts(counts):
     return counts > 0.0
 
 
-def _check_taxa_alias(taxa, tree, otu_ids):
-    # make `otu_ids` an alias of `taxa`; for backward compatibility
-    if taxa is None:
-        if otu_ids is None:
-            raise ValueError("A list of taxon IDs must be provided.")
-        taxa = otu_ids
-    if tree is None:
-        raise ValueError("A phylogenetic tree must be provided.")
-    return taxa
-
-
 def _table_to_numpy(table):
     """Convert a skbio.table.Table to a dense representation.
 

--- a/skbio/diversity/alpha/_pd.py
+++ b/skbio/diversity/alpha/_pd.py
@@ -51,7 +51,7 @@ def _faith_pd(counts_by_node, branch_lengths):
 
 
 @params_aliased([("taxa", "otu_ids", "0.6.0", True)])
-def faith_pd(counts, taxa=None, tree=None, validate=True):
+def faith_pd(counts, taxa, tree, validate=True):
     r"""Calculate Faith's phylogenetic diversity (Faith's PD) metric.
 
     The Faith's PD metric is defined as:
@@ -242,7 +242,7 @@ def _phydiv(counts_by_node, branch_lengths, rooted, weight):
 
 
 @params_aliased([("taxa", "otu_ids", "0.6.0", True)])
-def phydiv(counts, taxa=None, tree=None, rooted=None, weight=False, validate=True):
+def phydiv(counts, taxa, tree, rooted=None, weight=False, validate=True):
     r"""Calculate generalized phylogenetic diversity (PD) metrics.
 
     Parameters

--- a/skbio/diversity/alpha/_pd.py
+++ b/skbio/diversity/alpha/_pd.py
@@ -6,14 +6,16 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from sys import modules
+
 import numpy as np
 
 from skbio.diversity._util import (
     _validate_counts_vector,
     _validate_taxa_and_tree,
     vectorize_counts_and_tree,
-    _check_taxa_alias,
 )
+from skbio.util._decorator import params_aliased
 
 
 def _setup_pd(counts, taxa, tree, validate, rooted, single_sample):
@@ -50,7 +52,8 @@ def _faith_pd(counts_by_node, branch_lengths):
     return (branch_lengths * (counts_by_node > 0)).sum()
 
 
-def faith_pd(counts, taxa=None, tree=None, validate=True, otu_ids=None):
+@params_aliased([("taxa", "otu_ids", "0.6.0", True)])
+def faith_pd(counts, taxa=None, tree=None, validate=True):
     r"""Calculate Faith's phylogenetic diversity (Faith's PD) metric.
 
     The Faith's PD metric is defined as:
@@ -81,9 +84,6 @@ def faith_pd(counts, taxa=None, tree=None, validate=True, otu_ids=None):
         so this step should not be bypassed if you're not certain that your input data
         are valid. See :mod:`skbio.diversity` for the description of what validation
         entails so you can determine if you can safely disable validation.
-    otu_ids : list, np.array
-        Alias of ``taxa`` for backward compatibility. Deprecated and to be removed in a
-        future release.
 
     Returns
     -------
@@ -185,8 +185,6 @@ def faith_pd(counts, taxa=None, tree=None, validate=True, otu_ids=None):
     """
     # TODO: Remove `otu_ids` and make `taxa` and `tree` required in a future version.
 
-    taxa = _check_taxa_alias(taxa, tree, otu_ids)
-
     counts_by_node, branch_lengths = _setup_pd(
         counts, taxa, tree, validate, rooted=True, single_sample=True
     )
@@ -245,9 +243,8 @@ def _phydiv(counts_by_node, branch_lengths, rooted, weight):
     return (branch_lengths * fracs_by_node).sum()
 
 
-def phydiv(
-    counts, taxa=None, tree=None, rooted=None, weight=False, validate=True, otu_ids=None
-):
+@params_aliased([("taxa", "otu_ids", "0.6.0", True)])
+def phydiv(counts, taxa=None, tree=None, rooted=None, weight=False, validate=True):
     r"""Calculate generalized phylogenetic diversity (PD) metrics.
 
     Parameters
@@ -270,9 +267,6 @@ def phydiv(
         the degree of partial-weighting (0: unweighted, 1: fully-weighted).
     validate : bool, optional
         Whether validate the input data. See :func:`faith_pd` for details.
-    otu_ids : list, np.array
-        Alias of ``taxa`` for backward compatibility. Deprecated and to be removed in a
-        future release.
 
     Returns
     -------
@@ -435,8 +429,6 @@ def phydiv(
        2106-2113.
 
     """
-    taxa = _check_taxa_alias(taxa, tree, otu_ids)
-
     # whether tree is rooted should not affect whether metric can be calculated
     # ; it is common unrooted PD is calculated on a rooted tree
     counts_by_node, branch_lengths = _setup_pd(

--- a/skbio/diversity/alpha/_pd.py
+++ b/skbio/diversity/alpha/_pd.py
@@ -6,8 +6,6 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from sys import modules
-
 import numpy as np
 
 from skbio.diversity._util import (

--- a/skbio/diversity/beta/_unifrac.py
+++ b/skbio/diversity/beta/_unifrac.py
@@ -27,7 +27,7 @@ _normalize_weighted_unifrac_by_default = False
 
 
 @params_aliased([("taxa", "otu_ids", "0.6.0", True)])
-def unweighted_unifrac(u_counts, v_counts, taxa=None, tree=None, validate=True):
+def unweighted_unifrac(u_counts, v_counts, taxa, tree, validate=True):
     """Compute unweighted UniFrac.
 
     Parameters
@@ -157,8 +157,8 @@ def unweighted_unifrac(u_counts, v_counts, taxa=None, tree=None, validate=True):
 def weighted_unifrac(
     u_counts,
     v_counts,
-    taxa=None,
-    tree=None,
+    taxa,
+    tree,
     normalized=_normalize_weighted_unifrac_by_default,
     validate=True,
 ):

--- a/skbio/diversity/beta/_unifrac.py
+++ b/skbio/diversity/beta/_unifrac.py
@@ -14,9 +14,9 @@ from skbio.diversity._util import (
     _validate_counts_matrix,
     _validate_taxa_and_tree,
     vectorize_counts_and_tree,
-    _check_taxa_alias,
 )
 from skbio.diversity._phylogenetic import _tip_distances
+from skbio.util._decorator import params_aliased
 
 
 # The default value indicating whether normalization should be applied
@@ -26,9 +26,8 @@ from skbio.diversity._phylogenetic import _tip_distances
 _normalize_weighted_unifrac_by_default = False
 
 
-def unweighted_unifrac(
-    u_counts, v_counts, taxa=None, tree=None, validate=True, otu_ids=None
-):
+@params_aliased([("taxa", "otu_ids", "0.6.0", True)])
+def unweighted_unifrac(u_counts, v_counts, taxa=None, tree=None, validate=True):
     """Compute unweighted UniFrac.
 
     Parameters
@@ -50,9 +49,6 @@ def unweighted_unifrac(
         bypassed if you're not certain that your input data are valid. See
         :mod:`skbio.diversity` for the description of what validation entails
         so you can determine if you can safely disable validation.
-    otu_ids : list, np.array
-        Alias of ``taxa`` for backward compatibility. Deprecated and to be
-        removed in a future release.
 
     Returns
     -------
@@ -151,13 +147,13 @@ def unweighted_unifrac(
     0.37
 
     """
-    taxa = _check_taxa_alias(taxa, tree, otu_ids)
     u_node_counts, v_node_counts, _, _, tree_index = _setup_pairwise_unifrac(
         u_counts, v_counts, taxa, tree, validate, normalized=False, unweighted=True
     )
     return _unweighted_unifrac(u_node_counts, v_node_counts, tree_index["length"])
 
 
+@params_aliased([("taxa", "otu_ids", "0.6.0", True)])
 def weighted_unifrac(
     u_counts,
     v_counts,
@@ -165,7 +161,6 @@ def weighted_unifrac(
     tree=None,
     normalized=_normalize_weighted_unifrac_by_default,
     validate=True,
-    otu_ids=None,
 ):
     """Compute weighted UniFrac with or without branch length normalization.
 
@@ -191,9 +186,6 @@ def weighted_unifrac(
         bypassed if you're not certain that your input data are valid. See
         :mod:`skbio.diversity` for the description of what validation entails
         so you can determine if you can safely disable validation.
-    otu_ids : list, np.array
-        Alias of ``taxa`` for backward compatibility. Deprecated and to be
-        removed in a future release.
 
     Returns
     -------
@@ -294,7 +286,6 @@ def weighted_unifrac(
     0.33
 
     """
-    taxa = _check_taxa_alias(taxa, tree, otu_ids)
     (
         u_node_counts,
         v_node_counts,

--- a/skbio/diversity/tests/test_util.py
+++ b/skbio/diversity/tests/test_util.py
@@ -20,7 +20,6 @@ from skbio.diversity._util import (_validate_counts_vector,
                                    _validate_taxa_and_tree,
                                    vectorize_counts_and_tree,
                                    _quantitative_to_qualitative_counts,
-                                   _check_taxa_alias,
                                    _table_to_numpy,
                                    _validate_table)
 from skbio.tree import DuplicateNodeError, MissingNodeError
@@ -284,23 +283,6 @@ class ValidationTests(TestCase):
         exp = np.array([[False, False, False], [True, False, True]])
         obs = _quantitative_to_qualitative_counts(counts)
         npt.assert_equal(obs, exp)
-
-    def test_check_taxa_alias(self):
-        # for backward compatibility; will be removed in the future
-        msg = "A list of taxon IDs must be provided."
-        with self.assertRaises(ValueError) as cm:
-            _check_taxa_alias(None, None, None)
-        self.assertEqual(str(cm.exception), msg)
-
-        msg = "A phylogenetic tree must be provided."
-        with self.assertRaises(ValueError) as cm:
-            _check_taxa_alias([1], None, None)
-        self.assertEqual(str(cm.exception), msg)
-
-        obs = _check_taxa_alias([1], '1', None)
-        self.assertListEqual(obs, [1])
-        obs = _check_taxa_alias(None, '1', [1])
-        self.assertListEqual(obs, [1])
 
 
 class TableConversionTests(TestCase):


### PR DESCRIPTION
Addresses #2182. Additionally removes the `_check_taxa_alias` function, which is no longer required because of the `params_aliased` decorator, although @qiyunzhu your input in this regard would be appreciated.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
