### PR TITLE
fix gff3 attribute decoding

### DIFF
--- a/skbio/io/format/gff3.py
+++ b/skbio/io/format/gff3.py
@@ -214,6 +214,7 @@ Specifications/blob/master/gff3.md
 
 import re
 from collections.abc import Iterable
+from urllib.parse import unquote
 
 from skbio.sequence import DNA, Sequence
 from skbio.io import create_format, GFF3FormatError
@@ -461,7 +462,9 @@ def _parse_attr(s):
     # in case the line ending with ';', strip it.
     s = s.rstrip(";")
     for attr in s.split(";"):
-        k, v = attr.split("=")
+        k, v = attr.split("=", 1)
+        k = unquote(k)
+        v = ",".join(unquote(x) for x in v.split(","))
         if k in voca_change:
             k = voca_change[k]
         md[k] = v

--- a/skbio/io/format/tests/test_gff3.py
+++ b/skbio/io/format/tests/test_gff3.py
@@ -131,6 +131,18 @@ class ReaderTests(GFF3IOTests):
         exp = {'db_xref': 'GO:000152,GO:001234', 'note': 'fooo'}
         self.assertEqual(exp, obs)
 
+    def test_parse_attr_unescape(self):
+        s = 'ID=a%3B%3D%26%2Cb;Note=important%3B useful'
+        obs = _parse_attr(s)
+        exp = {'ID': 'a;=&,b', 'note': 'important; useful'}
+        self.assertEqual(exp, obs)
+
+    def test_parse_attr_unescape_multiple_values(self):
+        s = 'Dbxref=a%2Cb,c%3Bd'
+        obs = _parse_attr(s)
+        exp = {'db_xref': 'a,b,c;d'}
+        self.assertEqual(exp, obs)
+
     def test_yield_record(self):
         obs = [('data', 'seqid1', ['seqid1\txxx', 'seqid1\tyyy']),
                ('data', 'seqid2', ['seqid2\tzzz'])]
@@ -330,6 +342,18 @@ class RoundtripTests(GFF3IOTests):
             exp = [i.rstrip() for i in f.readlines() if not i.startswith('#')]
 
         self.assertEqual(obs, exp)
+
+    def test_roundtrip_interval_metadata_escape(self):
+        imd = IntervalMetadata(9)
+        imd.add([(0, 9)], metadata={
+            'type': 'gene', 'ID': 'a;=&,b', 'note': 'important; useful'})
+        with io.StringIO() as fh:
+            _interval_metadata_to_gff3(imd, fh, seq_id='ctg123')
+            fh.seek(0)
+            obs = _gff3_to_interval_metadata(fh, seq_id='ctg123')
+        md = dict(list(obs.query())[0].metadata)
+        self.assertEqual(md['ID'], 'a;=&,b')
+        self.assertEqual(md['note'], 'important; useful')
 
     def test_roundtrip_interval_metadata_generator(self):
         with io.StringIO() as fh:


### PR DESCRIPTION
Please complete the following checklist:

- [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

- [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

- [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

- [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

Closes #2454

## Description

The GFF3 reader left percent-encoded characters (`%3B`, `%2C`, `%3D`, `%26`) literal in attribute values, so write/read round-trips didn't return the original value. Added `unquote` in `_parse_attr` to decode keys and values on read, splitting multi-value attributes on `,` first so escaped commas are preserved. Tests cover the unescape path and a write/read round-trip.
