### PR TITLE
docs: mention required constructor in TabularMSA.read

### DIFF
--- a/skbio/io/descriptors.py
+++ b/skbio/io/descriptors.py
@@ -26,6 +26,13 @@ class Read:
 
     def _make_docstring(self, cls):
         name, supported_fmts, default, see = _docstring_vars(cls, "read")
+        constructor_param = ""
+        if name == "TabularMSA":
+            constructor_param = """constructor : subclass of ``GrammaredSequence``
+    Sequence constructor (e.g., ``DNA``, ``RNA``, ``Protein``). This parameter
+    is required when reading ``TabularMSA`` from FASTA, FASTQ, Clustal,
+    PHYLIP, and Stockholm formats.
+"""
         return f"""Create a new ``{name}`` instance from a file.
 
 This is a convenience method for :func:`skbio.io.registry.read`. For more information
@@ -42,6 +49,7 @@ file : openable (filepath, URL, filehandle, etc.)
 format : str, optional
     The format of the file. The format must be a format name with a reader for
     ``{name}``. If None, the format will be inferred.
+{constructor_param}\
 kwargs : dict, optional
     Additional arguments passed to :func:`skbio.io.registry.read()` and the reader for
     ``{name}``.

--- a/skbio/io/tests/test_descriptors.py
+++ b/skbio/io/tests/test_descriptors.py
@@ -89,6 +89,26 @@ class TestRead(unittest.TestCase):
         method = self.TestClass.read
         self.assertIsNotNone(method.__doc__)
         self.assertIn('TestClass', method.__doc__)
+
+    def test_tabular_msa_read_docstring_mentions_constructor(self):
+        """Test that TabularMSA read docstring mentions constructor."""
+        test_format = create_format('tabular_msa_docstring_test_format')
+
+        class TabularMSA:
+            read = Read()
+
+        @test_format.reader(TabularMSA)
+        def _reader(fh, cls=None):
+            if cls is None:
+                cls = TabularMSA
+            return cls()
+
+        try:
+            doc = TabularMSA.read.__doc__
+            self.assertIn('constructor', doc)
+            self.assertIn('GrammaredSequence', doc)
+        finally:
+            io_registry.remove_format('tabular_msa_docstring_test_format')
     
     def test_read_passes_kwargs(self):
         """Test that kwargs are passed through to the reader."""


### PR DESCRIPTION
## Summary
- update the autogenerated `TabularMSA.read` docstring to explicitly document the `constructor` argument
- clarify that `constructor` is required for common alignment formats (FASTA, FASTQ, Clustal, PHYLIP, Stockholm)
- add a regression test to ensure the `TabularMSA`-specific read docstring includes this guidance

Fixes #2388.

## Validation
- `python3 -m compileall skbio/io/descriptors.py skbio/io/tests/test_descriptors.py`
