### PR TITLE
Remove autoplotting functionality to enable inplace operations on large objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Let `AlignPath.shape` return native Python `int` rather than `np.int64` ([#2201](https://github.com/scikit-bio/scikit-bio/pull/2201)).
 * Updated documentation to include description of how to stream data through stdin with scikit-bio's `read` function ([2185](https://github.com/scikit-bio/scikit-bio/pull/2185))
 * Improved documentation for the `DistanceMatrix` object ([2204](https://github.com/scikit-bio/scikit-bio/pull/2204))
+* Remove autoplotting functionality to enable inplace operations on large in-memory objects ([2216](https://github.com/scikit-bio/scikit-bio/pull/2216))
 
 
 ## Version 0.6.3

--- a/skbio/util/_plotting.py
+++ b/skbio/util/_plotting.py
@@ -64,27 +64,3 @@ class PlottableMixin:
         self.plt.close(fig)
 
         return f.getvalue()
-
-    @property
-    def png(self):
-        """Get figure data in PNG format.
-
-        Returns
-        -------
-        bytes
-            Figure data in PNG format.
-
-        """
-        return self._repr_png_()
-
-    @property
-    def svg(self):
-        """Get figure data in SVG format.
-
-        Returns
-        -------
-        str
-            Figure data in SVG format.
-
-        """
-        return self._repr_svg_()

--- a/skbio/util/_plotting.py
+++ b/skbio/util/_plotting.py
@@ -65,14 +65,6 @@ class PlottableMixin:
 
         return f.getvalue()
 
-    def _repr_png_(self):
-        """Generate a PNG format figure for display in IPython."""
-        return self._figure_data("png")
-
-    def _repr_svg_(self):
-        """Generate an SVG format figure for display in IPython."""
-        return self._figure_data("svg")
-
     @property
     def png(self):
         """Get figure data in PNG format.

--- a/skbio/util/tests/test_plotting.py
+++ b/skbio/util/tests/test_plotting.py
@@ -75,34 +75,6 @@ class TestPlottableMixin(unittest.TestCase):
         self.assertIsNone(obj._figure_data())
         sys.modules['matplotlib'] = backup
 
-    def test_repr_png(self):
-        obj = PlottableMixin()
-        obj._get_mpl_plt()
-        obs = obj._repr_png_()
-        self.assertIsInstance(obs, bytes)
-        self.assertTrue(len(obs) > 0)
-
-    def test_repr_svg(self):
-        obj = PlottableMixin()
-        obj._get_mpl_plt()
-        obs = obj._repr_svg_()
-        self.assertIsInstance(obs, str)
-        self.assertTrue(len(obs) > 0)
-
-    def test_png(self):
-        obj = PlottableMixin()
-        obj._get_mpl_plt()
-        obs = obj.png
-        self.assertIsInstance(obs, bytes)
-        self.assertTrue(len(obs) > 0)
-
-    def test_svg(self):
-        obj = PlottableMixin()
-        obj._get_mpl_plt()
-        obs = obj.svg
-        self.assertIsInstance(obs, str)
-        self.assertTrue(len(obs) > 0)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
An issue with scikit-bio's current plotting functionality is that generating plots automatically by default can lead to kernel crashes for large objects such as `DistanceMatrix`. This is discussed further in issue #2215. To overcome this, this PR removes two functions from the `PlottableMixin` class:  `_repr_png_` and `_repr_svg_`. Removing these functions results in the default representation of an object which inherits from `PlottableMixin` to be that object's respective `_str_` representation. If the user wishes to plot the object, they may use the object's `plot()` method. The only objects in scikit-bio which inherit from `PlottableMixin` are `DistanceMatrix`, `DissimilarityMatrix`, and `OrdinationResults`.


Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
