### PR TITLE
Confidence ellipse - plotting of basic confidence ellipse (not actual) - does not include covariance matrix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Miscellaneous
 
 * Updated documentation to include description of how to stream data through stdin with scikit-bio's `read` function ([2185](https://github.com/scikit-bio/scikit-bio/pull/2185))
+* Improved documentation for the `DistanceMatrix` object ([2204](https://github.com/scikit-bio/scikit-bio/pull/2204))
 
 
 ## Version 0.6.3

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -189,7 +189,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'sklearn': ('https://scikit-learn.org/stable/', None),
     'statsmodels': ('https://www.statsmodels.org/stable/', None),
-    'biom-format': ('https://biom-format.org/', None),
+    # 'biom-format': ('https://biom-format.org/', None),
     'polars': ('https://docs.pola.rs/api/python/stable/', None),
     'anndata': ('https://anndata.readthedocs.io/en/stable/', None),
 }

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -20,7 +20,7 @@ from skbio.sequence._grammared_sequence import GrammaredSequence
 from skbio.util._decorator import classonlymethod, overrides
 from skbio.util._misc import resolve_key
 from skbio.alignment._indexing import TabularMSAILoc, TabularMSALoc
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 from skbio.alignment._repr import _TabularMSAReprBuilder
 

--- a/skbio/embedding/_embedding.py
+++ b/skbio/embedding/_embedding.py
@@ -14,7 +14,7 @@ from skbio.sequence import Sequence
 from skbio._base import SkbioObject
 from skbio.stats.ordination import OrdinationResults
 from skbio.diversity import beta_diversity
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 def _repr_helper(rstr, org_name, new_name, dim_name, regex_match, shape):

--- a/skbio/io/descriptors.py
+++ b/skbio/io/descriptors.py
@@ -1,0 +1,146 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import types
+
+import skbio.io
+
+
+class Read:
+    """A descriptor class to generate read methods for scikit-bio objects."""
+
+    def __get__(self, instance, cls):
+        if "_read_method" not in cls.__dict__:
+            cls._read_method = self._generate_read_method(cls)
+        return cls._read_method
+
+    def _generate_read_method(self, cls):
+        def _read_method(file, format=None, **kwargs):
+            return skbio.io.read(file, into=cls, format=format, **kwargs)
+
+        _read_method.__doc__ = self._make_docstring(cls)
+        return _read_method
+
+    def _make_docstring(self, cls):
+        name, supported_fmts, default, see = _docstring_vars(cls, "read")
+        return f"""Create a new ``{name}`` instance from a file.
+
+This is a convenience method for :func:`skbio.io.registry.read`. For more information
+about the I/O system in scikit-bio, please see :mod:`skbio.io`.
+
+{supported_fmts}
+
+Parameters
+----------
+file : openable (filepath, URL, filehandle, etc.)
+    The location to read the given `format` into. Something that is understood by
+    :func:`skbio.io.util.open`. Filehandles are not automatically closed, it is the
+    responsibility of the caller.
+format : str, optional
+    The format of the file. The format must be a format name with a reader for
+    ``{name}``. If None, the format will be inferred.
+kwargs : dict, optional
+    Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
+    ``{name}``.
+
+Returns
+-------
+``{name}``
+    A new instance.
+
+See Also
+--------
+write
+skbio.io.registry.read
+skbio.io.util.open
+{see}
+
+"""
+
+
+class Write:
+    """A descriptor class to generate write methods for scikit-bio objects."""
+
+    def __get__(self, instance, cls):
+        """This gets called when any skbio object accesses its ``write`` attribute."""
+        if instance is None:
+            if "_write_method" not in cls.__dict__:
+                cls._write_method = self._generate_write_method(cls)
+            return cls._write_method
+        if "_write_method" not in instance.__dict__:
+            instance._write_method = types.MethodType(
+                self._generate_write_method(cls), instance
+            )
+        return instance._write_method
+
+    def _generate_write_method(self, cls):
+        def _write_method(self, file, format=None, **kwargs):
+            if format is None:
+                if hasattr(cls, "default_write_format"):
+                    format = cls.default_write_format
+                else:
+                    raise ValueError(f"{cls.__name__} has no default write format.")
+            return skbio.io.write(self, into=file, format=format, **kwargs)
+
+        _write_method.__doc__ = self._make_docstring(cls)
+
+        return _write_method
+
+    def _make_docstring(self, cls):
+        name, supported_fmts, default, see = _docstring_vars(cls, "write")
+        return f"""Write an instance of ``{name}`` to a file.
+
+This is a convenience method for :func:`skbio.io.registry.write()`. For more
+information about the I/O system in scikit-bio, please see :mod:`skbio.io`.
+
+{supported_fmts}
+
+Parameters
+----------
+file : openable (filepath, filehandle, etc.)
+    The location to write the given `format` into. Something that is understood by
+    :func:`skbio.io.util.open()`. Filehandles are not automatically closed, it is the
+    responsibility of the caller.
+format : str, optional
+    The format to write the ``{name}`` object as. The format must be a registered
+    format name with a writer for ``{name}``. Default is ``'{default}'``.
+kwargs : dict, optional
+    Additional arguments passed to the writer for ``{name}``.
+
+See Also
+--------
+read
+skbio.io.registry.write
+skbio.io.util.open
+{see}
+
+"""
+
+
+def _docstring_vars(cls, func):
+    """Generate variables for dynamically generated docstrings."""
+    from skbio.io.registry import io_registry
+
+    if func == "write":
+        formats = io_registry.list_write_formats(cls)
+    elif func == "read":
+        formats = io_registry.list_read_formats(cls)
+    else:
+        raise ValueError("'func' parameter must be 'read' or 'write'.")
+
+    imports = io_registry._import_paths(formats)
+    formats = io_registry._formats_for_docs(formats, imports)
+    if formats:
+        supported_fmts = f"Supported file formats include:\n\n{formats}"
+    else:
+        supported_fmts = ""
+    name = cls.__name__
+    default = getattr(cls, "default_write_format", "None")
+    see = "\n".join(imports)
+
+    return name, supported_fmts, default, see

--- a/skbio/io/format/ordination.py
+++ b/skbio/io/format/ordination.py
@@ -191,7 +191,7 @@ import pandas as pd
 
 from skbio.stats.ordination import OrdinationResults
 from skbio.io import create_format, OrdinationFormatError
-from skbio.util.config._dispatcher import create_table, create_table_1d
+from skbio.util.config._dispatcher import _create_table, _create_table_1d
 
 ordination = create_format("ordination")
 
@@ -318,7 +318,7 @@ def _parse_vector_section(fh, header_id):
                 "Reached end of file while looking for line containing values "
                 "for %s section." % header_id
             )
-        vals = create_table_1d(
+        vals = _create_table_1d(
             data=np.asarray(line.strip().split("\t"), dtype=np.float64)
         )
         if len(vals) != num_vals:
@@ -376,7 +376,7 @@ def _parse_array_section(fh, header_id, has_ids=True):
                 )
             data[i, :] = np.asarray(vals, dtype=np.float64)
 
-        data = create_table(data=data, index=ids)
+        data = _create_table(data=data, index=ids)
 
     if has_ids:
         return data, ids

--- a/skbio/io/registry.py
+++ b/skbio/io/registry.py
@@ -851,7 +851,7 @@ class Format:
         Examples
         --------
         >>> from skbio.io.registry import Format, io_registry
-        >>> from skbio.io.registry import Read, Write
+        >>> from skbio.io.descriptors import Read, Write
         >>> myformat = Format('myformat')
         >>> io_registry.add_format(myformat)
         >>> # If developing a new format for skbio, use the create_format()
@@ -940,7 +940,7 @@ class Format:
         Examples
         --------
         >>> from skbio.io.registry import Format, io_registry
-        >>> from skbio.io.registry import Read, Write
+        >>> from skbio.io.descriptors import Read, Write
         >>> myformat = Format('myformat')
         >>> io_registry.add_format(myformat)
         >>> # If developing a new format for skbio, use the create_format()
@@ -1070,136 +1070,3 @@ def write(obj, format, into, **kwargs):
 def create_format(*args, **kwargs):
     """Make a new format."""
     return io_registry.create_format(*args, **kwargs)
-
-
-class Read:
-    """A descriptor class to generate read methods for scikit-bio objects."""
-
-    def __get__(self, instance, cls):
-        if "_read_method" not in cls.__dict__:
-            cls._read_method = self._generate_read_method(cls)
-        return cls._read_method
-
-    def _generate_read_method(self, cls):
-        def _read_method(file, format=None, **kwargs):
-            return skbio.io.read(file, into=cls, format=format, **kwargs)
-
-        _read_method.__doc__ = self._make_docstring(cls)
-        return _read_method
-
-    def _make_docstring(self, cls):
-        name, supported_fmts, default, see = _docstring_vars(cls, "read")
-        return f"""Create a new ``{name}`` instance from a file.
-
-This is a convenience method for :func:`skbio.io.registry.read`. For more information
-about the I/O system in scikit-bio, please see :mod:`skbio.io`.
-
-{supported_fmts}
-
-Parameters
-----------
-file : openable (filepath, URL, filehandle, etc.)
-    The location to read the given `format` into. Something that is understood by
-    :func:`skbio.io.util.open`. Filehandles are not automatically closed, it is the
-    responsibility of the caller.
-format : str, optional
-    The format of the file. The format must be a format name with a reader for
-    ``{name}``. If None, the format will be inferred.
-kwargs : dict, optional
-    Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
-    ``{name}``.
-
-Returns
--------
-``{name}``
-    A new instance.
-
-See Also
---------
-write
-skbio.io.registry.read
-skbio.io.util.open
-{see}
-
-"""
-
-
-class Write:
-    """A descriptor class to generate write methods for scikit-bio objects."""
-
-    def __get__(self, instance, cls):
-        """This gets called when any skbio object accesses its ``write`` attribute."""
-        if instance is None:
-            if "_write_method" not in cls.__dict__:
-                cls._write_method = self._generate_write_method(cls)
-            return cls._write_method
-        if "_write_method" not in instance.__dict__:
-            instance._write_method = types.MethodType(
-                self._generate_write_method(cls), instance
-            )
-        return instance._write_method
-
-    def _generate_write_method(self, cls):
-        def _write_method(self, file, format=None, **kwargs):
-            if format is None:
-                if hasattr(cls, "default_write_format"):
-                    format = cls.default_write_format
-                else:
-                    raise ValueError(f"{cls.__name__} has no default write format.")
-            return skbio.io.write(self, into=file, format=format, **kwargs)
-
-        _write_method.__doc__ = self._make_docstring(cls)
-
-        return _write_method
-
-    def _make_docstring(self, cls):
-        name, supported_fmts, default, see = _docstring_vars(cls, "write")
-        return f"""Write an instance of ``{name}`` to a file.
-
-This is a convenience method for :func:`skbio.io.registry.write()`. For more
-information about the I/O system in scikit-bio, please see :mod:`skbio.io`.
-
-{supported_fmts}
-
-Parameters
-----------
-file : openable (filepath, filehandle, etc.)
-    The location to write the given `format` into. Something that is understood by
-    :func:`skbio.io.util.open()`. Filehandles are not automatically closed, it is the
-    responsibility of the caller.
-format : str, optional
-    The format to write the ``{name}`` object as. The format must be a registered
-    format name with a writer for ``{name}``. Default is ``'{default}'``.
-kwargs : dict, optional
-    Additional arguments passed to the writer for ``{name}``.
-
-See Also
---------
-read
-skbio.io.registry.write
-skbio.io.util.open
-{see}
-
-"""
-
-
-def _docstring_vars(cls, func):
-    """Generate variables for dynamically generated docstrings."""
-    if func == "write":
-        formats = io_registry.list_write_formats(cls)
-    elif func == "read":
-        formats = io_registry.list_read_formats(cls)
-    else:
-        raise ValueError("'func' parameter must be 'read' or 'write'.")
-
-    imports = io_registry._import_paths(formats)
-    formats = io_registry._formats_for_docs(formats, imports)
-    if formats:
-        supported_fmts = f"Supported file formats include:\n\n{formats}"
-    else:
-        supported_fmts = ""
-    name = cls.__name__
-    default = getattr(cls, "default_write_format", "None")
-    see = "\n".join(imports)
-
-    return name, supported_fmts, default, see

--- a/skbio/metadata/_interval.py
+++ b/skbio/metadata/_interval.py
@@ -12,7 +12,7 @@ import functools
 
 from ._intersection import IntervalTree
 from skbio.util._decorator import classonlymethod
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Interval:

--- a/skbio/metadata/_metadata.py
+++ b/skbio/metadata/_metadata.py
@@ -19,7 +19,7 @@ import numpy as np
 import skbio.metadata.missing as _missing
 from skbio.util import find_duplicates
 from .base import SUPPORTED_COLUMN_TYPES, FORMATTED_ID_HEADERS, is_id_header
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 DEFAULT_MISSING = _missing.DEFAULT_MISSING

--- a/skbio/sequence/_dna.py
+++ b/skbio/sequence/_dna.py
@@ -10,7 +10,7 @@ import skbio
 from skbio.util._decorator import classproperty, overrides
 from ._nucleotide_mixin import NucleotideMixin, _motifs as _parent_motifs
 from ._grammared_sequence import GrammaredSequence
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class DNA(GrammaredSequence, NucleotideMixin):

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from skbio.util._decorator import classproperty, overrides
 from ._grammared_sequence import GrammaredSequence, _motifs as parent_motifs
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Protein(GrammaredSequence):

--- a/skbio/sequence/_rna.py
+++ b/skbio/sequence/_rna.py
@@ -10,7 +10,7 @@ import skbio
 from skbio.util._decorator import classproperty, overrides
 from ._nucleotide_mixin import NucleotideMixin, _motifs as _parent_motifs
 from ._grammared_sequence import GrammaredSequence
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class RNA(GrammaredSequence, NucleotideMixin):

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -30,7 +30,7 @@ from skbio.sequence._alphabet import (
 )
 from skbio.util import find_duplicates
 from skbio.util._decorator import classonlymethod, overrides
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 
 class Sequence(

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -19,7 +19,7 @@ from skbio.util import find_duplicates, get_rng
 from skbio.util._decorator import classonlymethod
 from skbio.util._misc import resolve_key
 from skbio.util._plotting import PlottableMixin
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow
 from ._utils import distmat_reorder, distmat_reorder_condensed
@@ -996,6 +996,26 @@ class DistanceMatrix(DissimilarityMatrix):
     A `DistanceMatrix` is a `DissimilarityMatrix` with the additional
     requirement that the matrix data is symmetric. There are additional methods
     made available that take advantage of this symmetry.
+
+    Parameters
+    ----------
+    data : array_like or DissimilarityMatrix
+        Square, hollow, two-dimensional ``numpy.ndarray`` of distances
+        (floats), or a structure that can be converted to a ``numpy.ndarray``
+        using ``numpy.asarray`` or a one-dimensional vector of distances
+        (floats), as defined by `scipy.spatial.distance.squareform`. Can
+        instead be a `DissimilarityMatrix` (or `DistanceMatrix`) instance,
+        in which case the instance's data will be used.
+        Data will be converted to a float ``dtype`` if necessary. A copy will
+        *not* be made if already a ``numpy.ndarray`` with a float ``dtype``.
+    ids : sequence of str, optional
+        Sequence of strings to be used as object IDs. Must match the number of
+        rows/cols in `data`. If ``None`` (the default), IDs will be
+        monotonically-increasing integers cast as strings, with numbering
+        starting from zero, e.g., ``('0', '1', '2', '3', ...)``.
+    validate : bool, optional
+        If `validate` is ``True`` (the default) and data is not a
+        DistanceMatrix object, the input data will be validated.
 
     See Also
     --------

--- a/skbio/stats/ordination/_canonical_correspondence_analysis.py
+++ b/skbio/stats/ordination/_canonical_correspondence_analysis.py
@@ -12,7 +12,7 @@ from scipy.linalg import svd, lstsq
 
 from ._ordination_results import OrdinationResults
 from ._utils import corr, svd_rank, scale
-from skbio.util.config._dispatcher import create_table, create_table_1d, ingest_array
+from skbio.util.config._dispatcher import _create_table, _create_table_1d, _ingest_array
 
 
 def cca(
@@ -44,33 +44,27 @@ def cca(
 
     Parameters
     ----------
-    y : DataFrame or ndarray
-        Samples by features table (n, m). Can be numpy, pandas, polars, AnnData,
-        or BIOM (skbio.Table).
-    x : DataFrame or ndarray
-        Samples by constraints table (n, q). Can be numpy, pandas, polars, AnnData,
-        or BIOM (skbio.Table).
+    y : table_like
+        Samples by features table (n, m). See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
+    x : table_like
+        Samples by constraints table (n, q). See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
     scaling : int, {1, 2}, optional
         Scaling type 1 maintains :math:`\chi^2` distances between rows.
         Scaling type 2 preserves :math:`\chi^2` distances between columns.
         For a more detailed explanation of the interpretation, check Legendre &
         Legendre 1998, section 9.4.3.
-    sample_ids : list of str, optional
-        List of ids of samples. If not provided implicitly by the input DataFrame or
-        explicitly by the user, sample_ids will default to a list of integers starting
-        at zero.
-    feature_ids : list of str, optional
-        List of ids of features. If not provided implicitly by y or explicitly by the
-        user, it will default to a list of integers starting at zero.
     constraint_ids : list of str, optional
-        List of ids of constraints. If not provided implicitly by y or explicitly by
-        the user, it will default to a list of integers starting at zero.
-    output_format : str, optional
-        The desired format of the output object. Can be ``pandas``, ``polars``, or
-        ``numpy``. Note that all scikit-bio ordination functions return an
-        ``OrdinationResults`` object. In this case the attributes of the
-        ``OrdinationResults`` object will be in the specified format. Default is
-        ``pandas``.
+        List of identifiers for metadata variables or constraints. If not provided
+        implicitly by the input data structure or explicitly by the user, defaults
+        to integers starting at zero.
+    sample_ids, feature_ids, output_format : optional
+        Standard ``DataTable`` parameters. See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
 
     Returns
     -------
@@ -124,10 +118,10 @@ def cca(
        Ecology. Elsevier, Amsterdam.
 
     """
-    Y, y_sample_ids, feature_ids = ingest_array(
+    Y, y_sample_ids, feature_ids = _ingest_array(
         y, row_ids=sample_ids, col_ids=feature_ids
     )
-    X, x_sample_ids, constraint_ids = ingest_array(
+    X, x_sample_ids, constraint_ids = _ingest_array(
         x, row_ids=sample_ids, col_ids=constraint_ids
     )
 
@@ -240,20 +234,20 @@ def cca(
     biplot_scores = corr(X_weighted, u)
 
     pc_ids = ["CCA%d" % (i + 1) for i in range(len(eigenvalues))]
-    eigvals = create_table_1d(eigenvalues, index=pc_ids, backend=output_format)
-    samples = create_table(
+    eigvals = _create_table_1d(eigenvalues, index=pc_ids, backend=output_format)
+    samples = _create_table(
         sample_scores, columns=pc_ids, index=y_sample_ids, backend=output_format
     )
-    features = create_table(
+    features = _create_table(
         features_scores, columns=pc_ids, index=feature_ids, backend=output_format
     )
-    biplot_scores = create_table(
+    biplot_scores = _create_table(
         biplot_scores,
         index=constraint_ids,
         columns=pc_ids[: biplot_scores.shape[1]],
         backend=output_format,
     )
-    sample_constraints = create_table(
+    sample_constraints = _create_table(
         sample_constraints, index=y_sample_ids, columns=pc_ids, backend=output_format
     )
 

--- a/skbio/stats/ordination/_correspondence_analysis.py
+++ b/skbio/stats/ordination/_correspondence_analysis.py
@@ -12,7 +12,7 @@ from scipy.linalg import svd
 
 from ._ordination_results import OrdinationResults
 from ._utils import svd_rank
-from skbio.util.config._dispatcher import create_table, create_table_1d, ingest_array
+from skbio.util.config._dispatcher import _create_table, _create_table_1d, _ingest_array
 
 
 def ca(X, scaling=1, sample_ids=None, feature_ids=None, output_format=None):
@@ -33,29 +33,21 @@ def ca(X, scaling=1, sample_ids=None, feature_ids=None, output_format=None):
 
     Parameters
     ----------
-    X : DataFrame or ndarray
+    X : table_like
         Samples by features table (n, m). It can be applied to different kinds
-        of data tables but data must be non-negative and dimensionally
-        homogeneous (quantitative or binary). The rows correspond to the
-        samples and the columns correspond to the features. Can be numpy,
-        pandas, polars, AnnData, or BIOM (skbio.Table).
-    sample_ids : list of str
-        List of ids of samples. If not provided implicitly by X or explicitly
-        by the user, it will default to a list of integers starting at zero.
-    feature_ids : list of str
-        List of ids of features. If not provided implicitly by X or explicitly
-        by the user, it will default to a list of integers starting at zero.
+        of data tables, but data must be non-negative and dimensionally homogeneous
+        (quantitative or binary). See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
     scaling : {1, 2}
         Scaling type 1 maintains :math:`\chi^2` distances between rows.
         Scaling type 2 preserves :math:`\chi^2` distances between columns.
         For a more detailed explanation of the interpretation,
         check notes below and Legendre & Legendre 1998, section 9.4.3.
-    output_format : str
-        The desired format of the output object. Can be ``pandas``, ``polars``, or
-        ``numpy``. Note that all scikit-bio ordination functions return an
-        ``OrdinationResults`` object. In this case the attributes of the
-        ``OrdinationResults`` object will be in the specified format. Default is
-        ``pandas``.
+    sample_ids, feature_ids, output_format : optional
+        Standard ``DataTable`` parameters. See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
 
     Returns
     -------
@@ -113,7 +105,7 @@ def ca(X, scaling=1, sample_ids=None, feature_ids=None, output_format=None):
 
     # we deconstruct the dataframe to avoid duplicating the data and be able
     # to perform operations on the matrix
-    X, row_ids, column_ids = ingest_array(X, row_ids=sample_ids, col_ids=feature_ids)
+    X, row_ids, column_ids = _ingest_array(X, row_ids=sample_ids, col_ids=feature_ids)
 
     # Correspondance Analysis
     r, c = X.shape
@@ -188,15 +180,15 @@ def ca(X, scaling=1, sample_ids=None, feature_ids=None, output_format=None):
     feature_columns = [
         "%s%d" % (short_method_name, i + 1) for i in range(features_scores.shape[1])
     ]
-    eigvals = create_table_1d(
+    eigvals = _create_table_1d(
         eigvals,
         index=["%s%d" % (short_method_name, i + 1) for i in range(eigvals.shape[0])],
         backend=output_format,
     )
-    samples = create_table(
+    samples = _create_table(
         sample_scores, index=row_ids, columns=sample_columns, backend=output_format
     )
-    features = create_table(
+    features = _create_table(
         features_scores,
         index=column_ids,
         columns=feature_columns,

--- a/skbio/stats/ordination/_ordination_results.py
+++ b/skbio/stats/ordination/_ordination_results.py
@@ -194,6 +194,7 @@ class OrdinationResults(SkbioObject, PlottableMixin):
         cmap=None,
         s=20,
         n_dims=3,
+        plot_confidence_ellipses=False,
     ):
         """Create a 3-D scatterplot of ordination results colored by metadata.
 
@@ -366,6 +367,28 @@ class OrdinationResults(SkbioObject, PlottableMixin):
             plot = scatter_fn()
         else:
             plot = scatter_fn(c=point_colors)
+
+        if plot_confidence_ellipses and zs is None and category_to_color:
+            for label, color in category_to_color.items():
+                group = self.samples[df[column] == label]
+                if len(group) < 2:
+                    continue  # can't draw ellipse with less than 2 points
+
+                x_vals = group.iloc[:, axes[0]]
+                y_vals = group.iloc[:, axes[1]]
+
+                mean_x = x_vals.mean()
+                mean_y = y_vals.mean()
+                std_x = x_vals.std()
+                std_y = y_vals.std()
+
+                t = np.linspace(0, 2 * np.pi, 100)
+                ellipse_x = mean_x + std_x * np.cos(t)
+                ellipse_y = mean_y + std_y * np.sin(t)
+
+                ax.plot(
+                    ellipse_x, ellipse_y, color=color, lw=2, label=f"'{label}' ellipse"
+                )
 
         if axis_labels is None:
             axis_labels = ["%d" % axis for axis in axes]

--- a/skbio/stats/ordination/_ordination_results.py
+++ b/skbio/stats/ordination/_ordination_results.py
@@ -172,7 +172,7 @@ class OrdinationResults(SkbioObject, PlottableMixin):
         self,
         df=None,
         column=None,
-        axes=(0, 1),
+        axes=None,
         axis_labels=None,
         title="",
         cmap=None,
@@ -299,6 +299,9 @@ class OrdinationResults(SkbioObject, PlottableMixin):
         # instead be added to EMPeror (http://biocore.github.io/emperor/).
         # Only bug fixes and minor updates should be made to this method.
 
+        if axes is None:
+            axes = np.arange(len(self.eigvals))
+
         self._get_mpl_plt()
 
         # print(df)
@@ -314,7 +317,6 @@ class OrdinationResults(SkbioObject, PlottableMixin):
             df, column, self.sample_ids, cmap
         )
         self._validate_plot_axes(coord_matrix, axes)
-
         if len(axes) == 3:  # 3d functionality
             fig = self.plt.figure()
             ax = fig.add_subplot(projection="3d")
@@ -324,7 +326,7 @@ class OrdinationResults(SkbioObject, PlottableMixin):
                 coord_matrix[axes[2]],
             )
 
-        else:  # 2d functionality
+        elif len(axes) == 2:  # 2d functionality
             fig, ax = self.plt.subplots()
             xs, ys = coord_matrix[axes[0]], coord_matrix[axes[1]]
             zs = None
@@ -345,7 +347,7 @@ class OrdinationResults(SkbioObject, PlottableMixin):
 
         if axis_labels is None:
             axis_labels = ["%d" % axis for axis in axes]
-        elif len(axis_labels) not in [2, 3]:
+        elif len(axis_labels) != len(axes):
             raise ValueError(
                 "axis_labels must contain exactly two or three elements "
                 "(found %d elements)." % len(axis_labels)
@@ -359,8 +361,8 @@ class OrdinationResults(SkbioObject, PlottableMixin):
         if len(axes) == 3:
             ax.set_zlabel(axis_labels[2])
             ax.set_zticklabels([])
-        else:
-            ax.set_title(title)
+
+        ax.set_title(title)
 
         # create legend/colorbar
         if point_colors is not None:
@@ -374,18 +376,18 @@ class OrdinationResults(SkbioObject, PlottableMixin):
     def _validate_plot_axes(self, coord_matrix, axes):
         """Validate `axes` against coordinates matrix."""
         num_dims = coord_matrix.shape[0]
-        if num_dims < 3:
+        if num_dims < 2:
             raise ValueError(
-                "At least three dimensions are required to plot "
+                "At least two dimensions are required to plot "
                 "ordination results. There are only %d "
                 "dimension(s)." % num_dims
             )
-        if len(axes) != 3:
+        if len(axes) not in [2, 3]:
             raise ValueError(
-                "`axes` must contain exactly three elements "
+                "`axes` must contain exactly two or three elements "
                 "(found %d elements)." % len(axes)
             )
-        if len(set(axes)) != 3:
+        if len(set(axes)) != len(axes):
             raise ValueError("The values provided for `axes` must be unique.")
 
         for idx, axis in enumerate(axes):

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -17,7 +17,7 @@ from scipy.linalg import eigh
 
 from skbio.util import get_rng
 from skbio.stats.distance import DistanceMatrix
-from skbio.util.config._dispatcher import create_table, create_table_1d
+from skbio.util.config._dispatcher import _create_table, _create_table_1d
 from ._ordination_results import OrdinationResults
 from ._utils import center_distance_matrix, scale
 
@@ -69,6 +69,11 @@ def pcoa(
         warning completely.
 
         .. versionadded:: 0.6.3
+
+    output_format : optional
+        Standard ``DataTable`` parameter. See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
 
     Returns
     -------
@@ -278,14 +283,14 @@ def pcoa(
     return OrdinationResults(
         short_method_name="PCoA",
         long_method_name=long_method_name,
-        eigvals=create_table_1d(eigvals, index=axis_labels, backend=output_format),
-        samples=create_table(
+        eigvals=_create_table_1d(eigvals, index=axis_labels, backend=output_format),
+        samples=_create_table(
             coordinates,
             index=distance_matrix.ids,
             columns=axis_labels,
             backend=output_format,
         ),
-        proportion_explained=create_table_1d(
+        proportion_explained=_create_table_1d(
             proportion_explained, index=axis_labels, backend=output_format
         ),
     )

--- a/skbio/stats/ordination/_redundancy_analysis.py
+++ b/skbio/stats/ordination/_redundancy_analysis.py
@@ -12,7 +12,7 @@ from scipy.linalg import svd, lstsq
 
 from ._ordination_results import OrdinationResults
 from ._utils import corr, svd_rank, scale
-from skbio.util.config._dispatcher import ingest_array, create_table, create_table_1d
+from skbio.util.config._dispatcher import _ingest_array, _create_table, _create_table_1d
 
 
 def rda(
@@ -37,20 +37,22 @@ def rda(
 
     Parameters
     ----------
-    y : DataFrame or ndarray
+    y : table_like
         :math:`n \times p` response matrix, where :math:`n` is the number
         of samples and :math:`p` is the number of features. Its columns
         need be dimensionally homogeneous (or you can set `scale_Y=True`).
         This matrix is also referred to as the community matrix that
-        commonly stores information about species abundances. Can be numpy,
-        pandas, polars, AnnData, or BIOM (skbio.Table).
-    x : DataFrame or ndarray
+        commonly stores information about species abundances. See the
+        `DataTable <https://scikit.bio/docs/dev/generated/skbio.util.config.html#
+        the-datatable-type>`_ type documentation for details.
+    x : table_like
         :math:`n \times m, n \geq m` matrix of explanatory
         variables, where :math:`n` is the number of samples and
         :math:`m` is the number of metadata variables. Its columns
         need not be standardized, but doing so turns regression
-        coefficients into standard regression coefficients. Can be numpy,
-        pandas, polars, AnnData, or BIOM (skbio.Table).
+        coefficients into standard regression coefficients. See the
+        `DataTable <https://scikit.bio/docs/dev/generated/skbio.util.config.html#
+        the-datatable-type>`_ type documentation for details.
     scale_Y : bool, optional
         Controls whether the response matrix columns are scaled to
         have unit standard deviation. Defaults to `False`.
@@ -60,24 +62,6 @@ def rda(
         distances approximate their original euclidean
         distances. Especially interesting when most explanatory
         variables are binary.
-    sample_ids : list of str, optional
-        List of ids of samples. If not provided implicitly by the input DataFrame or
-        explicitly by the user, sample_ids will default to a list of integers starting
-        at zero.
-    feature_ids : list of str, optional
-        List of ids of features. If not provided implicitly by y or explicitly by the
-        user, it will default to list of integers starting at zero.
-    constraint_ids : list of str, optional
-        List of ids of metadata variables (constraints). If not provided implicitly
-        by y or explicitly by the user, it will default to a list of integers
-        starting at zero.
-    output_format : str, optional
-        The desired format of the output object. Can be ``pandas``, ``polars``, or
-        ``numpy``. Note that all scikit-bio ordination functions return an
-        ``OrdinationResults`` object. In this case the attributes of the
-        ``OrdinationResults`` object will be in the specified format. Default is
-        ``pandas``.
-
         Scaling type 2 produces a correlation biplot. It focuses
         on the relationships among explained variables (`y`). It
         is interpreted like scaling type 1, but taking into
@@ -86,6 +70,14 @@ def rda(
 
         See more details about distance and correlation biplots in
         [1]_, \S 9.1.4.
+    constraint_ids : list of str, optional
+        List of identifiers for metadata variables or constraints (applicable in
+        constrained ordination methods). If not provided implicitly by the input data
+        structure or explicitly by the user, defaults to integers starting at zero.
+    sample_ids, feature_ids, output_format : optional
+        Standard ``DataTable`` parameters. See the `DataTable <https://scikit.bio/
+        docs/dev/generated/skbio.util.config.html#the-datatable-type>`_ type
+        documentation for details.
 
     Returns
     -------
@@ -123,8 +115,8 @@ def rda(
        Ecology. Elsevier, Amsterdam.
 
     """
-    Y, y_rows, y_cols = ingest_array(y)
-    X, x_rows, x_cols = ingest_array(x)
+    Y, y_rows, y_cols = _ingest_array(y)
+    X, x_rows, x_cols = _ingest_array(x)
 
     n, p = Y.shape
     n_, m = X.shape
@@ -213,7 +205,7 @@ def rda(
     # According to the vegan-FAQ.pdf, the scaling factor for scores
     # is (notice that L&L 1998 says in p. 586 that such scaling
     # doesn't affect the interpretation of a biplot):
-    eigvals = create_table_1d(
+    eigvals = _create_table_1d(
         eigenvalues,
         index=["RDA%d" % (i + 1) for i in range(len(eigenvalues))],
         backend=output_format,
@@ -226,13 +218,13 @@ def rda(
     feature_scores = np.hstack((U, U_res)) * scaling_factor
     sample_scores = np.hstack((F, F_res)) / scaling_factor
 
-    feature_scores = create_table(
+    feature_scores = _create_table(
         feature_scores,
         index=feature_ids,
         columns=["RDA%d" % (i + 1) for i in range(feature_scores.shape[1])],
         backend=output_format,
     )
-    sample_scores = create_table(
+    sample_scores = _create_table(
         sample_scores,
         index=sample_ids,
         columns=["RDA%d" % (i + 1) for i in range(sample_scores.shape[1])],
@@ -240,7 +232,7 @@ def rda(
     )
     # TODO not yet used/displayed
     sample_constraints = np.hstack((Z, F_res)) / scaling_factor
-    sample_constraints = create_table(
+    sample_constraints = _create_table(
         sample_constraints,
         index=sample_ids,
         columns=["RDA%d" % (i + 1) for i in range(sample_constraints.shape[1])],
@@ -253,7 +245,7 @@ def rda(
     # environmental variables (depth, coral, sand, other) even if
     # other = not(coral or sand)
     biplot_scores = corr(X, u)
-    biplot_scores = create_table(
+    biplot_scores = _create_table(
         biplot_scores,
         index=x_cols,
         columns=["RDA%d" % (i + 1) for i in range(biplot_scores.shape[1])],
@@ -263,7 +255,7 @@ def rda(
     # scores" from table 11.4 are quite similar to vegan's biplot
     # scores, but they're computed like this:
     # corr(X, F))
-    p_explained = create_table_1d(
+    p_explained = _create_table_1d(
         eigenvalues / eigenvalues.sum(),
         index=["RDA%d" % (i + 1) for i in range(len(eigenvalues))],
         backend=output_format,

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -330,5 +330,203 @@ class TestOrdinationResultsPlotting(unittest.TestCase):
         npt.assert_equal(sorted(colors), ['green', 'red'])
 
 
+@unittest.skipUnless(has_matplotlib, "Matplotlib not available.")
+class TestOrdinationResults2DPlotting(unittest.TestCase):
+    def setUp(self):
+        # DataFrame for testing plot method. Has a categorical column with a
+        # mix of numbers and strings. Has a numeric column with a mix of ints,
+        # floats, and strings that can be converted to floats. Has a numeric
+        # column with missing data (np.nan).
+        self.df = pd.DataFrame([['foo', '42'],
+                                [22, 0],
+                                [22, -4.2],
+                                ['foo', '42.19']],
+                               index=['A', 'B', 'C', 'D'],
+                               columns=['categorical', 'numeric'])
+
+        # Minimal ordination results for easier testing of plotting method.
+        # Paired with df above.
+        eigvals = np.array([0.50, 0.25])
+        samples = np.array([[0.1, 0.2],
+                            [0.2, 0.3],
+                            [0.3, 0.4],
+                            [0.4, 0.5]])
+        samples_df = pd.DataFrame(samples, ['A', 'B', 'C', 'D'],
+                                  ['PC1', 'PC2'])
+
+        self.min_ord_results = OrdinationResults(
+            'PCoA', 'Principal Coordinate Analysis', eigvals, samples_df)
+        self.min_ord_results._get_mpl_plt()
+
+    def check_basic_figure_sanity(self, fig, exp_num_subplots, exp_title,
+                                  exp_legend_exists, exp_xlabel, exp_ylabel):
+        # check type
+        self.assertIsInstance(fig, mpl.figure.Figure)
+
+        # check number of subplots
+        axes = fig.get_axes()
+        npt.assert_equal(len(axes), 1)
+
+        # check title
+        ax = axes[0]
+        npt.assert_equal(ax.get_title(), exp_title)
+
+        # shouldn't have tick labels
+        for tick_label in (ax.get_xticklabels() + ax.get_yticklabels()):
+            npt.assert_equal(tick_label.get_text(), '')
+
+        # check if legend is present
+        legend = ax.get_legend()
+        if exp_legend_exists:
+            self.assertTrue(legend is not None)
+        else:
+            self.assertTrue(legend is None)
+
+        # check axis labels
+        npt.assert_equal(ax.get_xlabel(), exp_xlabel)
+        npt.assert_equal(ax.get_ylabel(), exp_ylabel)
+
+    def test_plot_no_metadata(self):
+        fig = self.min_ord_results.plot()
+        self.check_basic_figure_sanity(fig, 1, '', False, '0', '1')
+
+    def test_plot_with_numeric_metadata_and_plot_options(self):
+        fig = self.min_ord_results.plot(
+            self.df, 'numeric', axes=(1, 0),
+            axis_labels=['PC 2', 'PC 1'], title='a title', cmap='Reds')
+        self.check_basic_figure_sanity(
+            fig, 2, 'a title', False, 'PC 2', 'PC 1')
+
+    def test_plot_with_categorical_metadata_and_plot_options(self):
+        fig = self.min_ord_results.plot(
+            self.df, 'categorical', axes=[0, 1], title='a title',
+            cmap='Accent')
+        self.check_basic_figure_sanity(fig, 1, 'a title', True, '0', '1')
+
+    def test_plot_with_invalid_axis_labels(self):
+        with self.assertRaisesRegex(ValueError, r'axis_labels.*4'):
+            self.min_ord_results.plot(axes=[0, 1],
+                                      axis_labels=('a', 'b', 'c'))
+
+    def test_validate_plot_axes_valid_input(self):
+        # shouldn't raise an error on valid input. nothing is returned, so
+        # nothing to check here
+        samples = self.min_ord_results.samples.values.T
+        self.min_ord_results._validate_plot_axes(samples, (0,1))
+
+    def test_validate_plot_axes_invalid_input(self):
+        # not enough dimensions
+        with self.assertRaisesRegex(ValueError, r'1 dimension\(s\)'):
+            self.min_ord_results._validate_plot_axes(
+                np.asarray([[0.1, 0.2], [0.2, 0.3]]), (0, 1, 2))
+
+        coord_matrix = self.min_ord_results.samples.values.T
+
+        # wrong number of axes
+        with self.assertRaisesRegex(ValueError, r'exactly two.*found 0'):
+            self.min_ord_results._validate_plot_axes(coord_matrix, [])
+        with self.assertRaisesRegex(ValueError, r'exactly two.*found 3'):
+            self.min_ord_results._validate_plot_axes(coord_matrix,
+                                                     (0, 1, 2))
+
+        # duplicate axes
+        with self.assertRaisesRegex(ValueError, r'must be unique'):
+            self.min_ord_results._validate_plot_axes(coord_matrix, (0, 0))
+
+        # out of range axes
+        with self.assertRaisesRegex(ValueError, r'axes\[0\].*3'):
+            self.min_ord_results._validate_plot_axes(coord_matrix, (0, -1))
+        with self.assertRaisesRegex(ValueError, r'axes\[1\].*3'):
+            self.min_ord_results._validate_plot_axes(coord_matrix, (0, 3))
+
+    def test_get_plot_point_colors_invalid_input(self):
+        # column provided without df
+        with npt.assert_raises(ValueError):
+            self.min_ord_results._get_plot_point_colors(None, 'numeric',
+                                                        ['B', 'C'], 'jet')
+
+        # df provided without column
+        with npt.assert_raises(ValueError):
+            self.min_ord_results._get_plot_point_colors(self.df, None,
+                                                        ['B', 'C'], 'jet')
+
+        # column not in df
+        with self.assertRaisesRegex(ValueError, r'missingcol'):
+            self.min_ord_results._get_plot_point_colors(self.df, 'missingcol',
+                                                        ['B', 'C'], 'jet')
+
+        # id not in df
+        with self.assertRaisesRegex(ValueError, r'numeric'):
+            self.min_ord_results._get_plot_point_colors(
+                self.df, 'numeric', ['B', 'missingid'], 'jet')
+
+        # missing data in df
+        with self.assertRaisesRegex(ValueError, r'nancolumn'):
+            self.min_ord_results._get_plot_point_colors(self.df, 'nancolumn',
+                                                        ['B', 'C'], 'jet')
+
+    def test_get_plot_point_colors_no_df_or_column(self):
+        obs = self.min_ord_results._get_plot_point_colors(None, None,
+                                                          ['B', 'C'], 'jet')
+        npt.assert_equal(obs, (None, None))
+
+    def test_get_plot_point_colors_numeric_column(self):
+        # subset of the ids in df
+        exp = [0.0, -4.2]
+        obs = self.min_ord_results._get_plot_point_colors(
+            self.df, 'numeric', ['B', 'C'], 'jet')
+        npt.assert_almost_equal(obs[0], exp)
+        self.assertTrue(obs[1] is None)
+
+        # all ids in df
+        exp = [0.0, 42.0]
+        obs = self.min_ord_results._get_plot_point_colors(
+            self.df, 'numeric', ['B', 'A'], 'jet')
+        npt.assert_almost_equal(obs[0], exp)
+        self.assertTrue(obs[1] is None)
+
+    def test_get_plot_point_colors_categorical_column(self):
+        # subset of the ids in df
+        exp_colors = [[0., 0., 0.5, 1.], [0., 0., 0.5, 1.]]
+        exp_color_dict = {
+            'foo': [0.5, 0., 0., 1.],
+            22: [0., 0., 0.5, 1.]
+        }
+        obs = self.min_ord_results._get_plot_point_colors(
+            self.df, 'categorical', ['B', 'C', 'A'], 'jet')
+        npt.assert_almost_equal(obs[0], exp_colors)
+        npt.assert_equal(obs[1], exp_color_dict)
+
+        # all ids in df
+        exp_colors = [[0., 0., 0.5, 1.], [0.5, 0., 0., 1.]]
+        obs = self.min_ord_results._get_plot_point_colors(
+            self.df, 'categorical', ['B', 'A'], 'jet')
+        npt.assert_almost_equal(obs[0], exp_colors)
+        # should get same color dict as before
+        npt.assert_equal(obs[1], exp_color_dict)
+
+    def test_plot_categorical_legend(self):
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+
+        # we shouldn't have a legend yet
+        self.assertTrue(ax.get_legend() is None)
+
+        self.min_ord_results._plot_categorical_legend(
+            ax, {'foo': 'red', 'bar': 'green'})
+
+        # make sure we have a legend now
+        legend = ax.get_legend()
+        self.assertTrue(legend is not None)
+
+        # do some light sanity checking to make sure our input labels and
+        # colors are present
+        labels = [t.get_text() for t in legend.get_texts()]
+        npt.assert_equal(sorted(labels), ['bar', 'foo'])
+
+        colors = [line.get_color() for line in legend.get_lines()]
+        npt.assert_equal(sorted(colors), ['green', 'red'])
+        
+
 if __name__ == '__main__':
     unittest.main()

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -217,16 +217,16 @@ class TestOrdinationResultsPlotting(unittest.TestCase):
 
     def test_validate_plot_axes_invalid_input(self):
         # not enough dimensions
-        with self.assertRaisesRegex(ValueError, r'2 dimension\(s\)'):
+        with self.assertRaisesRegex(ValueError, r'1 dimension\(s\)'):
             self.min_ord_results._validate_plot_axes(
-                np.asarray([[0.1, 0.2, 0.3], [0.2, 0.3, 0.4]]), (0, 1, 2))
+                np.asarray([[0.1, 0.2, 0.3]]), (0, 1, 2))
 
         coord_matrix = self.min_ord_results.samples.values.T
 
         # wrong number of axes
-        with self.assertRaisesRegex(ValueError, r'exactly three.*found 0'):
+        with self.assertRaisesRegex(ValueError, r'exactly two.*found 0'):
             self.min_ord_results._validate_plot_axes(coord_matrix, [])
-        with self.assertRaisesRegex(ValueError, r'exactly three.*found 4'):
+        with self.assertRaisesRegex(ValueError, r'exactly two.*found 4'):
             self.min_ord_results._validate_plot_axes(coord_matrix,
                                                      (0, 1, 2, 3))
 
@@ -365,7 +365,7 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
 
         # check number of subplots
         axes = fig.get_axes()
-        npt.assert_equal(len(axes), 1)
+        npt.assert_equal(len(axes), exp_num_subplots)
 
         # check title
         ax = axes[0]
@@ -416,7 +416,7 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
 
     def test_validate_plot_axes_invalid_input(self):
         # not enough dimensions
-        with self.assertRaisesRegex(ValueError, r'1 dimension\(s\)'):
+        with self.assertRaisesRegex(ValueError, r'`axes\[2\]` must be >= 0 and < 2.'):
             self.min_ord_results._validate_plot_axes(
                 np.asarray([[0.1, 0.2], [0.2, 0.3]]), (0, 1, 2))
 
@@ -425,18 +425,18 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
         # wrong number of axes
         with self.assertRaisesRegex(ValueError, r'exactly two.*found 0'):
             self.min_ord_results._validate_plot_axes(coord_matrix, [])
-        with self.assertRaisesRegex(ValueError, r'exactly two.*found 3'):
+        with self.assertRaisesRegex(ValueError, r'exactly two.*found 4'):
             self.min_ord_results._validate_plot_axes(coord_matrix,
-                                                     (0, 1, 2))
+                                                     (0, 1, 2, 3))
 
         # duplicate axes
         with self.assertRaisesRegex(ValueError, r'must be unique'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 0))
 
         # out of range axes
-        with self.assertRaisesRegex(ValueError, r'axes\[0\].*3'):
+        with self.assertRaisesRegex(ValueError, r'axes\[1\].*2'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, -1))
-        with self.assertRaisesRegex(ValueError, r'axes\[1\].*3'):
+        with self.assertRaisesRegex(ValueError, r'axes\[1\].*2'):
             self.min_ord_results._validate_plot_axes(coord_matrix, (0, 3))
 
     def test_get_plot_point_colors_invalid_input(self):

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -404,7 +404,7 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
         self.check_basic_figure_sanity(fig, 1, 'a title', True, '0', '1')
 
     def test_plot_with_invalid_axis_labels(self):
-        with self.assertRaisesRegex(ValueError, r'axis_labels.*4'):
+        with self.assertRaisesRegex(ValueError, r'axis_labels.*3'):
             self.min_ord_results.plot(axes=[0, 1],
                                       axis_labels=('a', 'b', 'c'))
 
@@ -487,20 +487,21 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
 
     def test_get_plot_point_colors_categorical_column(self):
         # subset of the ids in df
-        exp_colors = [[0., 0., 0.5, 1.], [0., 0., 0.5, 1.]]
+        exp_colors = [[0., 0., 0.5, 1.], [0.5, 0., 0., 1.]]
         exp_color_dict = {
             'foo': [0.5, 0., 0., 1.],
             22: [0., 0., 0.5, 1.]
         }
         obs = self.min_ord_results._get_plot_point_colors(
-            self.df, 'categorical', ['B', 'C', 'A'], 'jet')
+            self.df, 'categorical', ['B', 'A'], 'jet')
         npt.assert_almost_equal(obs[0], exp_colors)
         npt.assert_equal(obs[1], exp_color_dict)
 
         # all ids in df
-        exp_colors = [[0., 0., 0.5, 1.], [0.5, 0., 0., 1.]]
+        exp_colors = [[0., 0., 0.5, 1.], [0.5, 0., 0., 1.], 
+                      [0.5, 0., 0., 1.], [0., 0., 0.5, 1.]]
         obs = self.min_ord_results._get_plot_point_colors(
-            self.df, 'categorical', ['B', 'A'], 'jet')
+            self.df, 'categorical', ['B', 'A', 'D', 'C'], 'jet')
         npt.assert_almost_equal(obs[0], exp_colors)
         # should get same color dict as before
         npt.assert_equal(obs[1], exp_color_dict)
@@ -529,4 +530,4 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
         
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(buffer=False)

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -530,4 +530,4 @@ class TestOrdinationResults2DPlotting(unittest.TestCase):
         
 
 if __name__ == '__main__':
-    unittest.main(buffer=False)
+    unittest.main()

--- a/skbio/table/_base.py
+++ b/skbio/table/_base.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from biom import Table, example_table
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 
 Table.default_write_format = "biom"
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -32,7 +32,7 @@ from skbio.util._decorator import (
     params_aliased,
 )
 from skbio.util._warning import _warn_once
-from skbio.io.registry import Read, Write
+from skbio.io.descriptors import Read, Write
 from ._compare import (
     _check_dist_metric,
     _check_shuffler,

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -59,6 +59,15 @@ Decorators
    params_aliased
 
 
+Types
+-----
+
+.. autosummary::
+   :toctree: generated/
+
+   DataTable
+
+
 Miscellaneous utilities
 -----------------------
 
@@ -101,6 +110,7 @@ from ._decorator import (
 )
 from ._plotting import PlottableMixin
 from .config._config import get_config, set_config
+from ._types import DataTable
 
 __all__ = [
     "cardinal_to_ordinal",
@@ -122,4 +132,5 @@ __all__ = [
     "params_aliased",
     "get_config",
     "set_config",
+    "DataTable",
 ]

--- a/skbio/util/_types.py
+++ b/skbio/util/_types.py
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from typing import Union
+
+import pandas as pd
+import numpy as np
+
+from skbio.table import Table
+from skbio.util.config import _get_package
+
+# Base types which are always available
+DataTable = Union[pd.DataFrame, np.ndarray, Table]
+
+# add other types depending on availability
+pl, has_polars = _get_package("polars", raise_error=False, no_bool=False)
+if has_polars:
+    DataTable = Union[DataTable, pl.DataFrame]
+
+adt, has_anndata = _get_package("anndata", raise_error=False, no_bool=False)
+if has_anndata:
+    DataTable = Union[DataTable, adt.AnnData]

--- a/skbio/util/config/__init__.py
+++ b/skbio/util/config/__init__.py
@@ -20,22 +20,75 @@ Functions
    set_config
 
 
-Supported Input Formats
------------------------
+The DataTable Type
+----------------------
+The :data:`~skbio.util.DataTable` type is the union of the following types of objects:
+
 - Numpy :class:`~numpy.ndarray` (2D)
 - pandas :class:`~pandas.DataFrame`
 - Polars :class:`~polars.DataFrame`
 - scikit-bio :class:`~skbio.table.Table`
 - :class:`~anndata.AnnData` object
 
-Input handling of supported types is handled automatically. No need to set a
-configuration variable to use whichever input type you like. When possible, row and
-column identifiers will be preserved and carried through operations to the results.
-When IDs are not available from the input data and not provided explicitly, integer
-indices starting from 0 will be used.
+For all functions which accept a ``DataTable`` type as input, any objects from this
+list are acceptable input. Input handling of supported types is handled automatically.
+No need to set a configuration variable to use whichever input type you like. When
+possible, row and column identifiers will be preserved and carried through operations
+to the results. When IDs are not available from the input data and not provided
+explicitly, integer indices starting from 0 will be used.
+
+Sample and Feature Identifiers
+------------------------------
+In scikit-bio, data is commonly organized in a two-dimensional structure:
+
+- **sample_ids**: Identifiers for rows, typically representing biological samples,
+  observations, or experimental units (e.g., patients, sites, time points).
+
+- **feature_ids**: Identifiers for columns, typically representing measured variables
+  or characteristics (e.g., taxa, genes, OTUs, metabolites, environmental parameters).
+
+Different data formats use different terminology for these concepts:
+
+- ``pandas``: "index" (rows) and "columns"
+- ``anndata``: "obs" (samples) and "var" (features)
+- ``scikit-bio Table``: "sample" (samples) and "observation"
+  (features)
+- ``polars``: rows (by position) and "schema" (features)
+
+
+Common DataTable Parameters
+---------------------------
+Many functions that accept ``DataTable`` inputs share a set of common parameters that
+control how identifiers are handled and specify output format preferences:
+
+sample_ids : list of str, optional
+    List of identifiers for samples (rows). If not provided implicitly by the input
+    data structure or explicitly by the user, defaults to integers starting at zero.
+    This parameter is useful when the input format doesn't support row labels
+    (e.g., NumPy arrays) or when you want to override existing labels.
+
+feature_ids : list of str, optional
+    List of identifiers for features (columns). If not provided implicitly by the
+    input data structure or explicitly by the user, defaults to integers starting
+    at zero. This parameter is useful when the input format doesn't support column
+    labels (e.g., NumPy arrays) or when you want to override existing labels.
+
+output_format : str, optional
+    Specifies the desired format for the output. Valid options are:
+
+    - ``"pandas"``: Return pandas DataFrames/Series (default)
+    - ``"numpy"``: Return NumPy ndarrays
+    - ``"polars"``: Return Polars DataFrames/Series
+
+    Note that this parameter overrides the global configuration setting for
+    the specific function call.
 
 Supported Output Formats
 ------------------------
+Currently, scikit-bio functions support outputing the following types of data. Note
+that this list is not equivalent to the input types supported through the ``DataTable``
+type.
+
 - Numpy :class:`~numpy.ndarray` (2D and 1D)
 - pandas :class:`~pandas.DataFrame` and :class:`~pandas.Series` (default)
 - Polars :class:`~polars.DataFrame` and :class:`~polars.Series`
@@ -44,8 +97,8 @@ Configuring Output Format
 -------------------------
 There are two ways to control the output format.
 
-The first option is to use the `set_config` function. This function will change the
-global behavior of scikit-bio functions.:
+The first option is to use the :func:`set_config` function. This function will change
+the global behavior of scikit-bio functions.
 
 .. code-block:: python
 
@@ -59,7 +112,7 @@ global behavior of scikit-bio functions.:
     set_config("output", "pandas")
 
 The second option is to set the desired output format on a per-function basis, using
-the `output_format` parameter:
+the ``output_format`` parameter.
 
 .. code-block:: python
 
@@ -70,14 +123,13 @@ the `output_format` parameter:
     # numpy arrays
     res = cca(Y, X, output_format="numpy")
 
-
-Notes
------
-When using the default pandas backend, existing workflows remain unchanged.
-Additionally, input and output formats do not have to match.
-
 """
 
 from ._config import get_config, set_config
+from ._optionals import _get_package
 
-__all__ = ["get_config", "set_config"]
+__all__ = [
+    "get_config",
+    "set_config",
+    "_get_package",
+]

--- a/skbio/util/config/_config.py
+++ b/skbio/util/config/_config.py
@@ -10,14 +10,30 @@ _BACKEND_OPTIONS = {"output": "pandas"}
 
 
 def set_config(option: str, value: str):
-    """Set an skbio config option.
+    """Set a scikit-bio config option.
+
+    This function enables users to set the configuration of scikit-bio functions
+    globally.
 
     Parameters
     ----------
     option : str
-        The configuration option to be modified.
+        The configuration option to be modified. Currently there is only one
+        configurable option, ``"output"``.
     value : str
-        The value to update the configuration dictionary with.
+        The value to update the configuration dictionary with. For the
+        ``"output"`` option, ``value`` may be set to ``"pandas"``,
+        ``"polars"``, or ``"numpy"``. Defaults to ``"pandas"``.
+
+    Raises
+    ------
+    ValueError
+        If an unkown option is used or if an unsupported value for an option is used.
+
+    Examples
+    --------
+    >>> from skbio import set_config
+    >>> set_config("output", "numpy")
 
     """
     if option not in _BACKEND_OPTIONS:

--- a/skbio/util/config/_dispatcher.py
+++ b/skbio/util/config/_dispatcher.py
@@ -16,12 +16,12 @@ from ._config import get_config
 from ._optionals import _get_package
 
 
-def create_table(data, columns=None, index=None, backend=None):
+def _create_table(data, columns=None, index=None, backend=None):
     """Create a table object using the specified backend.
 
     Parameters
     ----------
-    data : ndarray
+    data : DataTable
     columns : array-like
         Column labels to use if data does not have them.
     index : array-like
@@ -50,12 +50,12 @@ def create_table(data, columns=None, index=None, backend=None):
         raise ValueError(f"Unsupported backend: '{backend}'")
 
 
-def create_table_1d(data, index=None, backend=None):
+def _create_table_1d(data, index=None, backend=None):
     """Create a 1d array using the specified backend.
 
     Parameters
     ----------
-    data : ndarray
+    data : DataTable
     columns : array-like
         Column labels to use if data does not have them.
     index : array-like
@@ -84,12 +84,12 @@ def create_table_1d(data, index=None, backend=None):
         raise ValueError(f"Unsupported backend: '{backend}'")
 
 
-def ingest_array(input_data, row_ids=None, col_ids=None):
+def _ingest_array(input_data, row_ids=None, col_ids=None):
     """Process an input dataframe, table, or array into individual components.
 
     Parameters
     ----------
-    input_data : tabular
+    input_data : DataTable
         The original source of data. May be pandas or polars DataFrame, numpy array,
         BIOM table, or anndata.AnnData.
     row_ids : list of str
@@ -163,11 +163,22 @@ def ingest_array(input_data, row_ids=None, col_ids=None):
     return data_, row_ids, col_ids
 
 
-def extract_row_ids(input_data):
+def _extract_row_ids(input_data, warn_ids=False):
     """Extract row ids from a dataframe or table."""
     if isinstance(input_data, pd.DataFrame):
         return list(input_data.index)
     # for right now, just going to worry about pandas/polars/numpy,
     # which is to say that if it's not pandas, then it doesn't have ids
     else:
+        # Raise warning if sample_ids and feature_ids are both None, as this means
+        # that both will have arbitrary integer IDs starting at 0.
+        if warn_ids:
+            warn(
+                (
+                    "sample_ids and feature_ids were both None. As a "
+                    "result, both have been set to integer IDs "
+                    "starting at 0. Namespaces for sample_ids and "
+                    "feature_ids are no longer mutually exclusive."
+                )
+            )
         return list(range(input_data.shape[0]))

--- a/skbio/util/config/_optionals.py
+++ b/skbio/util/config/_optionals.py
@@ -1,25 +1,25 @@
-# for handling optional dependencies, such as polars
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
 
 import importlib
 
 
-def _get_package(name):
+def _get_package(name, raise_error=True, no_bool=True):
     """Attempt to import a package for functions which require said package."""
     msg = f"Using the {name} backend requires the {name} package to be installed."
     try:
         pkg = importlib.import_module(f"{name}")
+        if no_bool:
+            return pkg
+        else:
+            return pkg, True
     except (ImportError, ModuleNotFoundError):
-        raise ImportError(msg)
-
-    return pkg
-
-
-# def _test_package(name):
-#     """Check if a package is available for testing purposes."""
-#     try:
-#         import name
-#         import polars.testing as plt
-#     except (ImportError, ModuleNotFoundError):
-#         has_polars = False
-#     else:
-#         has_polars = True
+        if raise_error:
+            raise ImportError(msg)
+        else:
+            return None, False

--- a/skbio/util/tests/test_dispatcher.py
+++ b/skbio/util/tests/test_dispatcher.py
@@ -13,23 +13,12 @@ import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
 
-try:
-    import polars as pl
-    import polars.testing as plt
-except (ImportError, ModuleNotFoundError):
-    has_polars = False
-else:
-    has_polars = True
-
-try:
-    import anndata as adt
-except (ImportError, ModuleNotFoundError):
-    has_anndata = False
-else:
-    has_anndata = True
+from skbio.util.config._optionals import _get_package
+pl, has_polars = _get_package('polars', raise_error=False, no_bool=False)
+adt, has_anndata = _get_package('anndata', raise_error=False, no_bool=False)
 
 from skbio.table import Table
-from skbio.util.config._dispatcher import create_table, create_table_1d, ingest_array
+from skbio.util.config._dispatcher import _create_table, _create_table_1d, _ingest_array
 from skbio.util import set_config
 from skbio.util._testing import assert_data_frame_almost_equal
 
@@ -43,24 +32,24 @@ class TestPandas(TestCase):
         self.columns = ["f1", "f2", "f3"]
 
     def test_create_table_no_backend(self):
-        obs = create_table(data=self.data, columns=self.columns, index=self.index)
+        obs = _create_table(data=self.data, columns=self.columns, index=self.index)
         exp = pd.DataFrame(self.data, columns=self.columns, index=self.index)
         assert_data_frame_almost_equal(obs, exp)
 
     def test_create_table_no_optionals(self):
-        obs = create_table(self.data)
+        obs = _create_table(self.data)
         exp = pd.DataFrame(self.data)
         assert_data_frame_almost_equal(obs, exp)
 
     def test_create_table_same_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="pandas"
         )
         exp = pd.DataFrame(self.data, columns=self.columns, index=self.index)
         assert_data_frame_almost_equal(obs, exp)
 
     def test_create_table_numpy_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="numpy"
         )
         exp = np.array(self.data)
@@ -68,31 +57,31 @@ class TestPandas(TestCase):
 
     def test_create_table_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table(self.data, backend="nonsense")
+            _create_table(self.data, backend="nonsense")
 
     def test_create_table_1d_no_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index)
+        obs = _create_table_1d(self.data_1d, index=self.index)
         exp = pd.Series(self.data_1d, index=self.index)
         pdt.assert_series_equal(obs, exp)
 
     def test_create_table_1d_no_optionals(self):
-        obs = create_table_1d(self.data_1d)
+        obs = _create_table_1d(self.data_1d)
         exp = pd.Series(self.data_1d)
         pdt.assert_series_equal(obs, exp)
 
     def test_create_table_1d_same_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="pandas")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="pandas")
         exp = pd.Series(self.data_1d, index=self.index)
         pdt.assert_series_equal(obs, exp)
 
     def test_create_table_1d_numpy_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="numpy")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="numpy")
         exp = np.array(self.data_1d)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_1d_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table_1d(self.data, backend="nonsense")
+            _create_table_1d(self.data, backend="nonsense")
 
 
 class TestNumpy(TestCase):
@@ -107,24 +96,24 @@ class TestNumpy(TestCase):
         set_config("output", "pandas")
 
     def test_create_table_no_backend(self):
-        obs = create_table(data=self.data, columns=self.columns, index=self.index)
+        obs = _create_table(data=self.data, columns=self.columns, index=self.index)
         exp = np.array(self.data)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_no_optionals(self):
-        obs = create_table(self.data)
+        obs = _create_table(self.data)
         exp = np.array(self.data)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_same_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="numpy"
         )
         exp = np.array(self.data)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_pandas_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="pandas"
         )
         exp = pd.DataFrame(self.data, columns=self.columns, index=self.index)
@@ -132,31 +121,31 @@ class TestNumpy(TestCase):
 
     def test_create_table_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table(self.data, backend="nonsense")
+            _create_table(self.data, backend="nonsense")
 
     def test_create_table_1d_no_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index)
+        obs = _create_table_1d(self.data_1d, index=self.index)
         exp = np.array(self.data_1d)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_1d_no_optionals(self):
-        obs = create_table_1d(self.data_1d)
+        obs = _create_table_1d(self.data_1d)
         exp = np.array(self.data_1d)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_1d_same_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="numpy")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="numpy")
         exp = np.array(self.data_1d)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_1d_pandas_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="pandas")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="pandas")
         exp = pd.Series(self.data_1d, index=self.index)
         pdt.assert_series_equal(obs, exp)
 
     def test_create_table_1d_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table_1d(self.data, backend="nonsense")
+            _create_table_1d(self.data, backend="nonsense")
 
 
 @skipIf(not has_polars, "Polars is not available for unit tests.")
@@ -172,31 +161,31 @@ class TestPolars(TestCase):
         set_config("output", "pandas")
 
     def test_create_table_no_backend(self):
-        obs = create_table(data=self.data, columns=self.columns, index=self.index)
+        obs = _create_table(data=self.data, columns=self.columns, index=self.index)
         exp = pl.DataFrame(self.data, schema=self.columns)
-        plt.assert_frame_equal(obs, exp)
+        pl.testing.assert_frame_equal(obs, exp)
 
     def test_create_table_no_optionals(self):
-        obs = create_table(self.data)
+        obs = _create_table(self.data)
         exp = pl.DataFrame(self.data)
-        plt.assert_frame_equal(obs, exp)
+        pl.testing.assert_frame_equal(obs, exp)
 
     def test_create_table_same_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="polars"
         )
         exp = pl.DataFrame(self.data, schema=self.columns)
-        plt.assert_frame_equal(obs, exp)
+        pl.testing.assert_frame_equal(obs, exp)
 
     def test_create_table_numpy_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="numpy"
         )
         exp = np.array(self.data)
         npt.assert_array_equal(obs, exp)
 
     def test_create_table_pandas_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="pandas"
         )
         exp = pd.DataFrame(self.data, columns=self.columns, index=self.index)
@@ -204,30 +193,30 @@ class TestPolars(TestCase):
 
     def test_create_table_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table(self.data, backend="nonsense")
+            _create_table(self.data, backend="nonsense")
 
     def test_create_table_1d_no_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index)
+        obs = _create_table_1d(self.data_1d, index=self.index)
         exp = pl.Series(self.data_1d)
-        plt.assert_series_equal(obs, exp)
+        pl.testing.assert_series_equal(obs, exp)
 
     def test_create_table_1d_no_optionals(self):
-        obs = create_table_1d(self.data_1d)
+        obs = _create_table_1d(self.data_1d)
         exp = pl.Series(self.data_1d)
-        plt.assert_series_equal(obs, exp)
+        pl.testing.assert_series_equal(obs, exp)
 
     def test_create_table_1d_same_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="polars")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="polars")
         exp = pl.Series(self.data_1d)
-        plt.assert_series_equal(obs, exp)
+        pl.testing.assert_series_equal(obs, exp)
 
     def test_create_table_1d_pandas_backend(self):
-        obs = create_table_1d(self.data_1d, index=self.index, backend="pandas")
+        obs = _create_table_1d(self.data_1d, index=self.index, backend="pandas")
         exp = pd.Series(self.data_1d, index=self.index)
         pdt.assert_series_equal(obs, exp)
 
     def test_create_table_1d_numpy_backend(self):
-        obs = create_table(
+        obs = _create_table(
             data=self.data, columns=self.columns, index=self.index, backend="numpy"
         )
         exp = np.array(self.data)
@@ -235,7 +224,7 @@ class TestPolars(TestCase):
 
     def test_create_table_1d_bad_backend(self):
         with self.assertRaisesRegex(ValueError, "Unsupported backend: 'nonsense'"):
-            create_table_1d(self.data, backend="nonsense")
+            _create_table_1d(self.data, backend="nonsense")
 
 
 class TestBIOM(TestCase):
@@ -255,7 +244,7 @@ class TestBIOM(TestCase):
             "scikit-bio functions expect samples as rows and features as columns. "
             "Please ensure your input is in the correct orientation.\n",
         ):
-            data, row_ids, col_ids = ingest_array(tbl)
+            data, row_ids, col_ids = _ingest_array(tbl)
         npt.assert_array_equal(data, self.data)
         self.assertEqual(row_ids, self.samples)
         self.assertEqual(col_ids, self.features)
@@ -271,7 +260,7 @@ class TestBIOM(TestCase):
             "scikit-bio functions expect samples as rows and features as columns. "
             "Please ensure your input is in the correct orientation.\n",
         ):
-            data, row_ids, col_ids = ingest_array(
+            data, row_ids, col_ids = _ingest_array(
                 tbl, row_ids=self.samples, col_ids=self.features
             )
         npt.assert_array_equal(data, self.data)
@@ -288,14 +277,14 @@ class TestAnndata(TestCase):
 
     def test_anndata_input(self):
         tbl = adt.AnnData(self.data, obs=self.samples, var=self.features)
-        data, row_ids, col_ids = ingest_array(tbl)
+        data, row_ids, col_ids = _ingest_array(tbl)
         npt.assert_array_equal(data, self.data)
         self.assertEqual(row_ids, list(self.samples.index))
         self.assertEqual(col_ids, list(self.features.index))
 
     def test_anndata_input_pass_ids(self):
         tbl = adt.AnnData(self.data, obs=self.samples, var=self.features)
-        data, row_ids, col_ids = ingest_array(
+        data, row_ids, col_ids = _ingest_array(
             tbl, row_ids=list(self.samples.index), col_ids=list(self.features.index)
         )
         npt.assert_array_equal(data, self.data)


### PR DESCRIPTION
Started working on confidence ellipse plotting with basic math in the code. Did not implement covariance matrix yet and Confidence Ellipse is implemented automatically implemented by matplotlib, therefore need discussion on this. 

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
