### PR TITLE
Tweaking NJ algorithm

### DIFF
--- a/skbio/tree/_c_nj.pyx
+++ b/skbio/tree/_c_nj.pyx
@@ -6,13 +6,15 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
+
 cimport cython
-from libc.float cimport DBL_MAX
+from cython cimport floating
+from libc.math cimport INFINITY
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def nj_minq_cy(double[:, :] dm, double[:] sums):
+def nj_minq_cy(floating[:, :] dm, floating[:] sums):
     r"""Find the minimum value in a Q-matrix during the NJ algorithm.
 
     Parameters
@@ -47,14 +49,14 @@ def nj_minq_cy(double[:, :] dm, double[:] sums):
     """
     cdef Py_ssize_t n = dm.shape[0]
     cdef Py_ssize_t i, j
-    cdef int n_2 = n - 2
+    cdef floating n_2 = n - 2.0
 
     # current minimum q value and its location
     cdef Py_ssize_t min_i, min_j
-    cdef double min_q = DBL_MAX
+    cdef floating min_q = <floating>INFINITY
 
     # current q value and minimum q value plus \sum d(i)
-    cdef double q_plus, min_q_plus
+    cdef floating q_plus, min_q_plus
 
     # loop the upper-right triangle of the distance matrix
     # i < j is guaranteed

--- a/skbio/tree/_nj.py
+++ b/skbio/tree/_nj.py
@@ -188,7 +188,7 @@ def _nj(dm):
     N = n = dm.shape[0]  # dimension
     sums = dm.sum(axis=0)  # distance sums
     idxs = np.arange(N)  # cluster indices
-    lm = np.empty((N - 1, 4))  # linkage matrix
+    lm = np.empty((N - 1, 4), dtype=dm.dtype)  # linkage matrix
 
     # Iteratively merge taxa until there are three left.
     while n > 3:

--- a/skbio/tree/tests/test_nj.py
+++ b/skbio/tree/tests/test_nj.py
@@ -102,6 +102,19 @@ class NjTests(TestCase):
         with self.assertRaises(AssertionError):
             npt.assert_almost_equal(dm.data, self.dm3.data)
 
+    def test_nj_floating(self):
+        dm = self.dm3.copy()
+        exp = nj(dm)
+        dm._data = dm._data.astype("float64")
+        obs = nj(dm)
+        self.assertAlmostEqual(obs.compare_cophenet(exp), 0.0)
+        dm._data = dm._data.astype("float32")
+        obs = nj(dm)
+        self.assertAlmostEqual(obs.compare_cophenet(exp), 0.0)
+        dm._data = dm._data.astype("int32")
+        with self.assertRaises(TypeError):
+            _ = nj(dm)
+
     def test_nj_zero_branch_length(self):
         # no nodes have negative branch length when we disallow negative
         # branch length. self is excluded as branch length is None


### PR DESCRIPTION
Some trivial tweaks of the neighbor-joining (NJ) algorithm. No visible performance gain. But one important thing to note:

It is favorable to support both float32 and float64 in scikit-bio algorithms. Here is a [proposal](https://github.com/scikit-learn/scikit-learn/wiki/GSoC-2016-Proposal:-Adding-fused-types-to-Cython-files) by scikit-learn. scikit-bio's `DistanceMatrix` already supports both float32 and float64 ([code](https://github.com/scikit-bio/scikit-bio/blob/bb0332773c9267bc77ba2601c9b4843144393289/skbio/stats/distance/_base.py#L138)), and some of scikit-bio's core algorithms such as PCoA ([code](https://github.com/scikit-bio/scikit-bio/blob/main/skbio/stats/ordination/_cutils.pyx)) and PERMANOVA ([code](https://github.com/scikit-bio/scikit-bio/blob/main/skbio/stats/distance/_cutils.pyx)) already support both float types via Cython's [fused type](https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html). The current PR also introduces fused type to `nj`. What's different is that it uses Cython's built-in `floating` type to represent `float` (float32) and `double` (float64), instead of creating a custom fused type. This approach is also adopted by scikit-learn ([code](https://github.com/scikit-learn/scikit-learn/blob/98ed9dc73a86f5f11781a0e21f24c8f47979ec67/sklearn/cluster/_k_means_common.pyx)). Tests showed that casting the distance matrix to float32 can moderately reduce runtime.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
