### PR TITLE
ENH: Add Array API support to centralize and vlr

### DIFF
--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -979,13 +979,20 @@ def _alr_inv(xp: ModuleType, mat: StdArray, ref_idx: int, axis: int) -> StdArray
     return _closure(xp, comp, axis)
 
 
-def centralize(mat: ArrayLike) -> StdArray:
+def centralize(mat: ArrayLike, validate: bool = True) -> StdArray:
     r"""Center data around its geometric average.
+
+    .. versionchanged:: 0.7.3
+        The function now supports the Array API standard and no longer depends on SciPy.
 
     Parameters
     ----------
     mat : array_like of shape (n_compositions, n_components)
         A matrix of proportions.
+    validate : bool, default True
+        Check if the compositions are legitimate.
+
+        .. versionadded:: 0.7.3
 
     Returns
     -------
@@ -998,26 +1005,31 @@ def centralize(mat: ArrayLike) -> StdArray:
     >>> from skbio.stats.composition import centralize
     >>> X = np.array([[.1, .3, .4, .2], [.2, .2, .2, .4]])
     >>> centralize(X)
-    array([[ 0.17445763,  0.30216948,  0.34891526,  0.17445763],
-           [ 0.32495488,  0.18761279,  0.16247744,  0.32495488]])
+    array([[0.17445763, 0.30216948, 0.34891526, 0.17445763],
+           [0.32495488, 0.18761279, 0.16247744, 0.32495488]])
 
     """
-    from scipy.stats import gmean
+    xp, mat = ingest_array(mat)
+    if validate:
+        _check_composition(xp, mat)
+    mat = _closure(xp, mat)
+    # geometric mean across compositions (axis=0), implemented as
+    # exp(mean(log(x))) to stay within the Array API standard
+    cen = xp.exp(xp.mean(xp.log(mat), axis=0, keepdims=True))
+    return _closure(xp, mat / cen)
 
-    mat = closure(mat)
-    cen = gmean(mat, axis=0)
-    return perturb_inv(mat, cen)
 
-
-def _vlr(x, y, ddof):
+def _vlr(xp, x, y, ddof):
     r"""Calculate variance log ratio.
 
     Parameters
     ----------
-    x : array_like of shape (n_components,)
-        A vector of proportions.
-    y : array_like of shape (n_components,)
-        A vector of proportions.
+    xp : namespace
+        The array API compatible namespace.
+    x : array of shape (n_components,)
+        A vector of proportions (closed).
+    y : array of shape (n_components,)
+        A vector of proportions (closed).
     ddof : int
         Degrees of freedom.
 
@@ -1027,12 +1039,9 @@ def _vlr(x, y, ddof):
         Variance log ratio value.
 
     """
-    # Log transformation
-    x = np.log(x)
-    y = np.log(y)
-
-    # Variance log ratio
-    return np.var(x - y, ddof=ddof)
+    diff = xp.log(x) - xp.log(y)
+    n = diff.shape[0]
+    return float(xp.sum((diff - xp.mean(diff)) ** 2) / (n - ddof))
 
 
 def _robust_vlr(x, y, ddof):
@@ -1065,8 +1074,16 @@ def _robust_vlr(x, y, ddof):
     return np.ma.var(x - y, ddof=ddof)
 
 
-def vlr(x, y, ddof=1, robust=False):
+def vlr(
+    x: ArrayLike,
+    y: ArrayLike,
+    ddof: int = 1,
+    robust: bool = False,
+) -> float:
     r"""Calculate variance log ratio.
+
+    .. versionchanged:: 0.7.3
+        The non-robust path now supports the Array API standard.
 
     Parameters
     ----------
@@ -1077,7 +1094,8 @@ def vlr(x, y, ddof=1, robust=False):
     ddof : int
         Degrees of freedom.
     robust : bool
-        Whether to mask zeros at the cost of performance.
+        Whether to mask zeros at the cost of performance. This path requires NumPy and
+        does not support the Array API standard.
 
     Returns
     -------
@@ -1109,22 +1127,14 @@ def vlr(x, y, ddof=1, robust=False):
     0.0
 
     """
-    # Convert array_like to numpy array
-    x = closure(x)
-    y = closure(y)
-
-    # Set up input and parameters
-    kwargs = {
-        "x": x,
-        "y": y,
-        "ddof": ddof,
-    }
-
-    # Run backend function
     if robust:
-        return _robust_vlr(**kwargs)
-    else:
-        return _vlr(**kwargs)
+        # robust path uses NumPy masked arrays; keep on numpy
+        cx = closure(x)
+        cy = closure(y)
+        return _robust_vlr(cx, cy, ddof)
+
+    xp, cx, cy = _closure_two(x, y, validate=True)
+    return _vlr(xp, cx, cy, ddof)
 
 
 def _pairwise_vlr(mat, ddof):

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -1132,9 +1132,9 @@ def vlr(
         cx = closure(x)
         cy = closure(y)
         return _robust_vlr(cx, cy, ddof)
-
-    xp, cx, cy = _closure_two(x, y, validate=True)
-    return _vlr(xp, cx, cy, ddof)
+    else:
+        xp, cx, cy = _closure_two(x, y, validate=True)
+        return _vlr(xp, cx, cy, ddof)
 
 
 def _pairwise_vlr(mat, ddof):

--- a/skbio/stats/composition/tests/test_ndarray.py
+++ b/skbio/stats/composition/tests/test_ndarray.py
@@ -19,7 +19,7 @@ from skbio.util._gpu import cuda_avail
 
 from skbio.stats.composition import (
     closure, clr, clr_inv, ilr,
-    ilr_inv, alr, alr_inv)
+    ilr_inv, alr, alr_inv, centralize, vlr)
 from skbio.stats.composition._base import _gram_schmidt_basis
 
 
@@ -1874,6 +1874,68 @@ class Tests_ILR_INV_helmert_basis(TestCase):
                 f"In {class_name}.{test_name}: tolerance increased from 1e-8 to 1e-4.",
                 UserWarning
             )
+
+
+class Tests_Centralize(TestCase):
+    def setUp(self):
+        self.mat = np.array([[.1, .3, .4, .2], [.2, .2, .2, .4]])
+
+    def _expected(self, mat):
+        """Compute centralize reference using pure numpy."""
+        closed = mat / mat.sum(axis=-1, keepdims=True)
+        cen = np.exp(np.mean(np.log(closed), axis=0, keepdims=True))
+        result = closed / cen
+        return result / result.sum(axis=-1, keepdims=True)
+
+    def test_ndarray_numpy(self):
+        exp = self._expected(self.mat)
+        rst = centralize(self.mat)
+        npt.assert_allclose(rst, exp)
+
+    @skipIf(no_torch, "Skipping tests: no torch dependency")
+    def test_ndarray_torch(self):
+        mat = torch.tensor(self.mat)
+        exp = self._expected(self.mat)
+        rst = centralize(mat)
+
+        assert type(rst) == type(mat), "type is changed"
+        assert rst.device == mat.device, "different device"
+        npt.assert_allclose(rst.numpy(), exp, atol=1e-7)
+
+    @skipIf(no_jax, "Skipping tests: no jax dependency")
+    def test_ndarray_jnp(self):
+        mat = jnp.array(self.mat)
+        exp = self._expected(self.mat)
+        rst = centralize(mat)
+
+        assert type(rst) == type(mat), "type is changed"
+        assert rst.device == mat.device, "different device"
+        npt.assert_allclose(np.asarray(rst), exp, atol=1e-7)
+
+
+class Tests_VLR(TestCase):
+    def setUp(self):
+        self.x = np.array([1.0, 2.0, 3.0])
+        self.y = np.array([2.0, 3.0, 4.0])
+        self.expected = vlr(self.x, self.y, ddof=1)
+
+    def test_ndarray_numpy(self):
+        rst = vlr(self.x, self.y, ddof=1)
+        self.assertAlmostEqual(rst, self.expected)
+
+    @skipIf(no_torch, "Skipping tests: no torch dependency")
+    def test_ndarray_torch(self):
+        x = torch.tensor(self.x)
+        y = torch.tensor(self.y)
+        rst = vlr(x, y, ddof=1)
+        self.assertAlmostEqual(rst, self.expected, places=7)
+
+    @skipIf(no_jax, "Skipping tests: no jax dependency")
+    def test_ndarray_jnp(self):
+        x = jnp.array(self.x)
+        y = jnp.array(self.y)
+        rst = vlr(x, y, ddof=1)
+        self.assertAlmostEqual(rst, self.expected, places=7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`centralize()` and `vlr()` are the last two composition stats functions that still use
hard-coded NumPy / SciPy calls. This brings them in line with `closure`, `clr`, `ilr`,
`alr`, and their inverses, which already go through `ingest_array`.

### What changed

**`centralize()`**

- Replaced the `scipy.stats.gmean` import with `exp(mean(log(x)))`, which only uses
  operations available in the Array API standard.
- Uses `ingest_array` → `xp` namespace like the rest of the module.
- Added a `validate` parameter (consistent with `closure`, `clr`, etc.).

**`vlr()` / `_vlr()`**

- The non-robust path now receives the `xp` namespace from `_closure_two` and computes
  log-ratio variance using `xp.log`, `xp.mean`, `xp.sum`.
- The `robust=True` path stays on NumPy (`np.ma` masked arrays have no Array API
  equivalent). The docstring notes this explicitly.

**Tests**

- Added `Tests_Centralize` and `Tests_VLR` classes in `test_ndarray.py` with NumPy,
  PyTorch, and JAX backend checks (same pattern as `Tests_Closure`, `Tests_CLR`, etc.).

### What I verified locally

```
$ python -m pytest skbio/stats/composition/tests/test_base.py \
                   skbio/stats/composition/tests/test_ndarray.py -q
40 passed, 40 skipped
```

(Torch/JAX/CUDA tests are skipped locally — they'll run in CI where those deps are available.)