### PR TITLE
ENH: Support translation of degenerate sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.7.3-dev
 
+### Features
+
+* Added support for translating DNA and RNA sequences containing ambiguous characters. Codons with degeneracies are now resolved to the most specific possible residues, allowing for direct translation without manual sequence expansion. ([#2411](https://github.com/scikit-bio/scikit-bio/pull/2411))
+
 
 ## Version 0.7.2
 

--- a/skbio/sequence/_genetic_code.py
+++ b/skbio/sequence/_genetic_code.py
@@ -191,7 +191,8 @@ class GeneticCode(SkbioObject):
         * -2 (reverse)
         * -3 (reverse)
 
-        This property can be passed into ``GeneticCode.translate(reading_frame)``.
+        This property can be passed into
+        ``GeneticCode.translate(reading_frame)``.
 
         Returns
         -------
@@ -226,13 +227,15 @@ class GeneticCode(SkbioObject):
 
         if len(amino_acids) != self._num_codons:
             raise ValueError(
-                "`amino_acids` must be length %d, not %d"
-                % (self._num_codons, len(amino_acids))
+                "`amino_acids` must be length {}, not {}".format(
+                    self._num_codons, len(amino_acids)
+                )
             )
         indices = (amino_acids.values == b"M").nonzero()[0]
         if indices.size < 1:
             raise ValueError(
-                "`amino_acids` must contain at least one M (methionine) character"
+                "`amino_acids` must contain at least one M "
+                "(methionine) character"
             )
         self._amino_acids = amino_acids
         self._m_character_codon = self._index_to_codon(indices[0])
@@ -242,9 +245,12 @@ class GeneticCode(SkbioObject):
 
         if len(starts) != self._num_codons:
             raise ValueError(
-                "`starts` must be length %d, not %d" % (self._num_codons, len(starts))
+                "`starts` must be length {}, not {}".format(
+                    self._num_codons, len(starts)
+                )
             )
-        if (starts.values == b"M").sum() + (starts.values == b"-").sum() != len(starts):
+        if (starts.values == b"M").sum() + (starts.values == b"-").sum() \
+                != len(starts):
             # to prevent the user from accidentally swapping `starts` and
             # `amino_acids` and getting a translation back
             raise ValueError("`starts` may only contain M and - characters")
@@ -262,12 +268,14 @@ class GeneticCode(SkbioObject):
         if not hasattr(self, "_degenerate_amino_acids_table"):
             # 15x15x15 table for degenerate codons (UCAGRYMKWSBDHVN)
             table = np.empty((15, 15, 15), dtype="|S1")
-            
+
             # Map of degenerate char to definite chars
             deg_map = {
                 'U': 'U', 'C': 'C', 'A': 'A', 'G': 'G',
-                'R': 'AG', 'Y': 'CU', 'M': 'AC', 'K': 'UG', 'W': 'AU', 'S': 'GC',
-                'B': 'CGU', 'D': 'AGU', 'H': 'ACU', 'V': 'ACG', 'N': 'ACGU'
+                'R': 'AG', 'Y': 'CU', 'M': 'AC', 'K': 'UG',
+                'W': 'AU', 'S': 'GC',
+                'B': 'CGU', 'D': 'AGU', 'H': 'ACU', 'V': 'ACG',
+                'N': 'ACGU'
             }
             chars = "UCAGRYMKWSBDHVN"
             definite_chars = "UCAG"
@@ -291,8 +299,9 @@ class GeneticCode(SkbioObject):
                                 for r3 in deg_map[c3]:
                                     off3 = definite_offsets[r3]
                                     idx = off1 * 16 + off2 * 4 + off3
-                                    possible_aas.add(self._amino_acids.values[idx])
-                        
+                                    aa = self._amino_acids.values[idx]
+                                    possible_aas.add(aa)
+
                         if len(possible_aas) == 1:
                             table[i, j, k] = list(possible_aas)[0]
                         else:
@@ -301,14 +310,16 @@ class GeneticCode(SkbioObject):
                             if b'*' in possible_aas:
                                 table[i, j, k] = b'X'
                                 continue
-                            
-                            # All possible definite versions of this degenerate codon
-                            # must be covered by a single degenerate AA character
-                            aas_str = {aa.decode('ascii') for aa in possible_aas}
+
+                            # All possible definite versions of this codon
+                            # must be covered by a single degenerate AA
+                            aas_str = {aa.decode('ascii') for aa in
+                                       possible_aas}
                             found_deg = False
                             for deg_aa, definite_set in aa_deg_map.items():
                                 if aas_str.issubset(definite_set):
-                                    table[i, j, k] = deg_aa.encode('ascii')
+                                    aa_enc = deg_aa.encode('ascii')
+                                    table[i, j, k] = aa_enc
                                     found_deg = True
                                     break
                             if not found_deg:
@@ -452,7 +463,8 @@ class GeneticCode(SkbioObject):
         """
         return not (self == other)
 
-    def translate(self, sequence, reading_frame=1, start="ignore", stop="ignore"):
+    def translate(self, sequence, reading_frame=1, start="ignore",
+                  stop="ignore"):
         r"""Translate RNA sequence into protein sequence.
 
         Parameters
@@ -634,7 +646,9 @@ class GeneticCode(SkbioObject):
                 self._raise_require_error("start", reading_frame)
 
         # Use the degenerate translation table
-        translated = self._degenerate_amino_acids[data[:, 0], data[:, 1], data[:, 2]]
+        translated = self._degenerate_amino_acids[
+            data[:, 0], data[:, 1], data[:, 2]
+        ]
 
         if stop in {"require", "optional"}:
             stop_codon_indices = (translated == b"*").nonzero()[0]
@@ -653,7 +667,9 @@ class GeneticCode(SkbioObject):
     def _validate_translate_inputs(self, sequence, reading_frame, start, stop):
         if not isinstance(sequence, RNA):
             raise TypeError(
-                "Sequence to translate must be RNA, not %s" % type(sequence).__name__
+                "Sequence to translate must be RNA, not {}".format(
+                    type(sequence).__name__
+                )
             )
 
         if reading_frame not in self.reading_frames:
@@ -842,7 +858,8 @@ _ncbi_genetic_codes = {
     4: GeneticCode(
         "FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG",
         "--MM---------------M------------MMMM---------------M------------",
-        "Mold, Protozoan, and Coelenterate Mitochondrial, and Mycoplasma/Spiroplasma",
+        "Mold, Protozoan, and Coelenterate Mitochondrial, "
+        "and Mycoplasma/Spiroplasma",
     ),
     5: GeneticCode(
         "FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSSSSVVVVAAAADDEEGGGG",

--- a/skbio/sequence/_genetic_code.py
+++ b/skbio/sequence/_genetic_code.py
@@ -129,19 +129,13 @@ class GeneticCode(SkbioObject):
     @classproperty
     def _offset_table(cls):
         if cls.__offset_table is None:
-            # create lookup table that is filled with 255 everywhere except for
-            # indices corresponding to U, C, A, and G. 255 was chosen to
-            # represent invalid character offsets because it will create an
-            # invalid (out of bounds) index into `amino_acids` which should
-            # error noisily. this is important in case the valid definite
-            # IUPAC RNA characters change in the future and the assumptions
-            # currently made by the code become invalid
-            table = np.empty(ord(b"U") + 1, dtype=np.uint8)
-            table.fill(255)
-            table[ord(b"U")] = 0
-            table[ord(b"C")] = 1
-            table[ord(b"A")] = 2
-            table[ord(b"G")] = 3
+            # table mapping IUPAC characters (including degenerates) to
+            # offsets 0-14 for the expanded translation table.
+            # 255 is used for invalid/gap characters.
+            table = np.full(128, 255, dtype=np.uint8)
+            iupac_order = "UCAGRYMKWSBDHVN"
+            for i, char in enumerate(iupac_order):
+                table[ord(char)] = i
             cls.__offset_table = table
         return cls.__offset_table
 
@@ -262,6 +256,65 @@ class GeneticCode(SkbioObject):
         for i, index in enumerate(indices):
             codons[i] = self._index_to_codon(index)
         self._start_codons = codons
+
+    @property
+    def _degenerate_amino_acids(self):
+        if not hasattr(self, "_degenerate_amino_acids_table"):
+            # 15x15x15 table for degenerate codons (UCAGRYMKWSBDHVN)
+            table = np.empty((15, 15, 15), dtype="|S1")
+            
+            # Map of degenerate char to definite chars
+            deg_map = {
+                'U': 'U', 'C': 'C', 'A': 'A', 'G': 'G',
+                'R': 'AG', 'Y': 'CU', 'M': 'AC', 'K': 'UG', 'W': 'AU', 'S': 'GC',
+                'B': 'CGU', 'D': 'AGU', 'H': 'ACU', 'V': 'ACG', 'N': 'ACGU'
+            }
+            chars = "UCAGRYMKWSBDHVN"
+            definite_chars = "UCAG"
+            definite_offsets = {c: i for i, c in enumerate(definite_chars)}
+
+            # Amino acid degeneracy map
+            aa_deg_map = {
+                'B': set("DN"),
+                'Z': set("EQ"),
+                'J': set("IL"),
+            }
+
+            for i, c1 in enumerate(chars):
+                for j, c2 in enumerate(chars):
+                    for k, c3 in enumerate(chars):
+                        possible_aas = set()
+                        for r1 in deg_map[c1]:
+                            off1 = definite_offsets[r1]
+                            for r2 in deg_map[c2]:
+                                off2 = definite_offsets[r2]
+                                for r3 in deg_map[c3]:
+                                    off3 = definite_offsets[r3]
+                                    idx = off1 * 16 + off2 * 4 + off3
+                                    possible_aas.add(self._amino_acids.values[idx])
+                        
+                        if len(possible_aas) == 1:
+                            table[i, j, k] = list(possible_aas)[0]
+                        else:
+                            # Try to find a specific degenerate amino acid
+                            # Remove stop if present, but mark as X
+                            if b'*' in possible_aas:
+                                table[i, j, k] = b'X'
+                                continue
+                            
+                            # All possible definite versions of this degenerate codon
+                            # must be covered by a single degenerate AA character
+                            aas_str = {aa.decode('ascii') for aa in possible_aas}
+                            found_deg = False
+                            for deg_aa, definite_set in aa_deg_map.items():
+                                if aas_str.issubset(definite_set):
+                                    table[i, j, k] = deg_aa.encode('ascii')
+                                    found_deg = True
+                                    break
+                            if not found_deg:
+                                table[i, j, k] = b'X'
+            self._degenerate_amino_acids_table = table
+        return self._degenerate_amino_acids_table
 
     def _index_to_codon(self, index):
         """Convert AA index (0-63) to codon encoded in offsets (0-3)."""
@@ -558,6 +611,11 @@ class GeneticCode(SkbioObject):
 
         if start in {"require", "optional"}:
             start_codon_index = data.shape[0]
+            # Degenerate start codons: we only consider a degenerate codon
+            # a start codon if ALL its definite versions are start codons.
+            # This is because 'require' start = fMet, which is specific.
+            # For simplicity, we only match definite start codons here for now,
+            # as that was the previous behavior.
             for start_codon in self._start_codons:
                 indices = np.all(data == start_codon, axis=1).nonzero()[0]
 
@@ -568,12 +626,15 @@ class GeneticCode(SkbioObject):
 
             if start_codon_index != data.shape[0]:
                 data = data[start_codon_index:]
+                # M character codon offset for U, C, A, G is 0, 1, 2, 3
+                # but in our expanded table it's also 0, 1, 2, 3.
+                # self._m_character_codon is [offset1, offset2, offset3]
                 data[0] = self._m_character_codon
             elif start == "require":
                 self._raise_require_error("start", reading_frame)
 
-        indices = (data * self._radix_multiplier).sum(axis=1)
-        translated = self._amino_acids.values[indices]
+        # Use the degenerate translation table
+        translated = self._degenerate_amino_acids[data[:, 0], data[:, 1], data[:, 2]]
 
         if stop in {"require", "optional"}:
             stop_codon_indices = (translated == b"*").nonzero()[0]
@@ -614,13 +675,7 @@ class GeneticCode(SkbioObject):
             )
 
         if sequence.has_degenerates():
-            raise NotImplementedError(
-                "scikit-bio does not currently support "
-                "translation of degenerate sequences."
-                "`RNA.expand_degenerates` can be used "
-                "to obtain all definite versions "
-                "of a degenerate sequence."
-            )
+            pass
 
     def _raise_require_error(self, name, reading_frame):
         raise ValueError(

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -179,12 +179,18 @@ class Protein(GrammaredSequence):
     @classproperty
     @overrides(GrammaredSequence)
     def alphabet(cls):
-        return super(Protein, cls).alphabet | cls.stop_chars
+        return (
+            cls.definite_chars
+            | cls.degenerate_chars
+            | cls.stop_chars
+            | cls.noncanonical_chars
+            | cls.gap_chars
+        )
 
     @classproperty
     @overrides(GrammaredSequence)
     def definite_chars(cls):
-        return set("ACDEFGHIKLMNOPQRSTUVWY")
+        return set("ACDEFGHIKLMNOPQRSTUVWY") | cls.stop_chars
 
     @classproperty
     @overrides(GrammaredSequence)

--- a/skbio/sequence/_protein.py
+++ b/skbio/sequence/_protein.py
@@ -115,7 +115,8 @@ class Protein(GrammaredSequence):
     |``X``|Xaa      |All 20      |
     +-----+---------+------------+
 
-    Plus one stop character: ``*`` (Ter), and two gap characters: ``-`` and ``.``.
+    Plus one stop character: ``*`` (Ter), and two gap characters: ``-`` and
+    ```.```.
 
     Characters other than the above 27 are not allowed. If you intend to use
     additional characters to represent non-canonical amino acids, such as ``U``
@@ -130,8 +131,9 @@ class Protein(GrammaredSequence):
 
     References
     ----------
-    .. [1] Cornish-Bowden, A. (1985). Nomenclature for incompletely specified bases in
-       nucleic acid sequences: recommendations 1984. Nucleic Acids Res, 13(9), 3021.
+    .. [1] Cornish-Bowden, A. (1985). Nomenclature for incompletely specified
+       bases in nucleic acid sequences: recommendations 1984. Nucleic Acids
+       Res, 13(9), 3021.
 
     Examples
     --------
@@ -190,7 +192,7 @@ class Protein(GrammaredSequence):
     @classproperty
     @overrides(GrammaredSequence)
     def definite_chars(cls):
-        return set("ACDEFGHIKLMNOPQRSTUVWY") | cls.stop_chars
+        return set("ACDEFGHIKLMNOPQRSTUVWY")
 
     @classproperty
     @overrides(GrammaredSequence)

--- a/skbio/sequence/tests/test_genetic_code.py
+++ b/skbio/sequence/tests/test_genetic_code.py
@@ -434,9 +434,20 @@ class TestGeneticCode(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r'gapped'):
             self.sgc.translate(RNA('UU-G'))
 
-        # degenerate sequence
-        with self.assertRaisesRegex(NotImplementedError, r'degenerate'):
-            self.sgc.translate(RNA('RUG'))
+    def test_translate_degenerate_sequences(self):
+        # test translation of degenerate sequences
+        # RUG: R=AG (purine), U=U, G=G -> AUG (M) or GUG (V)
+        # Different codons translate to different amino acids, so result
+        # is ambiguous (X)
+        result = self.sgc.translate(RNA('RUG'))
+        self.assertEqual(result, Protein('X'))
+
+        # Single unambiguous degenerate codon
+        # All possible definite codons decode to same amino acid
+        # YCN where Y=CU and N=ACGU should all code for the same amino
+        # acid. GCN are all Alanine.
+        result = self.sgc.translate(RNA('GCN'))  # All GCN codons are Ala
+        self.assertEqual(result, Protein('A'))
 
     def test_translate_varied_genetic_codes(self):
         # spot check using a few NCBI and custom genetic codes to translate


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

---
Closes #1911

## Description
This PR adds support for translating sequences that contain degenerate characters. Ambiguous codons are now resolved to the most specific residue possible, allowing for direct translation without needing to expand the sequence first.
