### PR TITLE
Run unit-tests on wheels before release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,10 +36,10 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
-        # CIBW_TEST_COMMAND: >
-        #     ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && 
-        #         'python -m skbio.test' || 
-        #         'python -c "import skbio; print(skbio.__version__)"' }}
+        CIBW_TEST_COMMAND: >
+            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && 
+                'python -m skbio.test' || 
+                'python -c "import skbio; print(skbio.__version__)"' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,6 +36,10 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
+        # CIBW_TEST_COMMAND: >
+        #     ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && 
+        #         'python -m skbio.test' || 
+        #         'python -c "import skbio; print(skbio.__version__)"' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 
 # Test dependencies
-test-requires = ["pytest", "coverage", "matplotlib", "responses"]
+test-requires = ["pytest", "coverage", "responses"]
 
 # Test command - just import the package
 test-command = "python -m skbio.test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,6 @@ build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 # Test dependencies
 test-requires = ["pytest", "coverage", "responses"]
 
-# Test command - just import the package
-test-command = "python -m skbio.test"
-
 # Install dependencies before building
 before-build = "pip install numpy cython"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 
 # Test command - just import the package
-test-command = "python -c \"import skbio; print(skbio.__version__)\""
+test-command = "python -m skbio.test"
 
 # Install dependencies before building
 before-build = "pip install numpy cython"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux*"]
 # Python versions to build
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 
+# Test dependencies
+test-requires = ["pytest", "coverage", "matplotlib", "responses"]
+
 # Test command - just import the package
 test-command = "python -m skbio.test"
 


### PR DESCRIPTION
Previously the test command for ensuring built wheels worked correctly was simply:
```
"python -c \"import skbio; print(skbio.__version__)\""
```
Due to the long runtime of scikit-bio's tests, this command was used to check minimal functionality of wheels. This PR changes the workflow so that during PR's the simple import test is run, but on releases the full test suite of scikit-bio (minus tests requiring matplotlib) is run for each wheel created. This ensures build quality of all wheels uploaded to PyPI, while still allowing quick CI runs for PRs.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
