### PR TITLE
FIX: accept single-base fuzzy locations like `<N`/`>N` in GenBank parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 * Fixed `permdisp` mutating the input `OrdinationResults` object by adding a `"grouping"` column to its `samples` DataFrame ([#2440](https://github.com/scikit-bio/scikit-bio/pull/2440)).
+* Fixed the GenBank/EMBL/GFF3 feature-location parser to accept single-base locations with a fuzzy boundary (e.g. `complement(<23231)` as found in the NCBI lambda virus record J02459.1). Previously such locations raised `FileFormatError: Could not parse location string`. The corresponding serializer was updated symmetrically to emit `<N`/`>N` instead of dropping the fuzzy marker ([#1666](https://github.com/scikit-bio/scikit-bio/issues/1666)).
 
 ### Miscellaneous
 

--- a/skbio/io/format/_sequence_feature_vocabulary.py
+++ b/skbio/io/format/_sequence_feature_vocabulary.py
@@ -215,7 +215,11 @@ def _parse_loc_str(loc_str):
     RPAREN = r"(?P<RPAREN>\))"
     COMMA = r"(?P<COMMA>,)"
     WS = r"(?P<WS>\s+)"
-    a = r"(?P<A>\d+)"
+    # A single base position, optionally prefixed with `<` or `>` to indicate
+    # that the exact boundary lies before or beyond the given base (issue #1666,
+    # e.g. "complement(<23231)" as seen in the NCBI lambda virus record
+    # J02459.1).
+    a = r"(?P<A>[<>]?\d+)"
     b = r"(?P<B>\d+\^\d+)"
     c = r"(?P<C>\d+\.\d+)"
     d = r"(?P<D><?\d+\.\.>?\d+)"
@@ -246,9 +250,16 @@ def _parse_loc_str(loc_str):
         if v == "complement":
             metadata["strand"] = "-"
         elif p == "A":
+            fuzzy_s = fuzzy_e = False
+            if v.startswith("<"):
+                v = v[1:]
+                fuzzy_s = True
+            elif v.startswith(">"):
+                v = v[1:]
+                fuzzy_e = True
             start = int(v)
             bounds.append((start - 1, start))
-            fuzzy.append((False, False))
+            fuzzy.append((fuzzy_s, fuzzy_e))
         elif p == "B":
             start, end = v.split("^")
             start = int(start)
@@ -341,7 +352,12 @@ def _serialize_location(intvl):
         start, end = bound
         start += 1
         if start == end:
-            s = str(start)
+            if fuzzy[0] and not fuzzy[1]:
+                s = "<%d" % start
+            elif fuzzy[1] and not fuzzy[0]:
+                s = ">%d" % start
+            else:
+                s = str(start)
         elif fuzzy[0] and fuzzy[1]:
             s = "<%d..>%d" % (start, end)
         elif fuzzy[0] and not fuzzy[1]:

--- a/skbio/io/format/tests/test_sequence_feature_vocabulary.py
+++ b/skbio/io/format/tests/test_sequence_feature_vocabulary.py
@@ -44,7 +44,14 @@ class Tests(TestCase):
             'join(J00194.1:1..9,3..8)',
             'join(3..8,J00194.1:1..9)',
             '1.9',
-            '1^2']
+            '1^2',
+            # single-base locations with fuzzy boundary (issue #1666):
+            # e.g. lambda virus (NCBI J02459.1) contains
+            # "mRNA complement(<23231)".
+            '<9',
+            '>9',
+            'complement(<23231)',
+            'complement(>23231)']
 
         expects = [
             ([(8, 9)], [(False, False)], {'strand': '+'}),
@@ -57,7 +64,11 @@ class Tests(TestCase):
             ([(2, 8)], [(False, False)], {'strand': '+'}),
             ([(2, 8)], [(False, False)], {'strand': '+'}),
             ([(0, 9)], [(False, False)], {'strand': '+'}),
-            ([(0, 1)], [(False, False)], {'strand': '+'})]
+            ([(0, 1)], [(False, False)], {'strand': '+'}),
+            ([(8, 9)], [(True, False)], {'strand': '+'}),
+            ([(8, 9)], [(False, True)], {'strand': '+'}),
+            ([(23230, 23231)], [(True, False)], {'strand': '-'}),
+            ([(23230, 23231)], [(False, True)], {'strand': '-'})]
 
         for example, expect in zip(examples, expects):
             parsed = _parse_loc_str(example)
@@ -77,6 +88,13 @@ class Tests(TestCase):
         imd = IntervalMetadata(9)
         i1 = imd.add([(0, 1)])
         self.assertEqual(_serialize_location(i1), '1')
+
+        # single-base with fuzzy lower/upper boundary (issue #1666)
+        i1a = imd.add([(0, 1)], [(True, False)])
+        self.assertEqual(_serialize_location(i1a), '<1')
+
+        i1b = imd.add([(0, 1)], [(False, True)])
+        self.assertEqual(_serialize_location(i1b), '>1')
 
         i2 = imd.add([(0, 2)], [(True, True)])
         self.assertEqual(_serialize_location(i2), '<1..>2')


### PR DESCRIPTION
The feature-location parser in `_sequence_feature_vocabulary.py` accepted fuzzy ranges (`<N..M`, `N..>M`, `<N..>M`) but not single-base fuzzy positions (`<N`, `>N`). Real-world GenBank records contain the latter — for example the NCBI lambda virus record (J02459.1) has `mRNA complement(<23231)`, which caused `DNA.read` to raise `FileFormatError: Could not parse location string`.

Fix:
- Extend the `A` (single base) token to accept an optional `<` or `>` prefix and record the corresponding fuzzy flag.
- Update `_serialize_location` symmetrically so single-base intervals with fuzzy metadata round-trip as `<N` / `>N` instead of silently dropping the marker.
- Add parser and serializer tests for the new forms, including the exact `complement(<23231)` case from the bug report.

Fixes #1666.

Please complete the following checklist:

* [ ] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [ ] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
