### PR TITLE
BUG: Fix multi_replace output type for Pandas 3.0 apply compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.7.3-dev
 
+### Bug Fixes
+
+* Fixed an issue where `composition.multi_replace` failed to expand into a DataFrame when used 
+
 
 ## Version 0.7.2
 

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -168,6 +168,20 @@ def multi_replace(mat, delta=None):
            [ 0.0625,  0.4375,  0.4375,  0.0625]])
 
     """
+    # Preserve pandas objects for Pandas >= 3.0 apply() compatibility
+    is_series = (
+        hasattr(mat, "name")
+        and hasattr(mat, "index")
+        and not hasattr(mat, "columns")
+    )
+    is_df = hasattr(mat, "columns") and hasattr(mat, "index")
+
+    if is_series:
+        orig_index, orig_name = mat.index, mat.name
+    elif is_df:
+        orig_index, orig_cols = mat.index, mat.columns
+
+    mat = closure(mat)
     mat = closure(mat)
     z_mat = mat == 0
 
@@ -184,7 +198,19 @@ def multi_replace(mat, delta=None):
             "using a smaller `delta`."
         )
     mat = np.where(z_mat, delta, zcnts * mat)
-    return mat.squeeze()
+    res = mat.squeeze()
+
+    # Restore pandas object to prevent downstream formatting issues
+    if is_series:
+        import pandas as pd
+        return pd.Series(res, index=orig_index, name=orig_name)
+    elif is_df:
+        import pandas as pd
+        # Ensure 2D shape is maintained if squeeze flattened a 1xN DataFrame
+        res = np.atleast_2d(res) if res.ndim == 1 else res
+        return pd.DataFrame(res, index=orig_index, columns=orig_cols)
+
+    return res
 
 
 def _closure_two(x, y, validate):


### PR DESCRIPTION
### Description
This addresses the `multi_replace` bug mentioned by @mataton in #2375.

#### The Issue
In Pandas 3.0, `df.apply(multi_replace, axis=1)` fails to expand the result into a DataFrame. Because the function was returning a raw `np.ndarray` via `mat.squeeze()`, Pandas 3.0 collapses the result into a single `object` dtype column instead of a 2D structure. This specifically affects workflows in the `05-marker-inference` tutorial.

#### The Fix
Added type-awareness to `multi_replace`. It now captures whether the input is a `pd.Series` or `pd.DataFrame`, preserves the metadata (index/columns), and restores the output to the corresponding Pandas object. This ensures `apply(axis=1)` correctly unpacks the results back into a DataFrame.

#### Technical Note
I verified the fix locally using Pandas 3.0.0. While `pytest` shows `DocTestFailures`, these are pre-existing issues related to NumPy 2.0 whitespace formatting and are unrelated to the changes in this PR.

---

### Checklist

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [x] This pull request does not include code, documentation, or other content derived from external source(s).
* [x] All tests pass locally (excluding pre-existing NumPy 2.0 doctest formatting issues).