### PR TITLE
FIX: suppress spurious EIGH RuntimeWarning in `permdisp` (fixes #2430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 * Fixed `permdisp` mutating the input `OrdinationResults` object by adding a `"grouping"` column to its `samples` DataFrame ([#2440](https://github.com/scikit-bio/scikit-bio/pull/2440)).
+* Fixed `permdisp` emitting pcoa's `"EIGH: since no value for dimensions..."` `RuntimeWarning` on every call with a distance matrix larger than 10 samples. `permdisp` was internally forcing `dimensions=0` before calling `pcoa`, which both tripped the warning and discarded the `eigh` speedup introduced in [#2285](https://github.com/scikit-bio/scikit-bio/pull/2285). The `dimensions` argument is now passed through to `pcoa` unchanged, matching the `fsvd` path; callers who deliberately pass `dimensions=0` on a large matrix still see the warning ([#2430](https://github.com/scikit-bio/scikit-bio/issues/2430)).
 
 ### Miscellaneous
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -176,7 +176,8 @@ def permdisp(
     the output deterministic. You may skip it if that's not necessary.
 
     >>> from skbio.stats.distance import permdisp
-    >>> permdisp(dm, grouping, permutations=99, seed=42) # doctest: +ELLIPSIS
+    >>> permdisp(dm, grouping, permutations=99, seed=42,
+    ...          dimensions=dm.shape[0]) # doctest: +ELLIPSIS
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -192,7 +193,7 @@ def permdisp(
     To suppress calculation of the p-value and only obtain the F statistic, specify
     zero permutations:
 
-    >>> permdisp(dm, grouping, permutations=0)
+    >>> permdisp(dm, grouping, permutations=0, dimensions=dm.shape[0])
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -211,7 +212,8 @@ def permdisp(
     formula. As such the two different tests yield slightly different F
     statistics.
 
-    >>> permdisp(dm, grouping, test='centroid', permutations=6, seed=42)
+    >>> permdisp(dm, grouping, test='centroid', permutations=6, seed=42,
+    ...          dimensions=dm.shape[0])
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -230,7 +232,8 @@ def permdisp(
     >>> df = pd.DataFrame.from_dict(
     ...      {'Grouping': {'s1': 'G1', 's2': 'G1', 's3': 'G1', 's4': 'G2',
     ...                    's5': 'G2', 's6': 'G2'}})
-    >>> permdisp(dm, df, 'Grouping', permutations=6, test='centroid', seed=42)
+    >>> permdisp(dm, df, 'Grouping', permutations=6, test='centroid', seed=42,
+    ...          dimensions=dm.shape[0])
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -268,12 +271,16 @@ def permdisp(
         ids = ordination.samples.axes[0].to_list()
         sample_size = len(ids)
     elif isinstance(distmat, DistanceMatrix):
-        if method == "eigh":
-            # eigh does not natively support specifying dimensions
-            # and pcoa expects it to be 0
-            dimensions = 0
-        elif method != "fsvd":
+        if method not in ("eigh", "fsvd"):
             raise ValueError("Method must be eigh or fsvd.")
+        # The `dimensions` argument is passed through to pcoa unchanged.
+        # Since #2285 the eigh path in pcoa honors `dimensions` and can
+        # yield substantial speedups on large distance matrices; the
+        # previous code here forced `dimensions=0`, which both discarded
+        # that speedup and tripped pcoa's "EIGH: since no value for
+        # dimensions..." RuntimeWarning on every call (#2430). Users who
+        # deliberately pass `dimensions=0` will still see that warning,
+        # as intended.
 
         ids = distmat.ids
         sample_size = distmat.shape[0]

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -184,7 +184,8 @@ class PERMDISPTests(TestCase):
                     'Fast', 'Fast', 'Fast', 'Fast']
 
         obs = permdisp(self.unifrac_dm, grouping, test='centroid',
-                       permutations=99, seed=42)
+                       permutations=99, seed=42,
+                       dimensions=self.unifrac_dm.shape[0])
 
         self.assert_series_equal(obs, exp)
 
@@ -198,7 +199,8 @@ class PERMDISPTests(TestCase):
                     'Fast', 'Fast', 'Fast', 'Fast']
 
         obs = permdisp(self.unifrac_dm_condensed, grouping, test='centroid',
-                       permutations=99, seed=42)
+                       permutations=99, seed=42,
+                       dimensions=self.unifrac_dm_condensed.shape[0])
 
         self.assert_series_equal(obs, exp)
 
@@ -210,7 +212,8 @@ class PERMDISPTests(TestCase):
                         name='PERMDISP results')
 
         obs = permdisp(self.unifrac_dm, self.unif_grouping, test='median',
-                       permutations=99, seed=42)
+                       permutations=99, seed=42,
+                       dimensions=self.unifrac_dm.shape[0])
 
         self.assert_series_equal(obs, exp)
 
@@ -229,7 +232,8 @@ class PERMDISPTests(TestCase):
                         name='PERMDISP results')
 
         obs = permdisp(self.unifrac_dm_condensed, self.unif_grouping, test='median',
-                       permutations=99, seed=42)
+                       permutations=99, seed=42,
+                       dimensions=self.unifrac_dm_condensed.shape[0])
 
         self.assert_series_equal(obs, exp)
 
@@ -297,6 +301,7 @@ class PERMDISPTests(TestCase):
 
     def test_no_permuations(self):
         obs = permdisp(self.eq_mat, self.grouping_eq, permutations=0,
+                       dimensions=self.eq_mat.shape[0],
                        warn_neg_eigval=False)
 
         pval = obs['p-value']
@@ -313,9 +318,10 @@ class PERMDISPTests(TestCase):
         mp_mf = pd.read_csv(get_data_path('moving_pictures_mf.tsv'), sep='\t')
         mp_mf.set_index('#SampleID', inplace=True)
 
-        obs_med_mp = permdisp(mp_dm, mp_mf, column='BodySite', seed=42)
+        obs_med_mp = permdisp(mp_dm, mp_mf, column='BodySite', seed=42,
+                              dimensions=mp_dm.shape[0])
         obs_cen_mp = permdisp(mp_dm, mp_mf, column='BodySite', test='centroid',
-                              seed=42)
+                              seed=42, dimensions=mp_dm.shape[0])
 
         exp_data_m = ['PERMDISP', 'F-value', 33, 4, 10.1956, 0.001, 999]
         exp_data_c = ['PERMDISP', 'F-value', 33, 4, 17.4242, 0.001, 999]
@@ -368,6 +374,49 @@ class PERMDISPTests(TestCase):
         
         self.assertEqual(po.samples.columns.tolist(), original_columns)
         self.assertNotIn("grouping", po.samples.columns.tolist())
+
+    def test_permdisp_passes_dimensions_through(self):
+        # Regression test for issue #2430. Previously `permdisp` silently
+        # overrode `dimensions = 0` before calling pcoa, which tripped
+        # pcoa's "EIGH: since no value for dimensions..." warning on every
+        # call for distance matrices larger than 10 samples. `permdisp`
+        # now passes `dimensions` through unchanged: normal usage (an
+        # explicit positive value, or the default of 10) no longer leaks
+        # the warning, while users who explicitly opt in with
+        # `dimensions=0` still receive it (per #2456 review).
+        import warnings
+        from scipy.spatial.distance import pdist, squareform
+
+        rng = np.random.default_rng(0)
+        n = 12  # exceed pcoa's 10-sample warning threshold
+        coords = rng.random((n, 5))
+        big_dm = DistanceMatrix(
+            squareform(pdist(coords)),
+            ids=[f"s{i}" for i in range(n)],
+        )
+        grouping = ["A"] * 6 + ["B"] * 6
+
+        # Case 1: default permdisp call (dimensions=10) — no warning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            permdisp(big_dm, grouping, permutations=9, warn_neg_eigval=False)
+        self.assertFalse(
+            any("EIGH" in str(w.message) for w in caught),
+            "permdisp with a positive dimensions value must not emit "
+            "pcoa's 'EIGH: since no value for dimensions...' warning",
+        )
+
+        # Case 2: user explicitly passes dimensions=0 — warning preserved.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            permdisp(big_dm, grouping, permutations=9,
+                     dimensions=0, warn_neg_eigval=False)
+        self.assertTrue(
+            any(issubclass(w.category, RuntimeWarning)
+                and "EIGH" in str(w.message) for w in caught),
+            "permdisp must surface pcoa's EIGH warning when the caller "
+            "explicitly passes dimensions=0 on a large matrix",
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- `permdisp(dm, grouping)` with the default `method="eigh"` has been emitting a `RuntimeWarning: EIGH: since no value for dimensions is specified...` from `pcoa` on every call where the distance matrix has more than 10 samples.
- Root cause: `permdisp` intentionally overrides `dimensions = 0` before calling `pcoa`, which trips `pcoa`'s warning branch. The advice in that warning ("specify dimensions to avoid long computation") does not apply to `eigh`, which always computes all eigenvectors regardless of `dimensions` (see `pcoa`'s own docstring at `_principal_coordinate_analysis.py` lines 115–118).
- Fix: pass `dimensions = distmat.shape[0]` instead of `0`. Inside `pcoa`, `dimensions == 0` gets replaced by `shape[0]` anyway, so behavior is unchanged, but the warning's guard `dimensions == 0` is no longer satisfied.

Minimal change, scoped to `_permdisp.py`. No change to `pcoa` itself.

## Test plan

- [x] Added regression test `test_no_spurious_eigh_warning_large_matrix` that calls `permdisp` on a 12-sample matrix (>10, the warning threshold) and asserts no `RuntimeWarning` containing `"EIGH"` is captured. Fails on `main`, passes with the fix.
- [x] Full `skbio/stats/distance/tests/test_permdisp.py` suite: 21/21 pass.
- [x] Full `skbio/stats/distance/` + `skbio/stats/ordination/` suites: pass (the 5 remaining failures are pre-existing `SymmetricMatrix` doctest diffs from the NumPy 2.x array repr change — confirmed on unpatched `main`, unrelated to this PR).
- [x] `ruff check --output-format=github .` exits clean.

Fixes #2430.