### PR TITLE
WIP:  Implement `PairwiseMatrix`, `SymmetricMatrix`, and `DistanceMatrix` classes

### DIFF
--- a/skbio/io/format/binary_dm.py
+++ b/skbio/io/format/binary_dm.py
@@ -15,7 +15,7 @@ Format Support
 +------+------+---------------------------------------------------------------+
 |Reader|Writer|                          Object Class                         |
 +======+======+===============================================================+
-|Yes   |Yes   |:mod:`skbio.stats.distance.DissimilarityMatrix`                |
+|Yes   |Yes   |:mod:`skbio.stats.distance.PairwiseMatrix`                |
 +------+------+---------------------------------------------------------------+
 |Yes   |Yes   |:mod:`skbio.stats.distance.DistanceMatrix`                     |
 +------+------+---------------------------------------------------------------+
@@ -82,7 +82,7 @@ import h5py
 from numpy import array as np_array
 
 from skbio.io import create_format
-from skbio.stats.distance import DissimilarityMatrix, DistanceMatrix
+from skbio.stats.distance import PairwiseMatrix, DistanceMatrix
 
 
 binary_dm = create_format("binary_dm", encoding="binary")
@@ -116,30 +116,31 @@ def _binary_dm_sniffer(fh):
     return True, {}
 
 
-@binary_dm.reader(DissimilarityMatrix)
+@binary_dm.reader(PairwiseMatrix)
 def _binary_dm_to_dissimilarity(fh):
-    return _h5py_mat_to_skbio_mat_stream(DissimilarityMatrix,fh)
+    return _h5py_mat_to_skbio_mat_stream(PairwiseMatrix, fh)
 
 
 @binary_dm.reader(DistanceMatrix)
 def _binary_dm_to_distance(fh):
-    return _h5py_mat_to_skbio_mat_stream(DistanceMatrix,fh)
+    return _h5py_mat_to_skbio_mat_stream(DistanceMatrix, fh)
 
 
-@binary_dm.writer(DissimilarityMatrix)
+@binary_dm.writer(PairwiseMatrix)
 def _dissimilarity_to_binary_dm(obj, fh):
-    return _skbio_mat_to_h5py_mat_stream(obj,fh)
+    return _skbio_mat_to_h5py_mat_stream(obj, fh)
 
 
 @binary_dm.writer(DistanceMatrix)
 def _distance_to_binary_dm(obj, fh):
-    return _skbio_mat_to_h5py_mat_stream(obj,fh)
+    return _skbio_mat_to_h5py_mat_stream(obj, fh)
 
 
 def _h5py_mat_to_skbio_mat_stream(cls, fh):
     with h5py.File(fh, "r") as f:
-      dm = _h5py_mat_to_skbio_mat(cls,f)
+        dm = _h5py_mat_to_skbio_mat(cls, f)
     return dm
+
 
 def _h5py_mat_to_skbio_mat(cls, f):
     mat = f.get("matrix")
@@ -151,12 +152,13 @@ def _h5py_mat_to_skbio_mat(cls, f):
 
 def _skbio_mat_to_h5py_mat_stream(obj, fh):
     with h5py.File(fh, "w") as f:
-      _skbio_mat_to_h5py_mat(obj, f)
+        _skbio_mat_to_h5py_mat(obj, f)
+
 
 def _skbio_mat_to_h5py_mat(obj, f):
     _set_header(f)
 
-    b_ids = [ x.encode("utf-8") for x in obj.ids]
+    b_ids = [x.encode("utf-8") for x in obj.ids]
     np_ids = np_array(b_ids)
     f.create_dataset("order", data=np_ids)
     f.create_dataset("matrix", data=obj.data)

--- a/skbio/io/format/lsmat.py
+++ b/skbio/io/format/lsmat.py
@@ -17,7 +17,7 @@ Format Support
 +------+------+---------------------------------------------------------------+
 |Reader|Writer|                          Object Class                         |
 +======+======+===============================================================+
-|Yes   |Yes   |:mod:`skbio.stats.distance.DissimilarityMatrix`                |
+|Yes   |Yes   |:mod:`skbio.stats.distance.PairwiseMatrix`                |
 +------+------+---------------------------------------------------------------+
 |Yes   |Yes   |:mod:`skbio.stats.distance.DistanceMatrix`                     |
 +------+------+---------------------------------------------------------------+
@@ -79,7 +79,7 @@ import csv
 
 import numpy as np
 
-from skbio.stats.distance import DissimilarityMatrix, DistanceMatrix
+from skbio.stats.distance import PairwiseMatrix, DistanceMatrix
 from skbio.io import create_format, LSMatFormatError
 
 
@@ -106,9 +106,9 @@ def _lsmat_sniffer(fh):
     return False, {}
 
 
-@lsmat.reader(DissimilarityMatrix)
+@lsmat.reader(PairwiseMatrix)
 def _lsmat_to_dissimilarity_matrix(fh, delimiter="\t"):
-    return _lsmat_to_matrix(DissimilarityMatrix, fh, delimiter)
+    return _lsmat_to_matrix(PairwiseMatrix, fh, delimiter)
 
 
 @lsmat.reader(DistanceMatrix)
@@ -116,7 +116,7 @@ def _lsmat_to_distance_matrix(fh, delimiter="\t"):
     return _lsmat_to_matrix(DistanceMatrix, fh, delimiter)
 
 
-@lsmat.writer(DissimilarityMatrix)
+@lsmat.writer(PairwiseMatrix)
 def _dissimilarity_matrix_to_lsmat(obj, fh, delimiter="\t"):
     _matrix_to_lsmat(obj, fh, delimiter)
 
@@ -156,7 +156,7 @@ def _lsmat_to_matrix(cls, fh, delimiter):
             # We've hit a nonempty line after we already filled the data
             # matrix. Raise an error because we shouldn't ignore extra data.
             raise LSMatFormatError(
-                "Encountered extra row(s) without corresponding IDs in " "the header."
+                "Encountered extra row(s) without corresponding IDs in the header."
             )
 
         num_vals = len(row_data)

--- a/skbio/io/format/tests/test_lsmat.py
+++ b/skbio/io/format/tests/test_lsmat.py
@@ -14,7 +14,7 @@ from skbio.io import LSMatFormatError
 from skbio.io.format.lsmat import (
     _lsmat_to_dissimilarity_matrix, _lsmat_to_distance_matrix,
     _dissimilarity_matrix_to_lsmat, _distance_matrix_to_lsmat, _lsmat_sniffer)
-from skbio.stats.distance import DissimilarityMatrix, DistanceMatrixError
+from skbio.stats.distance import PairwiseMatrix, DistanceMatrixError
 
 
 class LSMatTestData(TestCase):
@@ -69,11 +69,11 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
         # should be read into an equivalent object and written to an equivalent
         # format though, which is why we duplicate the 3x3 objects and strings.
         self.dissim_objs = [
-            DissimilarityMatrix(self.lsmat_1x1_data, ['a']),
-            DissimilarityMatrix(self.lsmat_2x2_data, ['a', 'b']),
-            DissimilarityMatrix(self.lsmat_2x2_asym_data, ['a', 'b']),
-            DissimilarityMatrix(self.lsmat_3x3_data, ['a', 'b', 'c']),
-            DissimilarityMatrix(self.lsmat_3x3_data, ['a', 'b', 'c'])
+            PairwiseMatrix(self.lsmat_1x1_data, ['a']),
+            PairwiseMatrix(self.lsmat_2x2_data, ['a', 'b']),
+            PairwiseMatrix(self.lsmat_2x2_asym_data, ['a', 'b']),
+            PairwiseMatrix(self.lsmat_3x3_data, ['a', 'b', 'c']),
+            PairwiseMatrix(self.lsmat_3x3_data, ['a', 'b', 'c'])
         ]
 
         self.dissim_strs = [LSMat_1x1, LSMat_2x2, LSMat_2x2_ASYM, LSMat_3x3,
@@ -97,7 +97,7 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
 
     def test_read_valid_files(self):
         for fn, cls, objs, fhs in ((_lsmat_to_dissimilarity_matrix,
-                                    DissimilarityMatrix, self.dissim_objs,
+                                    PairwiseMatrix, self.dissim_objs,
                                     self.dissim_fhs),
                                    (_lsmat_to_distance_matrix, DistanceMatrix,
                                     self.dist_objs, self.dist_fhs)):
@@ -108,7 +108,7 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
                 self.assertIsInstance(obs, cls)
 
         # Above files are TSV (default delimiter). Test that CSV works too.
-        for fn, cls in ((_lsmat_to_dissimilarity_matrix, DissimilarityMatrix),
+        for fn, cls in ((_lsmat_to_dissimilarity_matrix, PairwiseMatrix),
                         (_lsmat_to_distance_matrix, DistanceMatrix)):
             exp = cls(self.lsmat_3x3_data, ['a', 'b', 'c'])
             self.lsmat_3x3_csv_fh.seek(0)
@@ -117,7 +117,7 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
             self.assertIsInstance(obs, cls)
 
         # Test that fixed-width works too.
-        for fn, cls in ((_lsmat_to_dissimilarity_matrix, DissimilarityMatrix),
+        for fn, cls in ((_lsmat_to_dissimilarity_matrix, PairwiseMatrix),
                         (_lsmat_to_distance_matrix, DistanceMatrix)):
             exp = cls(self.lsmat_3x3_data, ['a', 'b', 'c'])
             self.lsmat_3x3_fw_fh.seek(0)
@@ -150,7 +150,7 @@ class DissimilarityAndDistanceMatrixReaderWriterTests(LSMatTestData):
                 self.assertEqual(obs, str_)
 
         # Test writing CSV (TSV is written above).
-        for fn, cls in ((_dissimilarity_matrix_to_lsmat, DissimilarityMatrix),
+        for fn, cls in ((_dissimilarity_matrix_to_lsmat, PairwiseMatrix),
                         (_distance_matrix_to_lsmat, DistanceMatrix)):
             obj = cls(self.lsmat_3x3_data, ['a', 'b', 'c'])
             fh = io.StringIO()

--- a/skbio/sequence/_substitution.py
+++ b/skbio/sequence/_substitution.py
@@ -12,11 +12,11 @@ from typing import Optional, Union, Iterable
 import numpy as np
 
 from skbio.util._decorator import classonlymethod
-from skbio.stats.distance import DissimilarityMatrix
+from skbio.stats.distance import PairwiseMatrix
 from skbio.sequence._alphabet import _alphabet_to_hashes
 
 
-class SubstitutionMatrix(DissimilarityMatrix):
+class SubstitutionMatrix(PairwiseMatrix):
     r"""Scoring matrix between characters in biological sequences.
 
     Parameters
@@ -27,11 +27,11 @@ class SubstitutionMatrix(DissimilarityMatrix):
         Scores of substitutions from one character (row, or axis=0) to another
         character (column, or axis=1).
     kwargs : dict
-        Additional arguments for the ``DissimilarityMatrix`` constructor.
+        Additional arguments for the ``PairwiseMatrix`` constructor.
 
     See Also
     --------
-    skbio.stats.distance.DissimilarityMatrix
+    skbio.stats.distance.PairwiseMatrix
 
     Notes
     -----
@@ -58,7 +58,7 @@ class SubstitutionMatrix(DissimilarityMatrix):
     pre-defined and can be referred to by name. Examples include NUC.4.4 for
     nucleotides, and variants of BLOSUM and PAM matrices for amino acids.
 
-    ``SubstitutionMatrix`` is a subclass of ``DissimilarityMatrix``. Therefore,
+    ``SubstitutionMatrix`` is a subclass of ``PairwiseMatrix``. Therefore,
     all attributes and methods of the latter also apply to the former.
 
     The default floating-point data type of ``SubstitutionMatrix`` is float32. If you
@@ -218,7 +218,7 @@ class SubstitutionMatrix(DissimilarityMatrix):
 
     def __init__(self, alphabet, scores, **kwargs):
         """Initialize a substitution matrix object."""
-        # cast to float32 (see DissimilarityMatrix.__init__)
+        # cast to float32 (see PairwiseMatrix.__init__)
         _issue_copy = True
         if isinstance(scores, np.ndarray):
             if scores.dtype in (np.float32, np.float64):

--- a/skbio/stats/composition.py
+++ b/skbio/stats/composition.py
@@ -1317,7 +1317,7 @@ def pairwise_vlr(mat, ids=None, ddof=1, robust=False, validate=True):
     -------
     skbio.DistanceMatrix if validate=True
         Distance matrix of variance log ratio values.
-    skbio.DissimilarityMatrix if validate=False
+    skbio.PairwiseMatrix if validate=False
         Dissimilarity matrix of variance log ratio values.
 
     Notes

--- a/skbio/stats/distance/__init__.py
+++ b/skbio/stats/distance/__init__.py
@@ -15,26 +15,26 @@ more distance matrices using the Mantel test).
 Data structures
 ---------------
 
-This package provides two matrix classes, `DissimilarityMatrix` and
-`DistanceMatrix`. Both classes can store measures of difference/distinction
-between objects. A dissimilarity/distance matrix includes both a matrix of
-dissimilarities/distances (floats) between objects, as well as unique IDs
+This package provides three matrix classes, `PairwiseMatrix`, `SymmetricMatrix`, and
+`DistanceMatrix`. All three classes can store measures of difference/distinction
+between objects. A pairwise/symmetric/distance matrix includes both a matrix of
+pairwise relationships/distances (floats) between objects, as well as unique IDs
 (object labels; strings) identifying each object in the matrix.
 
-`DissimilarityMatrix` can be used to store measures of dissimilarity between
-objects, and does not require that the dissimilarities are symmetric (e.g.,
+`PairwiseMatrix` can be used to store measures of relationships between
+objects, and does not require that the relationships are symmetric (e.g.,
 dissimilarities obtained using the *Gain in PD* measure [1]_).
-`DissimilarityMatrix` is a more general container to store differences than
+`PairwiseMatrix` is a more general container to store differences than
 `DistanceMatrix`.
 
 `DistanceMatrix` has the additional requirement that the differences it
 stores are symmetric (e.g., Euclidean or Hamming distances).
 
-.. note:: `DissimilarityMatrix` can be used to store distances, but it is
+.. note:: `PairwiseMatrix` can be used to store distances, but it is
    recommended to use `DistanceMatrix` to store this type of data as it
-   provides an additional check for symmetry. A distance matrix *is a*
-   dissimilarity matrix; this is modeled in the class design by having
-   `DistanceMatrix` subclass `DissimilarityMatrix`.
+   provides additional checks for symmetry and hollowness. A distance matrix *is a*
+   pairwise matrix; this is modeled in the class design by having
+   `DistanceMatrix` subclass `PairwiseMatrix`.
 
 Classes
 ^^^^^^^
@@ -42,7 +42,8 @@ Classes
 .. autosummary::
    :toctree:
 
-   DissimilarityMatrix
+   PairwiseMatrix
+   SymmetricMatrix
    DistanceMatrix
 
 Functions
@@ -58,7 +59,7 @@ Exceptions
 
 .. autosummary::
 
-   DissimilarityMatrixError
+   PairwiseMatrixError
    DistanceMatrixError
    MissingIDError
 
@@ -192,9 +193,11 @@ References
 # ----------------------------------------------------------------------------
 
 from ._base import (
+    PairwiseMatrixError,
     DissimilarityMatrixError,
     DistanceMatrixError,
     MissingIDError,
+    PairwiseMatrix,
     DissimilarityMatrix,
     DistanceMatrix,
     randdm,
@@ -206,11 +209,11 @@ from ._mantel import mantel, pwmantel
 from ._permdisp import permdisp
 
 __all__ = [
-    "DissimilarityMatrixError",
-    "DistanceMatrixError",
+    "PairwiseMatrixError",
+    "DissimilarityMatrixErrorDistanceMatrixError",
     "MissingIDError",
-    "DissimilarityMatrix",
-    "DistanceMatrix",
+    "PairwiseMatrix",
+    "DissimilarityMatrixDistanceMatrix",
     "randdm",
     "anosim",
     "permanova",

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -27,8 +27,8 @@ else:
 import skbio.sequence.distance
 from skbio import DistanceMatrix, Sequence
 from skbio.stats.distance import (
-    DissimilarityMatrixError, DistanceMatrixError, MissingIDError,
-    DissimilarityMatrix, randdm)
+    PairwiseMatrixError, DistanceMatrixError, MissingIDError,
+    PairwiseMatrix, randdm)
 from skbio.stats.distance._base import (_preprocess_input,
                                         _run_monte_carlo_stats)
 from skbio.stats.distance._utils import is_symmetric_and_hollow
@@ -36,7 +36,7 @@ from skbio.util import assert_data_frame_almost_equal
 from skbio.util._testing import assert_series_almost_equal
 
 
-class DissimilarityMatrixTestData:
+class PairwiseMatrixTestData:
     def setUp(self):
         self.dm_1x1_data = [[0.0]]
         self.dm_2x2_data = [[0.0, 0.123], [0.123, 0.0]]
@@ -50,13 +50,13 @@ class DissimilarityMatrixTestData:
                             [8, 9, 1, 2, 0]]
 
 
-class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
+class PairwiseMatrixTestBase(PairwiseMatrixTestData):
     @classmethod
     def get_matrix_class(cls):
         return None
 
     def setUp(self):
-        super(DissimilarityMatrixTestBase, self).setUp()
+        super(PairwiseMatrixTestBase, self).setUp()
         self.matobj = self.get_matrix_class()
         self.dm_1x1 = self.matobj(self.dm_1x1_data, ['a'])
         self.dm_2x2 = self.matobj(self.dm_2x2_data, ['a', 'b'])
@@ -88,7 +88,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
                  (np.array([[0, 1], [1, 0]], dtype='double'), False))
 
         for data, expect in tests:
-            obj = DissimilarityMatrix(data)
+            obj = PairwiseMatrix(data)
             self.assertEqual(id(obj.data) != id(data), expect)
 
     def test_within(self):
@@ -217,7 +217,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
     def test_init_from_dm(self):
         ids = ['foo', 'bar', 'baz']
 
-        # DissimilarityMatrix -> DissimilarityMatrix
+        # PairwiseMatrix -> PairwiseMatrix
         exp = self.matobj(self.dm_3x3_data, ids)
         obs = self.matobj(self.dm_3x3, ids)
         self.assertEqual(obs, exp)
@@ -226,13 +226,13 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
         obs.data[0, 1] = 424242
         self.assertTrue(np.array_equal(obs.data, self.dm_3x3.data))
 
-        # DistanceMatrix -> DissimilarityMatrix
+        # DistanceMatrix -> PairwiseMatrix
         exp = self.matobj(self.dm_3x3_data, ids)
         obs = self.matobj(
             self.matobj(self.dm_3x3_data, ('a', 'b', 'c')), ids)
         self.assertEqual(obs, exp)
 
-        # DissimilarityMatrix -> DistanceMatrix
+        # PairwiseMatrix -> DistanceMatrix
         with self.assertRaises(DistanceMatrixError):
             DistanceMatrix(self.dm_2x2_asym, ['foo', 'bar'])
 
@@ -251,31 +251,31 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
 
     def test_init_invalid_input(self):
         # Empty data.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj([], [])
 
         # Another type of empty data.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj(np.empty((0, 0)), [])
 
         # Invalid number of dimensions.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj([1, 2, 3], ['a'])
 
         # Dimensions don't match.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj([[1, 2, 3]], ['a'])
 
         data = [[0, 1], [1, 0]]
 
         # Duplicate IDs.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj(data, ['a', 'a'])
 
         # Number of IDs don't match dimensions.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj(data, ['a', 'b', 'c'])
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj(data, [])
 
     def test_from_iterable_non_hollow_data(self):
@@ -322,7 +322,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
         self.assertEqual(res, exp)
 
     def test_from_iterable_empty(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj.from_iterable([], lambda x: x)
 
     def test_from_iterable_single(self):
@@ -419,7 +419,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
             self.dm_3x3['b']
 
     def test_ids_invalid_input(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3.ids = ['foo', 'bar']
         # Make sure that we can still use the dissimilarity matrix after trying
         # to be evil.
@@ -534,7 +534,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
         self.assertEqual(obs, exp)
 
     def test_filter_duplicate_ids(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3.filter(['c', 'a', 'c'])
 
     def test_filter_missing_ids(self):
@@ -549,7 +549,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
         self.assertEqual(obs, exp)
 
     def test_filter_empty_ids(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3.filter([])
 
     @unittest.skipUnless(has_matplotlib, "Matplotlib not available.")
@@ -711,7 +711,7 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
             self.dm_3x3[:, 3]
 
     def test_validate_invalid_dtype(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate(np.array([[0, 42], [42, 0]]), ['a', 'b'])
 
     def test_validate_invalid_shape(self):
@@ -720,30 +720,30 @@ class DissimilarityMatrixTestBase(DissimilarityMatrixTestData):
         # it checks just the shape, not the content
         self.dm_3x3._validate_shape(np.array([[1., 2.], [3., 4.]]))
         # empty array
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_shape(np.array([]))
         # invalid shape
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_shape(np.array([[0., 42.],
                                                   [42., 0.],
                                                   [22., 22.]]))
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_shape(np.array([[[0., 42.], [42., 0.]],
                                                   [[0., 24.], [24., 0.]]]))
 
     def test_validate_invalid_ids(self):
         # repeated ids
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_ids(self.dm_3x3.data, ['a', 'a'])
         # empty ids
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_ids(self.dm_3x3.data, [])
         # invalid shape
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.dm_3x3._validate_ids(self.dm_3x3.data, ['a', 'b', 'c', 'd'])
 
 
-class DistanceMatrixTestBase(DissimilarityMatrixTestData):
+class DistanceMatrixTestBase(PairwiseMatrixTestData):
     @classmethod
     def get_matrix_class(cls):
         return None
@@ -779,7 +779,7 @@ class DistanceMatrixTestBase(DissimilarityMatrixTestData):
             self.matobj(data, ['a', 'b'])
 
         # Ensure that the superclass validation is still being performed.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj([[1, 2, 3]], ['a'])
 
     def test_init_nans(self):
@@ -848,7 +848,7 @@ class DistanceMatrixTestBase(DissimilarityMatrixTestData):
         self.assertEqual(res, exp)
 
     def test_from_iterable_empty(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             self.matobj.from_iterable([], lambda x: x)
 
     def test_from_iterable_single(self):
@@ -966,9 +966,9 @@ class DistanceMatrixTestBase(DissimilarityMatrixTestData):
         self.assertEqual(obs, exp)
 
     def test_eq(self):
-        # Compare DistanceMatrix to DissimilarityMatrix, where both have the
+        # Compare DistanceMatrix to PairwiseMatrix, where both have the
         # same data and IDs.
-        eq_dm = DissimilarityMatrix(self.dm_3x3_data, ['a', 'b', 'c'])
+        eq_dm = PairwiseMatrix(self.dm_3x3_data, ['a', 'b', 'c'])
         self.assertTrue(self.dm_3x3 == eq_dm)
         self.assertTrue(eq_dm == self.dm_3x3)
 
@@ -1115,10 +1115,10 @@ class RandomDistanceMatrixTests(TestCase):
         self.assertEqual(obs.ids, tuple(ids))
 
     def test_constructor(self):
-        exp = DissimilarityMatrix(np.asarray([[0.0]]), ['1'])
-        obs = randdm(1, constructor=DissimilarityMatrix)
+        exp = PairwiseMatrix(np.asarray([[0.0]]), ['1'])
+        obs = randdm(1, constructor=PairwiseMatrix)
         self.assertEqual(obs, exp)
-        self.assertEqual(type(obs), DissimilarityMatrix)
+        self.assertEqual(type(obs), PairwiseMatrix)
 
     def test_random_fn(self):
         def myrand(size):
@@ -1143,7 +1143,7 @@ class RandomDistanceMatrixTests(TestCase):
 
     def test_invalid_input(self):
         # Invalid dimensions.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             randdm(0)
 
         # Invalid dimensions.
@@ -1151,7 +1151,7 @@ class RandomDistanceMatrixTests(TestCase):
             randdm(-1)
 
         # Invalid number of IDs.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             randdm(2, ids=['foo'])
 
 
@@ -1184,7 +1184,7 @@ class CategoricalStatsHelperFunctionTests(TestCase):
         # Requires a DistanceMatrix.
         with self.assertRaises(TypeError):
             _preprocess_input(
-                DissimilarityMatrix([[0, 2], [3, 0]], ['a', 'b']),
+                PairwiseMatrix([[0, 2], [3, 0]], ['a', 'b']),
                 [1, 2], None)
 
         # Requires column if DataFrame.
@@ -1228,13 +1228,13 @@ class CategoricalStatsHelperFunctionTests(TestCase):
             _run_monte_carlo_stats(lambda e: 42, self.grouping, -1)
 
 
-class DissimilarityMatrixTests(DissimilarityMatrixTestBase, TestCase):
+class PairwiseMatrixTests(PairwiseMatrixTestBase, TestCase):
     @classmethod
     def get_matrix_class(cls):
-        return DissimilarityMatrix
+        return PairwiseMatrix
 
     def setUp(self):
-        super(DissimilarityMatrixTests, self).setUp()
+        super(PairwiseMatrixTests, self).setUp()
 
 
 class DistanceMatrixTests(DistanceMatrixTestBase, TestCase):

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -17,7 +17,7 @@ from scipy.spatial.distance import squareform
 from scipy.stats import pearsonr, spearmanr, ConstantInputWarning, NearConstantInputWarning
 
 from skbio import DistanceMatrix
-from skbio.stats.distance import (DissimilarityMatrixError,
+from skbio.stats.distance import (PairwiseMatrixError,
                                   DistanceMatrixError, mantel, pwmantel)
 from skbio.stats.distance._mantel import _order_dms
 from skbio.stats.distance._mantel import _mantel_stats_pearson
@@ -458,7 +458,7 @@ class MantelTests(MantelTestData):
 
     def test_invalid_distance_matrix(self):
         # Single asymmetric, non-hollow distance matrix.
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             mantel([[1, 2], [3, 4]], [[0, 0], [0, 0]])
 
         # Two asymmetric distance matrices.

--- a/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
@@ -14,7 +14,7 @@ from warnings import catch_warnings
 from unittest import TestCase, main
 
 from skbio import DistanceMatrix, OrdinationResults
-from skbio.stats.distance import DissimilarityMatrixError
+from skbio.stats.distance import PairwiseMatrixError
 from skbio.stats.ordination import pcoa, pcoa_biplot
 from skbio.stats.ordination._principal_coordinate_analysis import _fsvd
 from skbio.util import (get_data_path, assert_ordination_results_equal,
@@ -192,7 +192,7 @@ class TestPCoA(TestCase):
                                         ignore_directionality=True)
 
     def test_invalid_input(self):
-        with self.assertRaises(DissimilarityMatrixError):
+        with self.assertRaises(PairwiseMatrixError):
             pcoa([[1, 2], [3, 4]])
 
     def test_warn_neg_eigval(self):


### PR DESCRIPTION
This PR is a work in progress, not ready for review.

The goal of this PR is to implement a new class hierarchy in `skbio.stats.distance._base`. This is the first step in the plan to refactor the `DistanceMatrix` class in scikit-bio. The work will be broken up across several PR's to make reviews and progress more manageable.

The previous `DissimilarityMatrix` will be renamed `PairwiseMatrix`. The old name will be kept as an alias for backwards compatibility.

A new class `SymmetricMatrix` will be introduced to fill the gap between the old `DissimilarityMatrix` and `DistanceMatrix` classes.

`DistanceMatrix` will remain largely unchanged for now.


Please complete the following checklist:

* [ ] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [ ] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
