### PR TITLE
perf(stats/distance): parallelize geomedian_axis_one inner loops with prange

### DIFF
--- a/skbio/stats/distance/_cutils.pyx
+++ b/skbio/stats/distance/_cutils.pyx
@@ -501,13 +501,14 @@ def geomedian_axis_one(floating[:, :] X, floating eps=1e-7,
     cdef floating dist, Dinvs, total, r, rinv, tmp, Di
     cdef size_t nzeros = n
     cdef size_t iteration
+    cdef Py_ssize_t i, j
 
     with nogil:
         iteration = 0
         while iteration < maxiters:
 
-            for i in range(n):
-                Di = _dist_euclidean(X[:, i], y)
+            for i in prange(n, schedule='static'):
+                Di = _dist_euclidean_col(X, i, y, p) 
                 D[i] = Di
                 if fabs(Di) > eps:
                     Dinv[i] = 1. / Di
@@ -516,14 +517,14 @@ def geomedian_axis_one(floating[:, :] X, floating eps=1e-7,
 
             Dinvs = _sum(Dinv)
 
-            for i in range(n):
+            for i in prange(n, schedule='static'):
                 W[i] = Dinv[i] / Dinvs
 
-            for j in range(p):
+            for j in prange(p, schedule='static'):
                 total = 0.
                 for i in range(n):
                     if fabs(D[i]) > eps:
-                        total += W[i] * X[j, i]
+                        total = total + W[i] * X[j, i]
                 T[j] = total
 
             nzeros = n
@@ -536,14 +537,14 @@ def geomedian_axis_one(floating[:, :] X, floating eps=1e-7,
             elif nzeros == n:
                 break
             else:
-                for j in range(p):
+                for j in prange(p, schedule='static'):
                     R[j] = (T[j] - y[j]) * Dinvs
                 r = _norm_euclidean(R)
                 if r > eps:
                     rinv = nzeros/r
                 else:
                     rinv = 0.
-                for j in range(p):
+                for j in prange(p, schedule='static'):
                     y1[j] = max(0, 1-rinv)*T[j] + min(1, rinv)*y[j]
 
             dist = _dist_euclidean(y, y1)
@@ -554,6 +555,15 @@ def geomedian_axis_one(floating[:, :] X, floating eps=1e-7,
             iteration = iteration + 1
             
     return y
+
+cdef floating _dist_euclidean_col(floating[:, :] X, Py_ssize_t col, floating[:] y, Py_ssize_t p) nogil:
+    cdef float64_t d = 0.
+    cdef float64_t tmp
+    cdef Py_ssize_t j
+    for j in range(p):
+        tmp = X[j, col] - y[j]
+        d += tmp * tmp
+    return <floating>sqrt(d)
 
 cdef floating _dist_euclidean(floating[:] x, floating[:] y) nogil:
     cdef size_t n = x.shape[0]


### PR DESCRIPTION
The inner loops of `geomedian_axis_one` were sequential because `_dist_euclidean(X[:, i], y)` creates a temporary Python memoryview slice on every call, which requires the GIL and blocks `prange`.

Added a `_dist_euclidean_col` cdef helper that accesses the column by index directly, making it fully nogil-safe. This unlocks `prange` across the three independent inner loops: distance computation, weight normalization, and the weighted sum update. Loop variables use `Py_ssize_t` for Windows OpenMP compatibility.


---------
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
