### PR TITLE
Fix broken ASV badge and introduce new benchmark repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ scikit-bio began from code derived from `PyCogent <https://github.com/pycogent/p
    :target: https://codecov.io/gh/scikit-bio/scikit-bio
 .. |bench| image:: https://img.shields.io/badge/benchmarked%20by-asv-green.svg
    :alt: ASV Benchmarks
-   :target: https://s3-us-west-2.amazonaws.com/scikit-bio.org/benchmarks/main/index.html
+   :target: https://scikit.bio/scikit-bio-benchmarks
 .. |release| image:: https://img.shields.io/github/v/release/scikit-bio/scikit-bio.svg
    :alt: Release
    :target: https://github.com/scikit-bio/scikit-bio/releases

--- a/web/contribute.rst
+++ b/web/contribute.rst
@@ -459,3 +459,9 @@ Please read :doc:`devdoc/review` for more details on how pull requests should be
 After your code has been improved and the reviewer has approved it, they will `merge your pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request>`__ into the ``main`` branch of the official scikit-bio repository. This will be indicated by a note: :octicon:`git-merge` "Pull request successfully merged and closed".
 
 Congratulations! Your code is now an integral part of scikit-bio, and will benefit the broader community. You have successfully completed your contribution, and we extend our appreciation to you! 🎉🎉🎉"
+
+
+Benchmarks
+----------
+
+Scikit-bio utilizes `ASV <https://github.com/airspeed-velocity/asv>`__ to run benchmarks on a selection of its functions. Benchmarks help the development team prevent performance regression, the unintentional loss of performance which may come from modified code. Scikit-bio's benchmarks are run against every release of scikit-bio, starting with version ``0.6.1``. We welcome the addition of new benchmarks or the expansion of existing benchmarks to further protect against performance regression. If you are interested in contributing to our benchmarking system please see our `benchmark repository <https://github.com/scikit-bio/scikit-bio-benchmarks>`__.


### PR DESCRIPTION
Per issue #2206 , the current benchmarking system for scikit-bio is broken. This PR fixes the badge which is displayed on the main github page as well as within the main `README` file for the repo. Additionally, it adds documentation for the new [scikit-bio-benchmarks](https://github.com/scikit-bio/scikit-bio-benchmarks) repository which is where code for the benchmarks themselves, as well as the results of the benchmarks, are stored and hosted via Github Pages.

Currently, there is only a single benchmark for the `faith_pd` function. This was used as a simple benchmark to get the system up and running. Ideas for which functions within scikit-bio to add to the benchmark suite are welcome!

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
