### PR TITLE
Rename `distance_matrix` parameter to `distmat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Initiated efforts to add type annotations to scikit-bio's codebase, starting with the `stats.distance` module ([2219](https://github.com/scikit-bio/scikit-bio/pull/2219))
 * Restored functionality to scikit-bio's benchmarking system and introduced a new repository for storing, running, and hosting benchmarks to prevent performance regression ([#2245](https://github.com/scikit-bio/scikit-bio/pull/2245))
 * Renamed the parameter `number_of_dimensions` to `dimensions` for the `pcoa` and `permdisp` functions. `number_of_dimensions` will remain a valid alias of the parameter, such that either option may be used. ([#2257](https://github.com/scikit-bio/scikit-bio/pull/2257)).
+* Renamed the parameter `distance_matrix` to `distmat` in `pcoa`, `bioenv`, `anosim`, `permanova`, and `permdisp`. `distance_matrix` will remain a valid alias of the parameter, such that either option may be used. ([#2261](https://github.com/scikit-bio/scikit-bio/pull/2261))
 
 ### Backward-incompatible changes
 

--- a/skbio/stats/distance/_anosim.py
+++ b/skbio/stats/distance/_anosim.py
@@ -20,10 +20,12 @@ import numpy as np
 from scipy.stats import rankdata
 
 from ._base import _preprocess_input, _run_monte_carlo_stats, _build_results
+from skbio.util._decorator import params_aliased
 
 
+@params_aliased([("distmat", "distance_matrix", "0.7.0", False)])
 def anosim(
-    distance_matrix: "DistanceMatrix",
+    distmat: "DistanceMatrix",
     grouping: Union["pd.DataFrame", "ArrayLike"],
     column: Optional[str] = None,
     permutations: int = 999,
@@ -46,18 +48,18 @@ def anosim(
 
     Parameters
     ----------
-    distance_matrix : DistanceMatrix
+    distmat : DistanceMatrix
         Distance matrix containing distances between objects (e.g., distances
         between samples of microbial communities).
     grouping : 1-D array_like or pandas.DataFrame
         Vector indicating the assignment of objects to groups. For example,
         these could be strings or integers denoting which group an object
         belongs to. If `grouping` is 1-D ``array_like``, it must be the same
-        length and in the same order as the objects in `distance_matrix`. If
+        length and in the same order as the objects in `distmat`. If
         `grouping` is a ``DataFrame``, the column specified by `column` will be
         used as the grouping vector. The ``DataFrame`` must be indexed by the
-        IDs in `distance_matrix` (i.e., the row labels must be distance matrix
-        IDs), but the order of IDs between `distance_matrix` and the
+        IDs in `distmat` (i.e., the row labels must be distance matrix
+        IDs), but the order of IDs between `distmat` and the
         ``DataFrame`` need not be the same. All IDs in the distance matrix must
         be present in the ``DataFrame``. Extra IDs in the ``DataFrame`` are
         allowed (they are ignored in the calculations).
@@ -182,7 +184,7 @@ def anosim(
 
     """
     sample_size, num_groups, grouping, tri_idxs, distances = _preprocess_input(
-        distance_matrix, grouping, column
+        distmat, grouping, column
     )
 
     divisor = sample_size * ((sample_size - 1) / 4)

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -154,10 +154,12 @@ def permanova(distmat, grouping, column=None, permutations=999, seed=None):
     )
 
 
-def _compute_f_stat(sample_size, num_groups, distmat, group_sizes, s_T, grouping):
+def _compute_f_stat(
+    sample_size, num_groups, distance_matrix, group_sizes, s_T, grouping
+):
     """Compute PERMANOVA pseudo-F statistic."""
     # Calculate s_W for each group, accounting for different group sizes.
-    s_W = permanova_f_stat_sW_cy(distmat.data, group_sizes, grouping)
+    s_W = permanova_f_stat_sW_cy(distance_matrix.data, group_sizes, grouping)
 
     s_A = s_T - s_W
     return (s_A / (num_groups - 1)) / (s_W / (sample_size - num_groups))

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -26,9 +26,14 @@ from skbio.stats.ordination import pcoa, OrdinationResults
 from skbio.util._decorator import params_aliased
 
 
-@params_aliased([("dimensions", "number_of_dimensions", "0.7.0", False)])
+@params_aliased(
+    [
+        ("dimensions", "number_of_dimensions", "0.7.0", False),
+        ("distmat", "distance_matrix", "0.7.0", False),
+    ]
+)
 def permdisp(
-    distance_matrix,
+    distmat,
     grouping,
     column=None,
     test="median",
@@ -47,7 +52,7 @@ def permdisp(
 
     Parameters
     ----------
-    distance_matrix : DistanceMatrix or OrdinationResults
+    distmat : DistanceMatrix or OrdinationResults
         Distance matrix containing distances between objects (e.g., distances
         between samples of microbial communities) or
         result of pcoa on such a matrix.
@@ -55,11 +60,11 @@ def permdisp(
         Vector indicating the assignment of objects to groups. For example,
         these could be strings or integers denoting which group an object
         belongs to. If `grouping` is 1-D ``array_like``, it must be the same
-        length and in the same order as the objects in `distance_matrix`. If
+        length and in the same order as the objects in `distmat`. If
         `grouping` is a ``DataFrame``, the column specified by `column` will be
         used as the grouping vector. The ``DataFrame`` must be indexed by the
-        IDs in `distance_matrix` (i.e., the row labels must be distance matrix
-        IDs), but the order of IDs between `distance_matrix` and the
+        IDs in `distmat` (i.e., the row labels must be distance matrix
+        IDs), but the order of IDs between `distmat` and the
         ``DataFrame`` need not be the same. All IDs in the distance matrix must
         be present in the ``DataFrame``. Extra IDs in the ``DataFrame`` are
         allowed (they are ignored in the calculations).
@@ -79,7 +84,7 @@ def permdisp(
         Matrix decomposition method to use. Options are "eigh" (eigendecomposition,
         default) and "fsvd" (fast singular value decomposition). See
         :func:`skbio.stats.ordination.pcoa <pcoa>` for details. Not used if
-        distance_matrix is a OrdinationResults object.
+        distmat is a OrdinationResults object.
     dimensions : int, optional
         Dimensions to reduce the distance matrix to if using the `fsvd` method.
         Not used if the `eigh` method is being selected.
@@ -119,11 +124,11 @@ def permdisp(
         If a list and a column name are both provided
     ValueError
         If a list is provided for `grouping` and it's length does not match
-        the number of ids in distance_matrix
+        the number of ids in distmat
     ValueError
         If all of the values in the grouping vector are unique
     KeyError
-        If there are ids in grouping that are not in distance_matrix
+        If there are ids in grouping that are not in distmat
 
     See Also
     --------
@@ -254,12 +259,12 @@ def permdisp(
     if test not in ("centroid", "median"):
         raise ValueError("Test must be centroid or median.")
 
-    if isinstance(distance_matrix, OrdinationResults):
-        ordination = distance_matrix
+    if isinstance(distmat, OrdinationResults):
+        ordination = distmat
         ids = ordination.samples.axes[0].to_list()
         sample_size = len(ids)
-        distance_matrix = None  # not used anymore, avoid using by mistake
-    elif isinstance(distance_matrix, DistanceMatrix):
+        distmat = None  # not used anymore, avoid using by mistake
+    elif isinstance(distmat, DistanceMatrix):
         if method == "eigh":
             # eigh does not natively support specifying dimensions
             # and pcoa expects it to be 0
@@ -267,11 +272,11 @@ def permdisp(
         elif method != "fsvd":
             raise ValueError("Method must be eigh or fsvd.")
 
-        ids = distance_matrix.ids
-        sample_size = distance_matrix.shape[0]
+        ids = distmat.ids
+        sample_size = distmat.shape[0]
 
         ordination = pcoa(
-            distance_matrix,
+            distmat,
             method=method,
             dimensions=dimensions,
             warn_neg_eigval=warn_neg_eigval,


### PR DESCRIPTION
This PR changes the parameter name `distance_matrix` to `distmat` in `pcoa`, `bioenv`, `anosim`, `permanova`, and `permdisp`. `distance_matrix` will remain a valid alias of the parameter, thanks to the @params_aliased decorator.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
