### PR TITLE
Cast AnnData X attribute to numpy array

### DIFF
--- a/skbio/table/_tabular.py
+++ b/skbio/table/_tabular.py
@@ -181,7 +181,7 @@ def _ingest_table(table, sample_ids=None, feature_ids=None, expand=True):
     elif hasattr(table, "X"):
         adt = get_package("anndata")
         if isinstance(table, adt.AnnData):
-            data = table.X
+            data = np.asarray(table.X)
             samples = table.obs.index
             features = table.var.index
 


### PR DESCRIPTION
The `AnnData.X` attribute of an anndata object may be things other than numpy arrays. This PR converts the attribute to a numpy array upon being "ingested" into the scikit-bio system.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
