### PR TITLE
Move package metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,118 @@
+[project]
+name = "scikit-bio"
+dynamic = ["version"]
+description = "Data structures, algorithms and educational resources for bioinformatics."
+readme = "README.rst"
+requires-python = ">=3.9"
+license = {text = "BSD-3-Clause"}
+authors = [
+    {name = "scikit-bio development team", email = "qiyunzhu@gmail.com"}
+]
+maintainers = [
+    {name = "scikit-bio development team", email = "qiyunzhu@gmail.com"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: Unix",
+    "Operating System :: POSIX",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows"
+]
+dependencies = [
+    "requests >= 2.20.0",
+    "decorator >= 3.4.2",
+    "natsort >= 4.0.3",
+    "numpy >= 1.17.0",
+    "pandas >= 1.5.0",
+    "scipy >= 1.9.0",
+    "h5py >= 3.6.0",
+    "biom-format >= 2.1.16",
+    "statsmodels >= 0.14.0",
+    "patsy >= 0.5.0",
+]
+
+[project.urls]
+Homepage = "https://scikit.bio"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "coverage",
+    "responses",
+    "matplotlib"
+]
+docs = [
+    "sphinx",
+    "sphinx-design",
+    "sphinx-copybutton",
+    "pydata-sphinx-theme",
+    "sphinxcontrib-youtube",
+    "sphinx-sitemap",
+    "numpydoc",
+    "matplotlib",
+    "statsmodels",
+    "patsy"
+]
+lint = [
+    "check-manifest",
+    "python-dateutil",
+    "numpy",
+    "ruff",
+    "pre-commit"
+]
+dev = [
+    "pytest",
+    "coverage",
+    "responses",
+    "matplotlib",
+    "sphinx",
+    "sphinx-design",
+    "sphinx-copybutton",
+    "pydata-sphinx-theme",
+    "sphinxcontrib-youtube",
+    "sphinx-sitemap",
+    "numpydoc",
+    "statsmodels",
+    "patsy",
+    "check-manifest",
+    "python-dateutil",
+    "numpy",
+    "ruff",
+    "pre-commit"
+]
+
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "cython"]
+requires = ["setuptools>=45", "wheel", "numpy>=1.17.0", "cython>=0.29.32"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = {attr = "skbio.__version__"}
+
+[tool.setuptools]
+packages = ["skbio"]
+
+[tool.setuptools.package-data]
+"skbio.alignment.tests" = ["data/*"]
+"skbio.diversity.alpha.tests" = ["data/qiime-191-tt/*"]
+"skbio.diversity.beta.tests" = ["data/qiime-191-tt/*"]
+"skbio.io.tests" = ["data/*"]
+"skbio.io.format.tests" = ["data/*"]
+"skbio.stats.tests" = ["data/*"]
+"skbio.stats.distance.tests" = ["data/*"]
+"skbio.stats.ordination.tests" = ["data/*"]
+"skbio.metadata.tests" = ["data/invalid/*", "data/valid/*"]
+"skbio.embedding.tests" = ["data/*"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,12 +117,6 @@ packages = ["skbio"]
 "skbio.metadata.tests" = ["data/invalid/*", "data/valid/*"]
 "skbio.embedding.tests" = ["data/*"]
 
-[tool.cibuildhweel]
-test-command = "pytest {project}/skbio/tests"
-test-requires = ["pytest"]
-environment = { SKBIO_TEST_RUNNER = "True" }
-build = "cp39-* cp10-* cp311-* cp312-*"
-
 [tool.pytest.ini_options]
 addopts = [
     "--doctest-modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "cython"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "scikit-bio"
 dynamic = ["version"]
 description = "Data structures, algorithms and educational resources for bioinformatics."
 readme = "README.rst"
 requires-python = ">=3.9"
-license = {text = "BSD-3-Clause"}
+license = {file = "LICENSE"}
 authors = [
     {name = "scikit-bio development team", email = "qiyunzhu@gmail.com"}
 ]
@@ -44,6 +48,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://scikit.bio"
+Documentation = "https://scikit.bio/docs/latest/"
+Repository = "https://github.com/scikit-bio/scikit-bio"
+Issues = "https://github.com/scikit-bio/scikit-bio/issues"
 
 [project.optional-dependencies]
 test = [
@@ -92,10 +99,6 @@ dev = [
     "pre-commit"
 ]
 
-[build-system]
-requires = ["setuptools>=45", "wheel", "numpy>=1.17.0", "cython>=0.29.32"]
-build-backend = "setuptools.build_meta"
-
 [tool.setuptools.dynamic]
 version = {attr = "skbio.__version__"}
 
@@ -113,6 +116,12 @@ packages = ["skbio"]
 "skbio.stats.ordination.tests" = ["data/*"]
 "skbio.metadata.tests" = ["data/invalid/*", "data/valid/*"]
 "skbio.embedding.tests" = ["data/*"]
+
+[tool.cibuildhweel]
+test-command = "pytest {project}/skbio/tests"
+test-requires = ["pytest"]
+environment = { SKBIO_TEST_RUNNER = "True" }
+build = "cp39-* cp10-* cp311-* cp312-*"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ The full license is in the file LICENSE.txt, distributed with this software.
 
 import os
 import platform
-import re
-import ast
 import sys
 import sysconfig
 import subprocess
@@ -108,42 +106,6 @@ if gcc:
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
-# version parsing from __init__ pulled from Flask's setup.py
-# https://github.com/mitsuhiko/flask/blob/master/setup.py
-_version_re = re.compile(r"__version__\s+=\s+(.*)")
-
-with open("skbio/__init__.py", "rb") as f:
-    hit = _version_re.search(f.read().decode("utf-8")).group(1)
-    version = str(ast.literal_eval(hit))
-
-classes = """
-    Development Status :: 4 - Beta
-    License :: OSI Approved :: BSD License
-    Topic :: Software Development :: Libraries
-    Topic :: Scientific/Engineering
-    Topic :: Scientific/Engineering :: Bio-Informatics
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Operating System :: Unix
-    Operating System :: POSIX
-    Operating System :: MacOS :: MacOS X
-    Operating System :: Microsoft :: Windows
-"""
-classifiers = [s.strip() for s in classes.split("\n") if s]
-
-description = (
-    "Data structures, algorithms and educational " "resources for bioinformatics."
-)
-
-with open("README.rst") as f:
-    long_description = f.read()
-
-
 # Compile SSW module
 ssw_extra_compile_args = ["-I."]
 
@@ -224,43 +186,7 @@ extensions = cythonize(extensions, force=True)
 
 
 setup(
-    name="scikit-bio",
-    version=version,
-    license="BSD-3-Clause",
-    description=description,
-    long_description=long_description,
-    author="scikit-bio development team",
-    author_email="qiyunzhu@gmail.com",
-    maintainer="scikit-bio development team",
-    maintainer_email="qiyunzhu@gmail.com",
-    url="https://scikit.bio",
     packages=find_packages(),
     ext_modules=extensions,
     include_dirs=[np.get_include()],
-    tests_require=["pytest", "coverage"],
-    install_requires=[
-        "requests >= 2.20.0",
-        "decorator >= 3.4.2",
-        "natsort >= 4.0.3",
-        "numpy >= 1.17.0",
-        "pandas >= 1.5.0",
-        "scipy >= 1.9.0",
-        "h5py >= 3.6.0",
-        "biom-format >= 2.1.16",
-        "statsmodels >= 0.14.0",
-        "patsy >= 0.5.0",
-    ],
-    classifiers=classifiers,
-    package_data={
-        "skbio.alignment.tests": ["data/*"],
-        "skbio.diversity.alpha.tests": ["data/qiime-191-tt/*"],
-        "skbio.diversity.beta.tests": ["data/qiime-191-tt/*"],
-        "skbio.io.tests": ["data/*"],
-        "skbio.io.format.tests": ["data/*"],
-        "skbio.stats.tests": ["data/*"],
-        "skbio.stats.distance.tests": ["data/*"],
-        "skbio.stats.ordination.tests": ["data/*"],
-        "skbio.metadata.tests": ["data/invalid/*", "data/valid/*"],
-        "skbio.embedding.tests": ["data/*"],
-    },
 )


### PR DESCRIPTION
This PR adds dependency and package metadata to the `pyproject.toml` file, in line with modern best practices. Currently scikit-bio's package metadata is described in the `setup.py` file, which many modern development tools such as [deps.dev](https://deps.dev/) do not support.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
