### PR TITLE
Removed miniforge version and patched checkout in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # to prevent a "Git clone too shallow" warning by Sphinx
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
 env:
   latest_python: "3.13"
   supported_pythons: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
-  miniforge_version: "23.11.0-0"
-  miniforge_variant: "Mambaforge"
 
 jobs:
   conf:
@@ -43,8 +41,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
           environment-file: ci/conda_host_env.yml
       - name: Install dependencies
         run: |
@@ -67,8 +63,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
           environment-file: ci/conda_host_env.yml
       - name: Install dependencies
         run: |
@@ -112,8 +106,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
           environment-file: ci/conda_host_env.yml
       - name: Install dependencies
         run: |
@@ -162,8 +154,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python_version }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
           environment-file: ci/conda_host_env.yml
       - name: Install dependencies (conda)
         if: ${{ matrix.use_conda }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 env:
   earliest_python: "3.9"
   latest_python: "3.13"
-  miniforge_version: "23.11.0-0"
-  miniforge_variant: "Mambaforge"
 
 jobs:
   # Trigger wheel building workflow
@@ -34,8 +32,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
           environment-file: ci/conda_host_env.yml
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   latest_python: "3.13"
-  miniforge_version: "23.11.0-0"
-  miniforge_variant: "Mambaforge"
 
 jobs:
 
@@ -30,8 +28,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
-          miniforge-version: ${{ env.miniforge_version }}
-          miniforge-variant: ${{ env.miniforge_variant }}
 
       - name: Install dependencies
         run: pip install -r ci/requirements.doc.txt


### PR DESCRIPTION
In the previous status, when the GitHub Actions workflows were executed, a warning was raised:

> 'Mambaforge' variants are now equivalent to 'Miniforge3'. In the future, we will ignore with a warning and use 'Miniforge3'. Eventually, using 'Mambaforge' will throw an error. Please change to 'Miniforge3' at your earliest convenience.

Therefore, this PR aims to resolve this warning.

According to [setup-miniconda/action.yml](https://github.com/conda-incubator/setup-miniconda/blob/main/action.yml), if both `miniconda-version` and `miniforge-variant` are not specified, they will default to the latest Miniforge3. This is what we desire.

***

The 2nd commit also addresses a (maybe temporary) Sphinx problem: It reads the git timestamp for some reason (although I don't know what reason), whereas GitHub Actions' "checkout" by default checks out only the last commit and ignore previous git history. So when `make doc` is executed, it warns: "Git clone too shallow [git.too_shallow]", and this warning is treated as an error. One solution is to add `fetch-depth: 0` to `actions/checkout`, as is done here. Another solution is to ignore this or all warnings in Sphinx.


***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
