### PR TITLE
Fixed a bug in `AlignPath.from_cigar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Bug Fixes
 
-* Fixed a bug that `AlignPath.from_cigar` would ignore the first insertion (`I`) of a CIGAR string ([#2236](https://github.com/scikit-bio/scikit-bio/pull/2236)).
+* Fixed a bug that `PairAlignPath.from_cigar` would ignore the first insertion (`I`) of a CIGAR string ([#2236](https://github.com/scikit-bio/scikit-bio/pull/2236)).
 * Fixed an inaccurate statement that one can specify `gap` as np.inf or np.nan in `AlignPath.to_indices`. These cases are impossible because the output is integer type.
 * Fixed an inaccurate statement in the documentation of `SubstitutionMatrix.is_ascii`. This attribute is True when all characters in the alphabet are ASCII codes (0 to 127), not extended ASCII codes (0 to 255) ([#2226](https://github.com/scikit-bio/scikit-bio/pull/2226)).
 * Fixed a bug that a `SubstitutionMatrix` cannot be copied ([#2226](https://github.com/scikit-bio/scikit-bio/pull/2226)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 
+* Fixed a bug that `AlignPath.from_cigar` would ignore the first insertion (`I`) of a CIGAR string ([#2236](https://github.com/scikit-bio/scikit-bio/pull/2236)).
 * Fixed an inaccurate statement that one can specify `gap` as np.inf or np.nan in `AlignPath.to_indices`. These cases are impossible because the output is integer type.
 * Fixed an inaccurate statement in the documentation of `SubstitutionMatrix.is_ascii`. This attribute is True when all characters in the alphabet are ASCII codes (0 to 127), not extended ASCII codes (0 to 255) ([#2226](https://github.com/scikit-bio/scikit-bio/pull/2226)).
 * Fixed a bug that a `SubstitutionMatrix` cannot be copied ([#2226](https://github.com/scikit-bio/scikit-bio/pull/2226)).

--- a/skbio/alignment/tests/test_path.py
+++ b/skbio/alignment/tests/test_path.py
@@ -689,6 +689,14 @@ class TestPairAlignPath(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg % 1)
 
     def test_from_cigar(self):
+        # very simple case
+        cigar = "1I3M2D"
+        path = PairAlignPath.from_cigar(cigar)
+        lengths = [1, 3, 2]
+        states = [1, 0, 2]
+        npt.assert_array_equal(lengths, path.lengths)
+        npt.assert_array_equal(states, np.squeeze(path.states))
+
         # test valid cigar with no = or X
         cigar = "3M42I270M32D"
         path = PairAlignPath.from_cigar(cigar)

--- a/skbio/alignment/tests/test_path.py
+++ b/skbio/alignment/tests/test_path.py
@@ -714,12 +714,25 @@ class TestPairAlignPath(unittest.TestCase):
         npt.assert_array_equal(states, np.squeeze(path.states))
 
         # test empty cigar string
-        with self.assertRaises(ValueError, msg="CIGAR string must not be empty."):
+        msg = "CIGAR string must not be empty."
+        with self.assertRaises(ValueError) as cm:
             PairAlignPath.from_cigar("")
+        self.assertEqual(str(cm.exception), msg)
 
         # test invalid cigar string
-        with self.assertRaises(ValueError, msg="Invalid characters in CIGAR string."):
+        msg = "CIGAR string contains invalid character(s)."
+        with self.assertRaises(ValueError) as cm:
             PairAlignPath.from_cigar("23M45B13X")
+        self.assertEqual(str(cm.exception), msg)
+
+        # test invalid cigar string
+        msg = "CIGAR string contains invalid character(s)."
+        with self.assertRaises(ValueError) as cm:
+            PairAlignPath.from_cigar("23M45B13X")
+        self.assertEqual(str(cm.exception), msg)
+        with self.assertRaises(ValueError) as cm:
+            PairAlignPath.from_cigar("αβγ")
+        self.assertEqual(str(cm.exception), msg)
 
         # test valid cigar with no 1's
         cigar = "MID12MI"


### PR DESCRIPTION
Bug was that when a CIGAR string starts with an insertion (`I`), it will be ignored. For example, `1I3M` will become `3M`.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
