### PR TITLE
Change `number_of_dimensions` to `dimensions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Remove autoplotting functionality to enable inplace operations on large in-memory objects, and improve documentation of existing plotting methods ([2216](https://github.com/scikit-bio/scikit-bio/pull/2216), [2223](https://github.com/scikit-bio/scikit-bio/pull/2223))
 * Initiated efforts to add type annotations to scikit-bio's codebase, starting with the `stats.distance` module ([2219](https://github.com/scikit-bio/scikit-bio/pull/2219))
 * Restored functionality to scikit-bio's benchmarking system and introduced a new repository for storing, running, and hosting benchmarks to prevent performance regression ([#2245](https://github.com/scikit-bio/scikit-bio/pull/2245))
+* Renamed the parameter `number_of_dimensions` to `dimensions` for the `pcoa` and `permdisp` functions. `number_of_dimensions` will remain a valid alias of the parameter, such that either option may be used. ([#2257](https://github.com/scikit-bio/scikit-bio/pull/2245))
 
 ### Backward-incompatible changes
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -23,8 +23,10 @@ from ._base import (
 )
 
 from skbio.stats.ordination import pcoa, OrdinationResults
+from skbio.util._decorator import params_aliased
 
 
+@params_aliased([("dimensions", "number_of_dimensions", "0.7.0", False)])
 def permdisp(
     distance_matrix,
     grouping,
@@ -32,7 +34,7 @@ def permdisp(
     test="median",
     permutations=999,
     method="eigh",
-    number_of_dimensions=10,
+    dimensions=10,
     seed=None,
     warn_neg_eigval=0.01,
 ):
@@ -78,7 +80,7 @@ def permdisp(
         default) and "fsvd" (fast singular value decomposition). See
         :func:`skbio.stats.ordination.pcoa <pcoa>` for details. Not used if
         distance_matrix is a OrdinationResults object.
-    number_of_dimensions : int, optional
+    dimensions : int, optional
         Dimensions to reduce the distance matrix to if using the `fsvd` method.
         Not used if the `eigh` method is being selected.
     seed : int, Generator or RandomState, optional
@@ -259,9 +261,9 @@ def permdisp(
         distance_matrix = None  # not used anymore, avoid using by mistake
     elif isinstance(distance_matrix, DistanceMatrix):
         if method == "eigh":
-            # eigh does not natively support specifying number_of_dimensions
+            # eigh does not natively support specifying dimensions
             # and pcoa expects it to be 0
-            number_of_dimensions = 0
+            dimensions = 0
         elif method != "fsvd":
             raise ValueError("Method must be eigh or fsvd.")
 
@@ -271,7 +273,7 @@ def permdisp(
         ordination = pcoa(
             distance_matrix,
             method=method,
-            number_of_dimensions=number_of_dimensions,
+            dimensions=dimensions,
             warn_neg_eigval=warn_neg_eigval,
         )
     else:

--- a/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
@@ -114,7 +114,7 @@ class TestPCoA(TestCase):
 
         dm_big = DistanceMatrix.read(get_data_path('PCoA_sample_data_12dim'))
         with self.assertWarnsRegex(RuntimeWarning,
-                                   r"no value for number_of_dimensions"):
+                                   r"no value for dimensions"):
             pcoa(dm_big, method="fsvd", number_of_dimensions=0)
 
     def test_permutted(self):
@@ -292,7 +292,7 @@ class TestPCoA(TestCase):
             ("Invalid operation: cannot reduce distance matrix "
             "to negative dimensions using PCoA. Did you intend " 
             'to specify the default value "0", which sets ' 
-            "the number_of_dimensions equal to the " 
+            "the dimensions equal to the " 
             "dimensionality of the given distance matrix?")
             ):
             results = _fsvd(self.dm_invalid[1:4], number_of_dimensions=-1)


### PR DESCRIPTION
This PR changes the parameter name `number_of_dimensions` to `dimensions` in `pcoa` and `permdisp`. `number_of_dimensions` will remain a valid alias of the parameter, thanks to the `@params_aliased` decorator.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
