### PR TITLE
Move `Read` and `Write` descriptors to avoid circular imports

### DIFF
--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -20,7 +20,7 @@ from skbio.sequence._grammared_sequence import GrammaredSequence
 from skbio.util._decorator import classonlymethod, overrides
 from skbio.util._misc import resolve_key
 from skbio.alignment._indexing import TabularMSAILoc, TabularMSALoc
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 from skbio.alignment._repr import _TabularMSAReprBuilder
 

--- a/skbio/embedding/_embedding.py
+++ b/skbio/embedding/_embedding.py
@@ -14,7 +14,7 @@ from skbio.sequence import Sequence
 from skbio._base import SkbioObject
 from skbio.stats.ordination import OrdinationResults
 from skbio.diversity import beta_diversity
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 def _repr_helper(rstr, org_name, new_name, dim_name, regex_match, shape):

--- a/skbio/io/descriptors.py
+++ b/skbio/io/descriptors.py
@@ -1,0 +1,146 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import types
+
+import skbio.io
+
+
+class Read:
+    """A descriptor class to generate read methods for scikit-bio objects."""
+
+    def __get__(self, instance, cls):
+        if "_read_method" not in cls.__dict__:
+            cls._read_method = self._generate_read_method(cls)
+        return cls._read_method
+
+    def _generate_read_method(self, cls):
+        def _read_method(file, format=None, **kwargs):
+            return skbio.io.read(file, into=cls, format=format, **kwargs)
+
+        _read_method.__doc__ = self._make_docstring(cls)
+        return _read_method
+
+    def _make_docstring(self, cls):
+        name, supported_fmts, default, see = _docstring_vars(cls, "read")
+        return f"""Create a new ``{name}`` instance from a file.
+
+This is a convenience method for :func:`skbio.io.registry.read`. For more information
+about the I/O system in scikit-bio, please see :mod:`skbio.io`.
+
+{supported_fmts}
+
+Parameters
+----------
+file : openable (filepath, URL, filehandle, etc.)
+    The location to read the given `format` into. Something that is understood by
+    :func:`skbio.io.util.open`. Filehandles are not automatically closed, it is the
+    responsibility of the caller.
+format : str, optional
+    The format of the file. The format must be a format name with a reader for
+    ``{name}``. If None, the format will be inferred.
+kwargs : dict, optional
+    Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
+    ``{name}``.
+
+Returns
+-------
+``{name}``
+    A new instance.
+
+See Also
+--------
+write
+skbio.io.registry.read
+skbio.io.util.open
+{see}
+
+"""
+
+
+class Write:
+    """A descriptor class to generate write methods for scikit-bio objects."""
+
+    def __get__(self, instance, cls):
+        """This gets called when any skbio object accesses its ``write`` attribute."""
+        if instance is None:
+            if "_write_method" not in cls.__dict__:
+                cls._write_method = self._generate_write_method(cls)
+            return cls._write_method
+        if "_write_method" not in instance.__dict__:
+            instance._write_method = types.MethodType(
+                self._generate_write_method(cls), instance
+            )
+        return instance._write_method
+
+    def _generate_write_method(self, cls):
+        def _write_method(self, file, format=None, **kwargs):
+            if format is None:
+                if hasattr(cls, "default_write_format"):
+                    format = cls.default_write_format
+                else:
+                    raise ValueError(f"{cls.__name__} has no default write format.")
+            return skbio.io.write(self, into=file, format=format, **kwargs)
+
+        _write_method.__doc__ = self._make_docstring(cls)
+
+        return _write_method
+
+    def _make_docstring(self, cls):
+        name, supported_fmts, default, see = _docstring_vars(cls, "write")
+        return f"""Write an instance of ``{name}`` to a file.
+
+This is a convenience method for :func:`skbio.io.registry.write()`. For more
+information about the I/O system in scikit-bio, please see :mod:`skbio.io`.
+
+{supported_fmts}
+
+Parameters
+----------
+file : openable (filepath, filehandle, etc.)
+    The location to write the given `format` into. Something that is understood by
+    :func:`skbio.io.util.open()`. Filehandles are not automatically closed, it is the
+    responsibility of the caller.
+format : str, optional
+    The format to write the ``{name}`` object as. The format must be a registered
+    format name with a writer for ``{name}``. Default is ``'{default}'``.
+kwargs : dict, optional
+    Additional arguments passed to the writer for ``{name}``.
+
+See Also
+--------
+read
+skbio.io.registry.write
+skbio.io.util.open
+{see}
+
+"""
+
+
+def _docstring_vars(cls, func):
+    """Generate variables for dynamically generated docstrings."""
+    from skbio.io.registry import io_registry
+
+    if func == "write":
+        formats = io_registry.list_write_formats(cls)
+    elif func == "read":
+        formats = io_registry.list_read_formats(cls)
+    else:
+        raise ValueError("'func' parameter must be 'read' or 'write'.")
+
+    imports = io_registry._import_paths(formats)
+    formats = io_registry._formats_for_docs(formats, imports)
+    if formats:
+        supported_fmts = f"Supported file formats include:\n\n{formats}"
+    else:
+        supported_fmts = ""
+    name = cls.__name__
+    default = getattr(cls, "default_write_format", "None")
+    see = "\n".join(imports)
+
+    return name, supported_fmts, default, see

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -851,7 +851,7 @@ class Format:
         Examples
         --------
         >>> from skbio.io.registry import Format, io_registry
-        >>> from skbio.io.registry import Read, Write
+        >>> from skbio.io.descriptors import Read, Write
         >>> myformat = Format('myformat')
         >>> io_registry.add_format(myformat)
         >>> # If developing a new format for skbio, use the create_format()
@@ -940,7 +940,7 @@ class Format:
         Examples
         --------
         >>> from skbio.io.registry import Format, io_registry
-        >>> from skbio.io.registry import Read, Write
+        >>> from skbio.io.descriptors import Read, Write
         >>> myformat = Format('myformat')
         >>> io_registry.add_format(myformat)
         >>> # If developing a new format for skbio, use the create_format()
@@ -1070,136 +1070,3 @@ def write(obj, format, into, **kwargs):
 def create_format(*args, **kwargs):
     """Make a new format."""
     return io_registry.create_format(*args, **kwargs)
-
-
-class Read:
-    """A descriptor class to generate read methods for scikit-bio objects."""
-
-    def __get__(self, instance, cls):
-        if "_read_method" not in cls.__dict__:
-            cls._read_method = self._generate_read_method(cls)
-        return cls._read_method
-
-    def _generate_read_method(self, cls):
-        def _read_method(file, format=None, **kwargs):
-            return skbio.io.read(file, into=cls, format=format, **kwargs)
-
-        _read_method.__doc__ = self._make_docstring(cls)
-        return _read_method
-
-    def _make_docstring(self, cls):
-        name, supported_fmts, default, see = _docstring_vars(cls, "read")
-        return f"""Create a new ``{name}`` instance from a file.
-
-This is a convenience method for :func:`skbio.io.registry.read`. For more information
-about the I/O system in scikit-bio, please see :mod:`skbio.io`.
-
-{supported_fmts}
-
-Parameters
-----------
-file : openable (filepath, URL, filehandle, etc.)
-    The location to read the given `format` into. Something that is understood by
-    :func:`skbio.io.util.open`. Filehandles are not automatically closed, it is the
-    responsibility of the caller.
-format : str, optional
-    The format of the file. The format must be a format name with a reader for
-    ``{name}``. If None, the format will be inferred.
-kwargs : dict, optional
-    Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
-    ``{name}``.
-
-Returns
--------
-``{name}``
-    A new instance.
-
-See Also
---------
-write
-skbio.io.registry.read
-skbio.io.util.open
-{see}
-
-"""
-
-
-class Write:
-    """A descriptor class to generate write methods for scikit-bio objects."""
-
-    def __get__(self, instance, cls):
-        """This gets called when any skbio object accesses its ``write`` attribute."""
-        if instance is None:
-            if "_write_method" not in cls.__dict__:
-                cls._write_method = self._generate_write_method(cls)
-            return cls._write_method
-        if "_write_method" not in instance.__dict__:
-            instance._write_method = types.MethodType(
-                self._generate_write_method(cls), instance
-            )
-        return instance._write_method
-
-    def _generate_write_method(self, cls):
-        def _write_method(self, file, format=None, **kwargs):
-            if format is None:
-                if hasattr(cls, "default_write_format"):
-                    format = cls.default_write_format
-                else:
-                    raise ValueError(f"{cls.__name__} has no default write format.")
-            return skbio.io.write(self, into=file, format=format, **kwargs)
-
-        _write_method.__doc__ = self._make_docstring(cls)
-
-        return _write_method
-
-    def _make_docstring(self, cls):
-        name, supported_fmts, default, see = _docstring_vars(cls, "write")
-        return f"""Write an instance of ``{name}`` to a file.
-
-This is a convenience method for :func:`skbio.io.registry.write()`. For more
-information about the I/O system in scikit-bio, please see :mod:`skbio.io`.
-
-{supported_fmts}
-
-Parameters
-----------
-file : openable (filepath, filehandle, etc.)
-    The location to write the given `format` into. Something that is understood by
-    :func:`skbio.io.util.open()`. Filehandles are not automatically closed, it is the
-    responsibility of the caller.
-format : str, optional
-    The format to write the ``{name}`` object as. The format must be a registered
-    format name with a writer for ``{name}``. Default is ``'{default}'``.
-kwargs : dict, optional
-    Additional arguments passed to the writer for ``{name}``.
-
-See Also
---------
-read
-skbio.io.registry.write
-skbio.io.util.open
-{see}
-
-"""
-
-
-def _docstring_vars(cls, func):
-    """Generate variables for dynamically generated docstrings."""
-    if func == "write":
-        formats = io_registry.list_write_formats(cls)
-    elif func == "read":
-        formats = io_registry.list_read_formats(cls)
-    else:
-        raise ValueError("'func' parameter must be 'read' or 'write'.")
-
-    imports = io_registry._import_paths(formats)
-    formats = io_registry._formats_for_docs(formats, imports)
-    if formats:
-        supported_fmts = f"Supported file formats include:\n\n{formats}"
-    else:
-        supported_fmts = ""
-    name = cls.__name__
-    default = getattr(cls, "default_write_format", "None")
-    see = "\n".join(imports)
-
-    return name, supported_fmts, default, see

--- a/skbio/metadata/_interval.py
+++ b/skbio/metadata/_interval.py
@@ -12,7 +12,7 @@ import functools
 
 from ._intersection import IntervalTree
 from skbio.util._decorator import classonlymethod
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Interval:

--- a/skbio/metadata/_metadata.py
+++ b/skbio/metadata/_metadata.py
@@ -19,7 +19,7 @@ import numpy as np
 import skbio.metadata.missing as _missing
 from skbio.util import find_duplicates
 from .base import SUPPORTED_COLUMN_TYPES, FORMATTED_ID_HEADERS, is_id_header
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 DEFAULT_MISSING = _missing.DEFAULT_MISSING

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -10,7 +10,7 @@ import skbio
 from skbio.util._decorator import classproperty, overrides
 from ._nucleotide_mixin import NucleotideMixin, _motifs as _parent_motifs
 from ._grammared_sequence import GrammaredSequence
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class DNA(GrammaredSequence, NucleotideMixin):

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from skbio.util._decorator import classproperty, overrides
 from ._grammared_sequence import GrammaredSequence, _motifs as parent_motifs
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Protein(GrammaredSequence):

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -10,7 +10,7 @@ import skbio
 from skbio.util._decorator import classproperty, overrides
 from ._nucleotide_mixin import NucleotideMixin, _motifs as _parent_motifs
 from ._grammared_sequence import GrammaredSequence
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class RNA(GrammaredSequence, NucleotideMixin):

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -30,7 +30,7 @@ from skbio.sequence._alphabet import (
 )
 from skbio.util import find_duplicates
 from skbio.util._decorator import classonlymethod, overrides
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Sequence(

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -19,7 +19,7 @@ from skbio.util import find_duplicates, get_rng
 from skbio.util._decorator import classonlymethod
 from skbio.util._misc import resolve_key
 from skbio.util._plotting import PlottableMixin
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow
 from ._utils import distmat_reorder, distmat_reorder_condensed

--- a/skbio/stats/ordination/_ordination_results.py
+++ b/skbio/stats/ordination/_ordination_results.py
@@ -14,7 +14,7 @@ import pandas as pd
 from skbio._base import SkbioObject
 from skbio.stats._misc import _pprint_strs
 from skbio.util._plotting import PlottableMixin
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 from skbio.util.config._dispatcher import extract_row_ids
 
 

--- a/skbio/table/_base.py
+++ b/skbio/table/_base.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from biom import Table, example_table
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 Table.default_write_format = "biom"
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -32,7 +32,7 @@ from skbio.util._decorator import (
     params_aliased,
 )
 from skbio.util._warning import _warn_once
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 from ._compare import (
     _check_dist_metric,
     _check_shuffler,


### PR DESCRIPTION
The way that the `Read` and `Write` descriptors were implemented led to circular imports when adding new files to submodules within scikit-bio. This breaks the circular loop by placing the descriptors in their own file, which itself contains minimal imports.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
