### PR TITLE
WIP: Provide pre-built binaries for scikit-bio using cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
           # Skip 32-bit builds, PyPy, and muslinux
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
           
-          # Python versions to build (matching your supported versions)
+          # Python versions to build
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           
           # Install test dependencies and run a simple import test
@@ -42,21 +42,13 @@ jobs:
           # Install numpy before building (required by setup.py)
           CIBW_BEFORE_BUILD: "pip install numpy cython"
           
-          # macOS: use native compilers, enable OpenMP via libomp
-          CIBW_BEFORE_BUILD_MACOS: "brew install libomp && pip install numpy cython"
-          CIBW_ENVIRONMENT_MACOS: >
-            CC=clang
-            CXX=clang++
-            CFLAGS="-I/opt/homebrew/opt/libomp/include -I/usr/local/opt/libomp/include"
-            LDFLAGS="-L/opt/homebrew/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
-          
           # Windows: Use MSVC compiler
           CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy cython"
           
           # Build native wheels for Apple Silicon
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           
-          # Enable building Linux aarch64 wheels (emulated)
+          # Enable building Linux aarch64 wheels
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
       
       - uses: actions/upload-artifact@v4
@@ -79,10 +71,13 @@ jobs:
       
       - name: Install build dependencies
         run: |
+          export RELEASE_VERSION=${{ github.ref_name }}
           pip install numpy cython build
       
       - name: Build sdist
-        run: python -m build --sdist
+        run: |
+          export RELEASE_VERSION=${{ github.ref_name }}
+          python -m build --sdist
       
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,113 @@
+name: Build Wheels
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.0
+        env:
+          # Skip 32-bit builds, PyPy, and muslinux
+          CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
+          
+          # Python versions to build (matching your supported versions)
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          
+          # Install test dependencies and run a simple import test
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "python -c \"import skbio; print(skbio.__version__)\""
+          
+          # Use latest manylinux image
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          
+          # Install numpy before building (required by setup.py)
+          CIBW_BEFORE_BUILD: "pip install numpy cython"
+          
+          # macOS: use native compilers, enable OpenMP via libomp
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp && pip install numpy cython"
+          CIBW_ENVIRONMENT_MACOS: >
+            CC=clang
+            CXX=clang++
+            CFLAGS="-I/opt/homebrew/opt/libomp/include -I/usr/local/opt/libomp/include"
+            LDFLAGS="-L/opt/homebrew/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
+          
+          # Windows: Use MSVC compiler
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy cython"
+          
+          # Build native wheels for Apple Silicon
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          
+          # Enable building Linux aarch64 wheels (emulated)
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      
+      - name: Install build dependencies
+        run: |
+          pip install numpy cython build
+      
+      - name: Build sdist
+        run: python -m build --sdist
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # Only upload to PyPI on tagged commits
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
   doc:
     name: Publish documentation
     runs-on: ubuntu-latest
+    needs: build_and_publish  # Wait for wheels to be built
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - '*'
 
 env:
+  earliest_python: "3.9"
   latest_python: "3.13"
   miniforge_version: "23.11.0-0"
   miniforge_variant: "Mambaforge"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,38 +6,16 @@ on:
       - '*'
 
 env:
-  earliest_python: "3.9"
   latest_python: "3.13"
   miniforge_version: "23.11.0-0"
   miniforge_variant: "Mambaforge"
 
 jobs:
-  pypi:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.earliest_python }}
-
-      - name: Build distribution
-        run: |
-          export RELEASE_VERSION=${{ github.ref_name }}
-          pip install numpy cython
-          python setup.py sdist
-
-      - name: Publish distribution
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  # Trigger wheel building workflow
+  build_and_publish:
+    name: Build and publish to PyPI
+    uses: ./.github/workflows/wheels.yml
+    secrets: inherit
 
   doc:
     name: Publish documentation

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,8 +3,6 @@ name: Build Wheels
 on:
   push:
     branches: [ main ]
-    tags:
-      - '*'
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.0
         # Environment variables are set in pyproject.toml
+        env:
+          # Skip ARM64 builds on PRs to save time
+          CIBW_ARCHS_LINUX: ${{ github.event_name == 'pull_request' && 'x86_64' || 'x86_64 aarch64' }}
       
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,38 +22,20 @@ jobs:
         with:
           submodules: true
       
+      # Set up QEMU for Linux ARM builds
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.0
-        env:
-          # Skip 32-bit builds, PyPy, and muslinux
-          CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
-          
-          # Python versions to build
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          
-          # Install test dependencies and run a simple import test
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: "python -c \"import skbio; print(skbio.__version__)\""
-          
-          # Use latest manylinux image
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-          
-          # Install numpy before building (required by setup.py)
-          CIBW_BEFORE_BUILD: "pip install numpy cython"
-          
-          # Windows: Use MSVC compiler
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install numpy cython"
-          
-          # Build native wheels for Apple Silicon
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          
-          # Enable building Linux aarch64 wheels
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+        # Environment variables are set in pyproject.toml
       
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -71,13 +53,10 @@ jobs:
       
       - name: Install build dependencies
         run: |
-          export RELEASE_VERSION=${{ github.ref_name }}
           pip install numpy cython build
       
       - name: Build sdist
-        run: |
-          export RELEASE_VERSION=${{ github.ref_name }}
-          python -m build --sdist
+        run: python -m build --sdist
       
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,6 @@
 name: Build Wheels
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,29 @@ packages = ["skbio"]
 "skbio.metadata.tests" = ["data/invalid/*", "data/valid/*"]
 "skbio.embedding.tests" = ["data/*"]
 
+# Add this section to your existing pyproject.toml
+
+[tool.cibuildwheel]
+# Skip 32-bit builds, PyPy, and musllinux
+skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]
+
+# Test command - just import the package
+test-command = "python -c \"import skbio; print(skbio.__version__)\""
+test-requires = ["pytest"]
+before-build = "pip install numpy cython"
+
+[tool.cibuildwheel.macos]
+before-build = "pip install numpy cython"
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.windows]
+before-build = "pip install numpy cython"
+
 [tool.pytest.ini_options]
 addopts = [
     "--doctest-modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,6 @@ packages = ["skbio"]
 "skbio.metadata.tests" = ["data/invalid/*", "data/valid/*"]
 "skbio.embedding.tests" = ["data/*"]
 
-# Add this section to your existing pyproject.toml
-
 [tool.cibuildwheel]
 # Skip 32-bit builds, PyPy, and musllinux
 skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,22 +121,39 @@ packages = ["skbio"]
 # Skip 32-bit builds, PyPy, and musllinux
 skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]
 
+# Python versions to build
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+
 # Test command - just import the package
 test-command = "python -c \"import skbio; print(skbio.__version__)\""
 test-requires = ["pytest"]
+
+# Skip tests on emulated architectures (they're very slow)
+# This will skip tests for ARM64 on Linux but still build the wheels
+test-skip = "*-*linux_aarch64"
+
+# Install dependencies before building
 before-build = "pip install numpy cython"
 
 [tool.cibuildwheel.macos]
-before-build = "pip install numpy cython"
+# Build for both Intel and Apple Silicon
 archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.linux]
+# Use manylinux2014 for better compatibility
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
+
+# Build for both x86_64 and ARM64
 archs = ["x86_64", "aarch64"]
 
+# Install system dependencies if needed for ARM builds
+# Uncomment if need specific system libraries:
+# before-all = "yum install -y epel-release && yum install -y openblas-devel"
+
 [tool.cibuildwheel.windows]
-before-build = "pip install numpy cython"
+# Windows only supports x86_64 (no ARM64 for Python on Windows yet)
+archs = ["AMD64"]
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Add wheel building with `cibuildwheel`

Addresses lack of pre-built wheels on PyPI, which makes scikit-bio difficult to install (especially on Windows). Implements automated wheel building using `cibuildwheel`.

## Changes
- Add .github/workflows/wheels.yml to build wheels for all platforms (Linux, macOS, Windows) and Python 3.9-3.13
- Update .github/workflows/release.yml to use the new wheels workflow
- Add cibuildwheel configuration to pyproject.toml

## Impact
- Users can now pip install scikit-bio without needing compilers
- Installation time reduced
- Significantly improves Windows user experience

Resolves #588 .



Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
