### PR TITLE
Skip unit tests for typing module

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,4 +10,5 @@ coverage:
 ignore:
  - "*/tests/*"
  - "test_*.py"
+ - "util/_typing.py"
  

--- a/.coveragerc
+++ b/.coveragerc
@@ -18,3 +18,4 @@ exclude_lines =
 omit =
     */tests/*
     */__init__.py
+    util/typing.py

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -248,30 +248,6 @@ def _assert_frame_dists_equal(
             pdt.assert_index_equal(left_df.columns, right_df.columns)
 
 
-# def _assert_frame_equal(
-#     left_df,
-#     right_df,
-#     ignore_index=False,
-#     ignore_columns=False,
-#     ignore_directionality=False,
-#     decimal=7,
-# ):
-#     # assert_frame_equal doesn't like None...
-#     if left_df is None or right_df is None:
-#         assert left_df is None and right_df is None
-#     else:
-#         left_values = left_df.values
-#         right_values = right_df.values
-#         if ignore_directionality:
-#             left_values, right_values = _normalize_signs(left_values, right_values)
-#         npt.assert_almost_equal(left_values, right_values, decimal=decimal)
-
-#         if not ignore_index:
-#             pdt.assert_index_equal(left_df.index, right_df.index)
-#         if not ignore_columns:
-#             pdt.assert_index_equal(left_df.columns, right_df.columns)
-
-
 def _normalize_signs(arr1, arr2):
     """Change column signs so that "column" and "-column" compare equal.
 

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -248,28 +248,28 @@ def _assert_frame_dists_equal(
             pdt.assert_index_equal(left_df.columns, right_df.columns)
 
 
-def _assert_frame_equal(
-    left_df,
-    right_df,
-    ignore_index=False,
-    ignore_columns=False,
-    ignore_directionality=False,
-    decimal=7,
-):
-    # assert_frame_equal doesn't like None...
-    if left_df is None or right_df is None:
-        assert left_df is None and right_df is None
-    else:
-        left_values = left_df.values
-        right_values = right_df.values
-        if ignore_directionality:
-            left_values, right_values = _normalize_signs(left_values, right_values)
-        npt.assert_almost_equal(left_values, right_values, decimal=decimal)
+# def _assert_frame_equal(
+#     left_df,
+#     right_df,
+#     ignore_index=False,
+#     ignore_columns=False,
+#     ignore_directionality=False,
+#     decimal=7,
+# ):
+#     # assert_frame_equal doesn't like None...
+#     if left_df is None or right_df is None:
+#         assert left_df is None and right_df is None
+#     else:
+#         left_values = left_df.values
+#         right_values = right_df.values
+#         if ignore_directionality:
+#             left_values, right_values = _normalize_signs(left_values, right_values)
+#         npt.assert_almost_equal(left_values, right_values, decimal=decimal)
 
-        if not ignore_index:
-            pdt.assert_index_equal(left_df.index, right_df.index)
-        if not ignore_columns:
-            pdt.assert_index_equal(left_df.columns, right_df.columns)
+#         if not ignore_index:
+#             pdt.assert_index_equal(left_df.index, right_df.index)
+#         if not ignore_columns:
+#             pdt.assert_index_equal(left_df.columns, right_df.columns)
 
 
 def _normalize_signs(arr1, arr2):


### PR DESCRIPTION
This PR puts the `util/_typing` module into the ignore category for unit test coverage. It also deletes an unused testing function.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
