### PR TITLE
WIP:  Use new gpu runner for array-api Actions workflow

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         include:
           - backend: torch
+            device: cuda
           # - backend: jax
           # - backend: cupy
     steps:
@@ -35,6 +36,6 @@ jobs:
           pip install -r ci/requirements.txt -r ci/requirements.test.txt
       - name: Run tests
         env:
-          SKBIO_ARRAY_BACKEND: torch # ${{ matrix.backend }}
-          SKBIO_DEVICE: gpu
+          SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
+          SKBIO_DEVICE: ${{ matrix.device }}
         run: pytest skbio/stats/composition/tests/test_base.py

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -72,10 +72,10 @@ jobs:
               print("cupy:", cupy.__version__, "devices:", n)
           PY
 
-      - name: Check for compiled extensions
-        run: |
-          find . -name "_intersection*" -type f -not -path "*/\.*"
-          python -c "import skbio.metadata._intersection; print('OK:', skbio.metadata._intersection.__file__)"
+      # - name: Check for compiled extensions
+      #   run: |
+      #     find . -name "_intersection*" -type f -not -path "*/\.*"
+      #     python -c "import skbio.metadata._intersection; print('OK:', skbio.metadata._intersection.__file__)"
 
       - name: Run tests
         env:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -26,8 +26,10 @@ jobs:
           python-version: ${{ env.latest_python }}
       - name: Install scikit-bio + backend
         run: |
-          pip install -e .
+          python -m ensurepip
+          pip install --no-deps .
           pip install ${{ matrix.backend }}
+          pip install -r ci/requirements.txt -r ci/requirements.test.txt
       - name: Run tests
         env:
           SKBIO_ARRAY_BACKEND: torch # ${{ matrix.backend }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -11,17 +11,14 @@ env:
 jobs:
   test:
     name: Array API (${{ matrix.backend }})
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: gpu-t4-4-core
     strategy:
       fail-fast: false
       matrix:
         include:
           - backend: torch
-            runs-on: ubuntu-latest
           - backend: jax
-            runs-on: ubuntu-latest
           - backend: cupy
-            runs-on: ubuntu-latest-gpu   # TODO: replace with your GPU runner label
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -43,7 +43,7 @@ jobs:
               pip install -U "jax[cuda12]"
               ;;
             cupy)
-              pip install cupy-cuda12x
+              pip install cupy-cuda12x[ctk]
               ;;
           esac
           pip install -r ci/requirements.txt -r ci/requirements.test.txt

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -1,6 +1,8 @@
 name: Array API Compatibility
 
 on:
+  pull_request:
+    types: [labeled, synchronize]
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'   # Every Monday at 06:00 UTC
@@ -10,6 +12,9 @@ env:
 
 jobs:
   test:
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'gpu-ci')
     name: Array API (${{ matrix.backend }})
     runs-on: gpu-t4-4-core
     strategy:
@@ -71,11 +76,6 @@ jobs:
               assert n > 0, "cupy sees no GPU"
               print("cupy:", cupy.__version__, "devices:", n)
           PY
-
-      # - name: Check for compiled extensions
-      #   run: |
-      #     find . -name "_intersection*" -type f -not -path "*/\.*"
-      #     python -c "import skbio.metadata._intersection; print('OK:', skbio.metadata._intersection.__file__)"
 
       - name: Run tests
         env:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -76,4 +76,5 @@ jobs:
         env:
           SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
           SKBIO_DEVICE: ${{ matrix.device }}
-        run: pytest skbio/stats/composition/tests/test_base.py
+        # This only runs tests which are decorated with the @array_backends decorator
+        run: pytest -m array_api skbio/

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.latest_python }}
+      - name: Check CUDA
+        run: nvidia-smi
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: Array API (${{ matrix.backend }})
-    runs-on: gpu-t4-4-core
+    runs-on: ubuntu-latest # gpu-t4-4-core
     strategy:
       fail-fast: false
       matrix:
@@ -30,5 +30,6 @@ jobs:
           pip install ${{ matrix.backend }}
       - name: Run tests
         env:
-          SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
+          SKBIO_ARRAY_BACKEND: torch # ${{ matrix.backend }}
+          SKBIO_DEVICE: cpu
         run: python -m skbio.test

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip
-          pip install .
+          pip install -v .
           case "${{ matrix.backend }}" in
             torch)
               pip install torch --index-url https://download.pytorch.org/whl/cu128
@@ -71,6 +71,11 @@ jobs:
               assert n > 0, "cupy sees no GPU"
               print("cupy:", cupy.__version__, "devices:", n)
           PY
+
+      - name: Check for compiled extensions
+        run: |
+          find . -name "_intersection*" -type f -not -path "*/\.*"
+          python -c "import skbio.metadata._intersection; print('OK:', skbio.metadata._intersection.__file__)"
 
       - name: Run tests
         env:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ env.latest_python }}
       - name: Check CUDA
-        run: nvidia-smi
+        run: nvcc --version
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -82,4 +82,4 @@ jobs:
           SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
           SKBIO_DEVICE: ${{ matrix.device }}
         # This only runs tests which are decorated with the @array_backends decorator
-        run: pytest -m array_api skbio/
+        run: cd ci && pytest -m array_api --pyargs skbio

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -20,8 +20,8 @@ jobs:
           - backend: jax
           - backend: cupy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.latest_python }}
       - name: Check CUDA

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip
-          pip install --no-deps .
+          pip install .
           case "${{ matrix.backend }}" in
             torch)
               pip install torch --index-url https://download.pytorch.org/whl/cu128

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -5,9 +5,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'   # Every Monday at 06:00 UTC
 
-# torch doesn't have wheels for 3.14 yet
 env:
-  latest_python: "3.13"
+  latest_python: "3.13"   # torch has no 3.14 wheels yet
 
 jobs:
   test:
@@ -19,21 +18,60 @@ jobs:
         include:
           - backend: torch
             device: cuda
-          # - backend: jax
-          # - backend: cupy
+          - backend: jax
+            device: cuda
+          - backend: cupy
+            device: cuda
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.latest_python }}
-      - name: Check CUDA
+
+      - name: Check CUDA driver
         run: nvidia-smi
+
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip
           pip install --no-deps .
-          pip install ${{ matrix.backend }}
+          case "${{ matrix.backend }}" in
+            torch)
+              pip install torch --index-url https://download.pytorch.org/whl/cu128
+              ;;
+            jax)
+              pip install -U "jax[cuda12]"
+              ;;
+            cupy)
+              pip install cupy-cuda12x
+              ;;
+          esac
           pip install -r ci/requirements.txt -r ci/requirements.test.txt
+
+      - name: Verify GPU is visible to backend
+        env:
+          BACKEND: ${{ matrix.backend }}
+        run: |
+          python - <<'PY'
+          import os
+          backend = os.environ["BACKEND"]
+          if backend == "torch":
+              import torch
+              assert torch.cuda.is_available(), "torch installed without CUDA"
+              print("torch:", torch.__version__, "CUDA:", torch.version.cuda,
+                    "device:", torch.cuda.get_device_name(0))
+          elif backend == "jax":
+              import jax
+              gpus = jax.devices("gpu")
+              assert gpus, "jax sees no GPU"
+              print("jax:", jax.__version__, "devices:", gpus)
+          elif backend == "cupy":
+              import cupy
+              n = cupy.cuda.runtime.getDeviceCount()
+              assert n > 0, "cupy sees no GPU"
+              print("cupy:", cupy.__version__, "devices:", n)
+          PY
+
       - name: Run tests
         env:
           SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -5,27 +5,28 @@ on:
   schedule:
     - cron: '0 6 * * 1'   # Every Monday at 06:00 UTC
 
+# torch doesn't have wheels for 3.14 yet
 env:
-  latest_python: "3.14"
+  latest_python: "3.13"
 
 jobs:
   test:
     name: Array API (${{ matrix.backend }})
-    runs-on: ubuntu-latest # gpu-t4-4-core
+    runs-on: gpu-t4-4-core
     strategy:
       fail-fast: false
       matrix:
         include:
           - backend: torch
-          - backend: jax
-          - backend: cupy
+          # - backend: jax
+          # - backend: cupy
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.latest_python }}
       - name: Check CUDA
-        run: nvcc --version
+        run: nvidia-smi
       - name: Install scikit-bio + backend
         run: |
           python -m ensurepip
@@ -35,5 +36,5 @@ jobs:
       - name: Run tests
         env:
           SKBIO_ARRAY_BACKEND: torch # ${{ matrix.backend }}
-          SKBIO_DEVICE: cpu
-        run: python -m skbio.test
+          SKBIO_DEVICE: gpu
+        run: pytest skbio/stats/composition/tests/test_base.py

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -12,10 +12,12 @@ env:
 
 jobs:
   test:
+    # workflow will be triggered on PRs which have the 'gpu-ci' label added.
     if: |
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'gpu-ci')
     name: Array API (${{ matrix.backend }})
+    # gpu-t4-4-core is a runner specifically configured in the scikit-bio organization
     runs-on: gpu-t4-4-core
     strategy:
       fail-fast: false
@@ -37,6 +39,8 @@ jobs:
         run: nvidia-smi
 
       - name: Install scikit-bio + backend
+      # CUDA 12 is pinned for the libraries. To update CUDA versions check the
+      # installation guides for each package.
         run: |
           python -m ensurepip
           pip install -v .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "IGNORE_EXCEPTION_DETAIL",
 ]
+markers = [
+    "array_api: tests that exercise the Array API across backends",
+]
 
 [tool.check-manifest]
 ignore = [

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -103,7 +103,7 @@ from ._decorator import (
     params_aliased,
     array_api_doc,
 )
-from ._optionals import get_package
+from ._optionals import get_package, _is_usable
 from ._plotting import PlottableMixin
 
 __all__ = [
@@ -117,7 +117,7 @@ __all__ = [
     "assert_data_frame_almost_equal",
     "pytestrunner",
     "get_package",
-    "PlottableMixin",
+    "_is_usablePlottableMixin",
     "overrides",
     "classproperty",
     "classonlymethod",

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -105,6 +105,7 @@ from ._decorator import (
 )
 from ._optionals import get_package, _is_usable
 from ._plotting import PlottableMixin
+from ._array import ingest_array
 
 __all__ = [
     "cardinal_to_ordinal",
@@ -117,7 +118,9 @@ __all__ = [
     "assert_data_frame_almost_equal",
     "pytestrunner",
     "get_package",
-    "_is_usablePlottableMixin",
+    "_is_usable",
+    "ingest_array",
+    "PlottableMixin",
     "overrides",
     "classproperty",
     "classonlymethod",

--- a/skbio/util/_array.py
+++ b/skbio/util/_array.py
@@ -98,65 +98,6 @@ _BACKEND_CHECKERS = {
 }
 
 
-def _get_namespace_from_args(args, kwargs):
-    r"""Return the array namespace if any argument is an array object.
-
-    Parameters
-    ----------
-    args : tuple
-        Positional arguments.
-    kwargs : dict
-        Keyword arguments.
-
-    Returns
-    -------
-    namespace or None
-        A uniform array namespace for all detected array objects, or `None` if no array
-        object is found.
-
-    Raises
-    ------
-    TypeError
-        If `args` or `kwargs` contain arrays from different array libraries.
-
-    """
-    arrays = [
-        obj for obj in list(args) + list(kwargs.values()) if aac.is_array_api_obj(obj)
-    ]
-    if not arrays:
-        return None
-    return aac.array_namespace(*arrays)
-
-
-def _check_array_api_backend(xp, backends, func_name):
-    r"""Raise TypeError if xp is not among the declared supported backends.
-
-    Parameters
-    ----------
-    xp : namespace
-        Array namespace to check.
-    backends : list of str
-        Allowed backend names (e.g. `['numpy', 'torch']`).
-    func_name : str
-        Name of the calling function, used in the error message.
-
-    Raises
-    ------
-    TypeError
-        If `xp` is not a supported backend.
-
-    """
-    for name in backends:
-        checker = _BACKEND_CHECKERS.get(name)
-        if checker is not None and checker(xp):
-            return
-    supported = ", ".join(backends)
-    raise TypeError(
-        f"{func_name}() received an array from an unsupported backend. "
-        f"Supported backends are: {supported}."
-    )
-
-
 # -------------------------------------------------------------------------------------
 # Conversion and device helpers (used primarily in testing)
 # -------------------------------------------------------------------------------------

--- a/skbio/util/_optionals.py
+++ b/skbio/util/_optionals.py
@@ -42,3 +42,14 @@ def get_package(name, raise_error=True):
     except (ImportError, ModuleNotFoundError):
         if raise_error:
             raise ImportError(msg)
+
+
+def _is_usable(mod, probe):
+    """Return True if `mod` is importable AND `probe()` runs without error."""
+    if mod is None:
+        return False
+    try:
+        probe()
+        return True
+    except Exception:
+        return False

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -461,12 +461,16 @@ def pytestrunner():
 # -------------------------------------------------------------------------------------
 # Array API test infrastructure
 #
-# Write one test method, run it against every supported array backend.
-# Uses unittest.subTest() for per-backend reporting — no pytest needed.
+# Write one test method, run it against every supported array backend
+# (numpy, jax, torch, cupy). Uses ``unittest.subTest()`` for per-backend
+# reporting — no pytest required.
 #
 # Env vars:
 #   SKBIO_ARRAY_BACKEND  — "numpy" (default), "jax", "torch", "cupy", or "all"
-#   SKBIO_DEVICE             — "cpu" (default), "cuda", "gpu"
+#   SKBIO_DEVICE         — "cpu" (default), "cuda", "gpu"
+#
+# Note: ``"gpu"`` (JAX's native string) and ``"cuda"`` (Torch/CuPy's native
+# string) refer to the same hardware and compare equal after normalization.
 #
 # Usage:
 #     class TestClosure(TestCase, ArrayAPITestMixin):
@@ -479,14 +483,33 @@ def pytestrunner():
 # -------------------------------------------------------------------------------------
 
 
-_DEVICE_ALIASES = {"gpu": "cuda", "cuda": "cuda"}
+# Comparison-only canonical form: collapse equivalent device specifiers from
+# different backends to a single key. Do NOT pass the canonical form back to a
+# backend as a device argument — JAX wants "gpu", Torch/CuPy want "cuda".
+_DEVICE_ALIASES = {"gpu": "cuda"}
 
 
 def _normalize_device(device):
-    """Canonicalize device name so that ``'gpu'`` and ``'cuda'`` are equivalent."""
+    """Canonicalize a device specifier for equality comparison.
+
+    - ``None`` stays ``None``.
+    - Case-insensitive (``"CUDA"`` → ``"cuda"``).
+    - Strips a default device index (``"cuda:0"`` → ``"cuda"``); non-zero
+      indices are preserved (``"cuda:1"`` → ``"cuda:1"``).
+    - JAX's ``"gpu"`` and Torch/CuPy's ``"cuda"`` collapse to ``"cuda"``.
+    - Accepts ``torch.device`` or any object with a sensible ``str()``.
+
+    The returned string is for *comparison only*. It is not safe to pass back
+    to a backend as a device argument.
+    """
     if device is None:
         return None
-    return _DEVICE_ALIASES.get(device.lower(), device.lower())
+    s = str(device).lower()
+    if ":" in s:
+        kind, idx = s.split(":", 1)
+        if idx == "0":
+            s = kind
+    return _DEVICE_ALIASES.get(s, s)
 
 
 def _read_env():
@@ -497,7 +520,13 @@ def _read_env():
 
 
 def _get_array_backends():
-    """Return dict of {name: (namespace, [devices])} for installed backends."""
+    """Return dict of {name: (namespace, [devices])} for installed backends.
+
+    The device strings stored here are each backend's *native* form — JAX uses
+    ``"gpu"``, Torch and CuPy use ``"cuda"`` — because they get passed back to
+    the backend (e.g. via ``_move_to_device``). Use ``_normalize_device`` only
+    when comparing device specifiers across backends.
+    """
     _backends = {"numpy": (np, ["cpu"])}
 
     try:
@@ -628,11 +657,6 @@ def array_backends(*backend_names, cpu_only=False):
 
                     ran_any = True
                     with self.subTest(backend=name, device=device):
-                        # Comment this print statement out when finished
-                        # print(
-                        #     f"\n  → Running {test_func.__name__} [{name}, {device}]",
-                        #     flush=True,
-                        # )
                         test_func(self, xp, device)
             if not ran_any:
                 if env_device:
@@ -657,16 +681,8 @@ class ArrayAPITestMixin:
 
     """
 
-    # def make_array(self, xp, device, data, dtype=None):
-    #     """Create an array on the appropriate backend and device."""
-    #     if dtype is not None:
-    #         arr = xp.asarray(data, dtype=dtype)
-    #     else:
-    #         arr = xp.asarray(data)
-    #     return _move_to_device(arr, xp, device)
-
     def make_array(self, xp, device, data, dtype=None):
-        """Create an array on the appropriate backend and device."""
+        """Create an array on the given backend and device."""
         if dtype is None:
             dtype = xp.float64
         arr = xp.asarray(data, dtype=dtype)
@@ -674,9 +690,7 @@ class ArrayAPITestMixin:
 
     def assert_close(self, actual, expected, rtol=1e-7, atol=1e-7):
         """Assert two arrays are numerically close (converts to numpy)."""
-        npt.assert_allclose(
-            _to_numpy(actual), _to_numpy(expected), rtol=rtol, atol=atol
-        )
+        xp_assert_close(actual, expected, rtol=rtol, atol=atol)
 
     def assert_type_preserved(self, result, xp, device):
         """Assert result is from the correct backend and on the right device."""
@@ -692,10 +706,7 @@ class ArrayAPITestMixin:
 
         if device not in ("cpu", None) and hasattr(result, "device"):
             self.assertEqual(
-                self._normalize_device(result.device),
-                self._normalize_device(device),
+                _normalize_device(result.device),
+                _normalize_device(device),
                 f"Device not preserved: result on {result.device}, expected {device}",
             )
-
-    def _normalize_device(self, name):
-        return _normalize_device(str(name))

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -716,6 +716,15 @@ def array_backends(*backend_names, cpu_only=False):
                     )
                 raise unittest.SkipTest(f"No matching backends for {backend_names}")
 
+        # Tag with a pytest marker so we can filter for CI with
+        # `pytest -m array_api`. Falls back silently if pytest not installed.
+        try:
+            import pytest
+
+            wrapper = pytest.mark.array_api(wrapper)
+        except ImportError:
+            pass
+
         return wrapper
 
     return decorator

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -470,7 +470,7 @@ def pytestrunner():
 #   SKBIO_DEVICE         — "cpu" (default), "cuda", "gpu"
 #
 # Note: ``"gpu"`` (JAX's native string) and ``"cuda"`` (Torch/CuPy's native
-# string) refer to the same hardware and compare equal after normalization.
+# string) refer to the same hardware and are treated as equivalent.
 #
 # Usage:
 #     class TestClosure(TestCase, ArrayAPITestMixin):
@@ -483,33 +483,86 @@ def pytestrunner():
 # -------------------------------------------------------------------------------------
 
 
-# Comparison-only canonical form: collapse equivalent device specifiers from
-# different backends to a single key. Do NOT pass the canonical form back to a
-# backend as a device argument — JAX wants "gpu", Torch/CuPy want "cuda".
-_DEVICE_ALIASES = {"gpu": "cuda"}
+# Two device-name spellings that refer to the same hardware. Used only to
+# decide whether a requested ``SKBIO_DEVICE`` matches a backend's advertised
+# device — never to inspect a real array (see ``_on_device`` for that).
+_GPU_ALIASES = frozenset({"cuda", "gpu"})
 
 
-def _normalize_device(device):
-    """Canonicalize a device specifier for equality comparison.
+def _device_specs_match(a, b):
+    """True if two device-spec strings refer to the same hardware.
 
-    - ``None`` stays ``None``.
-    - Case-insensitive (``"CUDA"`` → ``"cuda"``).
-    - Strips a default device index (``"cuda:0"`` → ``"cuda"``); non-zero
-      indices are preserved (``"cuda:1"`` → ``"cuda:1"``).
-    - JAX's ``"gpu"`` and Torch/CuPy's ``"cuda"`` collapse to ``"cuda"``.
-    - Accepts ``torch.device`` or any object with a sensible ``str()``.
-
-    The returned string is for *comparison only*. It is not safe to pass back
-    to a backend as a device argument.
+    Both inputs are expected to be the per-backend strings stored in
+    ``_BACKENDS`` or read from ``SKBIO_DEVICE`` — short labels like ``"cpu"``,
+    ``"cuda"``, or ``"gpu"``. This is *not* for inspecting a real array's
+    device; use ``_on_device`` for that.
     """
-    if device is None:
-        return None
-    s = str(device).lower()
-    if ":" in s:
-        kind, idx = s.split(":", 1)
-        if idx == "0":
-            s = kind
-    return _DEVICE_ALIASES.get(s, s)
+    if a is None or b is None:
+        return a == b
+    a, b = a.lower(), b.lower()
+    if a == b:
+        return True
+    return a in _GPU_ALIASES and b in _GPU_ALIASES
+
+
+def _on_device(arr, xp, device):
+    """Return whether ``arr`` lives on ``device`` according to its backend.
+
+    Asks each backend a structured question rather than parsing the
+    ``__repr__`` of a device object, so it doesn't break when a backend
+    changes how it prints devices.
+
+    Parameters
+    ----------
+    arr : array
+        An array produced by ``xp``.
+    xp : module
+        The array namespace that produced ``arr`` (e.g. ``numpy``,
+        ``jax.numpy``, ``torch``, ``cupy``).
+    device : str or None
+        The expected device: ``"cpu"``, ``"cuda"``, ``"gpu"``, or ``None``
+        (treated as ``"cpu"``).
+
+    Returns
+    -------
+    bool
+
+    Raises
+    ------
+    NotImplementedError
+        If ``xp`` is not a recognized backend.
+    """
+    backend = _get_backend_name(xp)
+    want_gpu = device is not None and device.lower() in _GPU_ALIASES
+    want_cpu = device is None or device.lower() == "cpu"
+
+    if backend == "numpy":
+        # NumPy is CPU-only; "cuda"/"gpu" never matches.
+        return want_cpu
+
+    if backend == "cupy":
+        # CuPy arrays are always on CUDA.
+        return want_gpu
+
+    if backend == "torch":
+        # arr.device.type is "cpu" or "cuda" (or "mps", etc.)
+        kind = arr.device.type
+        if want_cpu:
+            return kind == "cpu"
+        if want_gpu:
+            return kind == "cuda"
+        return False
+
+    if backend == "jax":
+        # JAX device objects expose .platform: "cpu", "gpu", or "tpu".
+        platform = arr.device.platform
+        if want_cpu:
+            return platform == "cpu"
+        if want_gpu:
+            return platform == "gpu"
+        return False
+
+    raise NotImplementedError(f"_on_device: unknown backend {backend!r}")
 
 
 def _read_env():
@@ -524,8 +577,7 @@ def _get_array_backends():
 
     The device strings stored here are each backend's *native* form — JAX uses
     ``"gpu"``, Torch and CuPy use ``"cuda"`` — because they get passed back to
-    the backend (e.g. via ``_move_to_device``). Use ``_normalize_device`` only
-    when comparing device specifiers across backends.
+    the backend (e.g. via ``_move_to_device``).
     """
     _backends = {"numpy": (np, ["cpu"])}
 
@@ -570,21 +622,19 @@ _BACKENDS = _get_array_backends()
 def _should_run(backend_name, device):
     """Check whether a backend/device combo should execute."""
     env_backend, env_device = _read_env()
-    norm_env = _normalize_device(env_device)
-    norm_dev = _normalize_device(device)
 
     if not env_backend:
         return backend_name == "numpy" and device == "cpu"
 
     if env_backend == "all":
-        if norm_env and norm_env != norm_dev:
+        if env_device and not _device_specs_match(env_device, device):
             return False
         return True
 
     if env_backend != backend_name:
         return False
 
-    if norm_env and norm_env != norm_dev:
+    if env_device and not _device_specs_match(env_device, device):
         return False
 
     return True
@@ -704,9 +754,13 @@ class ArrayAPITestMixin:
             f"Backend not preserved: result is {result_name}, expected {expected_name}",
         )
 
-        if device not in ("cpu", None) and hasattr(result, "device"):
-            self.assertEqual(
-                _normalize_device(result.device),
-                _normalize_device(device),
-                f"Device not preserved: result on {result.device}, expected {device}",
-            )
+        # Skip the device check on CPU: not every backend exposes a useful
+        # device attribute for CPU arrays, and CPU/CPU is the trivial case.
+        if device in (None, "cpu"):
+            return
+
+        self.assertTrue(
+            _on_device(result, xp, device),
+            f"Device not preserved: result on "
+            f"{getattr(result, 'device', '<unknown>')}, expected {device}",
+        )

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -479,6 +479,16 @@ def pytestrunner():
 # -------------------------------------------------------------------------------------
 
 
+_DEVICE_ALIASES = {"gpu": "cuda", "cuda": "cuda"}
+
+
+def _normalize_device(device):
+    """Canonicalize device name so that ``'gpu'`` and ``'cuda'`` are equivalent."""
+    if device is None:
+        return None
+    return _DEVICE_ALIASES.get(device.lower(), device.lower())
+
+
 def _read_env():
     """Read backend/device environment variables."""
     backend = os.environ.get("SKBIO_ARRAY_BACKEND", "").strip()
@@ -531,19 +541,21 @@ _BACKENDS = _get_array_backends()
 def _should_run(backend_name, device):
     """Check whether a backend/device combo should execute."""
     env_backend, env_device = _read_env()
+    norm_env = _normalize_device(env_device)
+    norm_dev = _normalize_device(device)
 
     if not env_backend:
         return backend_name == "numpy" and device == "cpu"
 
     if env_backend == "all":
-        if env_device and env_device != device:
+        if norm_env and norm_env != norm_dev:
             return False
         return True
 
     if env_backend != backend_name:
         return False
 
-    if env_device and env_device != device:
+    if norm_env and norm_env != norm_dev:
         return False
 
     return True
@@ -686,7 +698,4 @@ class ArrayAPITestMixin:
             )
 
     def _normalize_device(self, name):
-        name = str(name).lower()
-        if "cuda" in name or name == "gpu":
-            return "gpu"
-        return name
+        return _normalize_device(str(name))

--- a/skbio/util/tests/test_array.py
+++ b/skbio/util/tests/test_array.py
@@ -31,9 +31,23 @@ cp = get_package("cupy", raise_error=False)
 jax = get_package("jax", raise_error=False)
 torch = get_package("torch", raise_error=False)
 xr = get_package("xarray", raise_error=False)
-dask = get_package("dask", raise_error=False)
-if dask is not None:
-    da = get_package("dask.array")
+da = get_package("dask.array", raise_error=False)
+
+def _is_usable(mod, probe):
+    """Return True if `mod` is importable AND `probe()` runs without error."""
+    if mod is None:
+        return False
+    try:
+        probe()
+        return True
+    except Exception:
+        return False
+
+CUPY_OK = _is_usable(cp, lambda: cp.arange(1))
+TORCH_OK = _is_usable(torch, lambda: torch.arange(1))
+JAX_OK = _is_usable(jax, lambda: jax.numpy.arange(1))
+DASK_OK = _is_usable(da, lambda: da.arange(1, chunks=1).compute())
+XARRAY_OK = _is_usable(xr, lambda: xr.DataArray([1]))
 
 # Get the numpy namespace via array_api_compat (aac has no .numpy attribute).
 np_xp = aac.array_namespace(np.empty(0))
@@ -62,35 +76,35 @@ class TestGetArray(TestCase):
         obs = _get_array(arr, to_numpy=True)
         self.assertIs(obs, arr)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_kept_when_to_numpy_false(self):
         ten = torch.arange(5)
         obs = _get_array(ten)
         self.assertIsInstance(obs, torch.Tensor)
         self.assertIs(obs, ten)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_to_numpy_via_dlpack(self):
         ten = torch.arange(5)
         obs = _get_array(ten, to_numpy=True)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(cp is None, "CuPy is not available.")
+    @skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_to_numpy(self):
         arr = cp.arange(5)
         obs = _get_array(arr, to_numpy=True)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(jax is None, "JAX is not available.")
+    @skipIf(not JAX_OK, "JAX is not usable.")
     def test_jax_to_numpy(self):
         arr = jax.numpy.arange(5)
         obs = _get_array(arr, to_numpy=True)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(dask is None, "Dask is not available.")
+    @skipIf(not DASK_OK, "Dask is not usable.")
     def test_dask_to_numpy_fallback(self):
         # Dask doesn't support __dlpack__, so _get_array should fall back
         # to np.asarray.
@@ -140,7 +154,7 @@ class TestGetNamespaceFromArgs(TestCase):
         result = _get_namespace_from_args((a,), {"b": b})
         self.assertIs(result, np_xp)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_in_args(self):
         ten = torch.arange(3)
         result = _get_namespace_from_args((ten,), {})
@@ -171,12 +185,12 @@ class TestCheckArrayApiBackend(TestCase):
     def test_multiple_backends_allowed(self):
         _check_array_api_backend(np_xp, ["numpy", "torch"], "my_func")
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_allowed(self):
         xp = aac.array_namespace(torch.arange(1))
         _check_array_api_backend(xp, ["torch"], "my_func")
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_not_allowed_raises(self):
         xp = aac.array_namespace(torch.arange(1))
         with self.assertRaises(TypeError):
@@ -212,35 +226,35 @@ class TestToNumpy(TestCase):
         obs = _to_numpy(arr)
         self.assertIs(obs, arr)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_cpu(self):
         ten = torch.arange(5)
         obs = _to_numpy(ten)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_requires_grad(self):
         ten = torch.arange(5, dtype=torch.float32).requires_grad_(True)
         obs = _to_numpy(ten)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5, dtype=np.float32))
 
-    @skipIf(cp is None, "CuPy is not available.")
+    @skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy(self):
         arr = cp.arange(5)
         obs = _to_numpy(arr)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(jax is None, "JAX is not available.")
+    @skipIf(not JAX_OK, "JAX is not usable.")
     def test_jax(self):
         arr = jax.numpy.arange(5)
         obs = _to_numpy(arr)
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(dask is None, "Dask is not available.")
+    @skipIf(not DASK_OK, "Dask is not usable.")
     def test_dask(self):
         arr = da.arange(5, chunks=5)
         obs = _to_numpy(arr)
@@ -274,14 +288,14 @@ class TestMoveToDevice(TestCase):
         obs = _move_to_device(arr, np, "cpu")
         self.assertIs(obs, arr)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_cpu_noop(self):
         ten = torch.arange(5)
         obs = _move_to_device(ten, torch, "cpu")
         self.assertIs(obs, ten)
 
-    @skipIf(torch is None or not torch.cuda.is_available(),
-            "PyTorch CUDA is not available.")
+    @skipIf(not TORCH_OK or not torch.cuda.is_available(),
+            "PyTorch CUDA is not usable.")
     def test_torch_cuda(self):
         ten = torch.arange(5)
         obs = _move_to_device(ten, torch, "cuda")
@@ -294,14 +308,14 @@ class TestMoveToDevice(TestCase):
         obs = _move_to_device(arr, np, "gpu")
         self.assertIs(obs, arr)
 
-    @skipIf(cp is None, "CuPy is not available.")
+    @skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_non_cpu_passthrough(self):
         import cupy
         arr = cupy.arange(5)
         obs = _move_to_device(arr, cupy, "gpu")
         self.assertIs(obs, arr)
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_to_device(self):
         # torch.to("cpu") should work and return a CPU tensor.
         ten = torch.arange(5)
@@ -322,22 +336,22 @@ class TestGetBackendName(TestCase):
     def test_numpy(self):
         self.assertEqual(_get_backend_name(np_xp), "numpy")
 
-    @skipIf(torch is None, "PyTorch is not available.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch(self):
         xp = aac.array_namespace(torch.arange(1))
         self.assertEqual(_get_backend_name(xp), "torch")
 
-    @skipIf(cp is None, "CuPy is not available.")
+    @skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy(self):
         xp = aac.array_namespace(cp.arange(1))
         self.assertEqual(_get_backend_name(xp), "cupy")
 
-    @skipIf(jax is None, "JAX is not available.")
+    @skipIf(not JAX_OK, "JAX is not usable.")
     def test_jax(self):
         xp = aac.array_namespace(jax.numpy.arange(1))
         self.assertEqual(_get_backend_name(xp), "jax")
 
-    @skipIf(dask is None, "Dask is not available.")
+    @skipIf(not DASK_OK, "Dask is not usable.")
     def test_dask(self):
         xp = aac.array_namespace(da.arange(1, chunks=1))
         self.assertEqual(_get_backend_name(xp), "dask")
@@ -420,7 +434,7 @@ class TestIngestArray(TestCase):
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.asarray(arr))
 
-    @skipIf(cp is None, "CuPy is not available for unit tests.")
+    @skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_ingest_array_cupy(self):
         # CuPy arrays are kept as-is in default mode.
         arr = cp.arange(5)
@@ -436,7 +450,7 @@ class TestIngestArray(TestCase):
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(torch is None, "PyTorch is not available for unit tests.")
+    @skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_ingest_array_torch(self):
         # PyTorch tensors are kept as-is in default mode.
         ten = torch.arange(5)
@@ -452,7 +466,7 @@ class TestIngestArray(TestCase):
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(jax is None, "JAX is not available for unit tests.")
+    @skipIf(not JAX_OK, "JAX is not usable.")
     def test_ingest_array_jax(self):
         # JAX arrays are kept as-is in default mode.
         arr = jax.numpy.arange(5)
@@ -468,7 +482,7 @@ class TestIngestArray(TestCase):
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(obs, np.arange(5))
 
-    @skipIf(dask is None, "Dask is not available for unit tests.")
+    @skipIf(not DASK_OK, "Dask is not usable.")
     def test_ingest_array_dask(self):
         # Dask arrays are kept as-is in default mode.
         arr = da.arange(20, chunks=4)
@@ -521,7 +535,7 @@ class TestIngestArray(TestCase):
         self.assertIsInstance(obs, np.ndarray)
         npt.assert_array_equal(df.to_numpy(), np.arange(5).reshape(-1, 1))
 
-    @skipIf(xr is None, "Xarray is not available for unit tests.")
+    @skipIf(not XARRAY_OK, "Xarray is not usable.")
     def test_ingest_array_xarray(self):
         # Xarray DataArrays are not API-compatible arrays, but they can be casted into
         # Numpy arrays.

--- a/skbio/util/tests/test_array.py
+++ b/skbio/util/tests/test_array.py
@@ -14,7 +14,7 @@ import pandas as pd
 import numpy.testing as npt
 import array_api_compat as aac
 
-from skbio.util import get_package
+from skbio.util import get_package, _is_usable
 from skbio.util._array import (
     ingest_array,
     _get_array,
@@ -25,23 +25,12 @@ from skbio.util._array import (
     _get_backend_name,
 )
 
-
 # import optional dependencies
 cp = get_package("cupy", raise_error=False)
 jax = get_package("jax", raise_error=False)
 torch = get_package("torch", raise_error=False)
 xr = get_package("xarray", raise_error=False)
 da = get_package("dask.array", raise_error=False)
-
-def _is_usable(mod, probe):
-    """Return True if `mod` is importable AND `probe()` runs without error."""
-    if mod is None:
-        return False
-    try:
-        probe()
-        return True
-    except Exception:
-        return False
 
 CUPY_OK = _is_usable(cp, lambda: cp.arange(1))
 TORCH_OK = _is_usable(torch, lambda: torch.arange(1))

--- a/skbio/util/tests/test_array.py
+++ b/skbio/util/tests/test_array.py
@@ -18,8 +18,6 @@ from skbio.util import get_package, _is_usable
 from skbio.util._array import (
     ingest_array,
     _get_array,
-    _get_namespace_from_args,
-    _check_array_api_backend,
     _to_numpy,
     _move_to_device,
     _get_backend_name,
@@ -114,93 +112,6 @@ class TestGetArray(TestCase):
                     patch("skbio.util._array.np.from_dlpack", side_effect=exc):
                     obs = _get_array(FakeArr(), to_numpy=True)
                 self.assertIsInstance(obs, np.ndarray)
-
-
-# =====================================================================
-# Tests for _get_namespace_from_args
-# =====================================================================
-
-
-class TestGetNamespaceFromArgs(TestCase):
-
-    def test_no_arrays_returns_none(self):
-        result = _get_namespace_from_args((1, "hello", [1, 2]), {})
-        self.assertIsNone(result)
-
-    def test_numpy_in_args(self):
-        arr = np.arange(3)
-        result = _get_namespace_from_args((arr,), {})
-        self.assertIs(result, np_xp)
-
-    def test_numpy_in_kwargs(self):
-        arr = np.arange(3)
-        result = _get_namespace_from_args((), {"x": arr})
-        self.assertIs(result, np_xp)
-
-    def test_mixed_args_and_kwargs(self):
-        a = np.arange(3)
-        b = np.ones(3)
-        result = _get_namespace_from_args((a,), {"b": b})
-        self.assertIs(result, np_xp)
-
-    @skipIf(not TORCH_OK, "PyTorch is not usable.")
-    def test_torch_in_args(self):
-        ten = torch.arange(3)
-        result = _get_namespace_from_args((ten,), {})
-        self.assertTrue(aac.is_torch_namespace(result))
-
-    def test_empty_args_and_kwargs(self):
-        result = _get_namespace_from_args((), {})
-        self.assertIsNone(result)
-
-
-# =====================================================================
-# Tests for _check_array_api_backend
-# =====================================================================
-
-
-class TestCheckArrayApiBackend(TestCase):
-
-    def test_numpy_allowed(self):
-        # Should not raise.
-        _check_array_api_backend(np_xp, ["numpy"], "my_func")
-
-    def test_numpy_not_allowed_raises(self):
-        with self.assertRaises(TypeError) as ctx:
-            _check_array_api_backend(np_xp, ["torch"], "my_func")
-        self.assertIn("my_func", str(ctx.exception))
-        self.assertIn("torch", str(ctx.exception))
-
-    def test_multiple_backends_allowed(self):
-        _check_array_api_backend(np_xp, ["numpy", "torch"], "my_func")
-
-    @skipIf(not TORCH_OK, "PyTorch is not usable.")
-    def test_torch_allowed(self):
-        xp = aac.array_namespace(torch.arange(1))
-        _check_array_api_backend(xp, ["torch"], "my_func")
-
-    @skipIf(not TORCH_OK, "PyTorch is not usable.")
-    def test_torch_not_allowed_raises(self):
-        xp = aac.array_namespace(torch.arange(1))
-        with self.assertRaises(TypeError):
-            _check_array_api_backend(xp, ["numpy"], "my_func")
-
-    def test_unknown_backend_in_list_ignored(self):
-        # "unknown_backend" isn't in _BACKEND_CHECKERS, so checker is None.
-        # numpy is also listed, so this should pass.
-        _check_array_api_backend(np_xp, ["unknown_backend", "numpy"], "f")
-
-    def test_only_unknown_backend_raises(self):
-        # No checker matches numpy if only "unknown_backend" is listed.
-        with self.assertRaises(TypeError):
-            _check_array_api_backend(np_xp, ["unknown_backend"], "f")
-
-    def test_error_message_lists_supported(self):
-        with self.assertRaises(TypeError) as ctx:
-            _check_array_api_backend(np_xp, ["torch", "jax"], "compute")
-        msg = str(ctx.exception)
-        self.assertIn("compute", msg)
-        self.assertIn("torch, jax", msg)
 
 
 # =====================================================================

--- a/skbio/util/tests/test_optionals.py
+++ b/skbio/util/tests/test_optionals.py
@@ -11,7 +11,7 @@ import importlib
 
 from unittest import mock
 
-from skbio.util import get_package
+from skbio.util import get_package, _is_usable
 
 
 class TestGetPackage(TestCase):
@@ -37,6 +37,23 @@ class TestGetPackage(TestCase):
             with self.assertRaises(ImportError) as cm:
                 get_package("polars")
             self.assertEqual(str(cm.exception), msg)
+
+
+class TestIsUsable(TestCase):
+    def test_returns_false_when_mod_is_none(self):
+        assert _is_usable(None, lambda: "anything") is False
+
+    def test_returns_true_when_probe_succeeds(self):
+        mod = mock.MagicMock()
+        probe = mock.MagicMock(return_value="ok")
+        assert _is_usable(mod, probe) is True
+        probe.assert_called_once()
+
+    def test_returns_false_when_probe_raises(self):
+        mod = mock.MagicMock()
+        def probe():
+            raise RuntimeError("boom")
+        assert _is_usable(mod, probe) is False
 
 
 if __name__ == "__main__":

--- a/skbio/util/tests/test_testing.py
+++ b/skbio/util/tests/test_testing.py
@@ -790,10 +790,11 @@ class TestArrayAPITestMixin(unittest.TestCase, ArrayAPITestMixin):
             self.assert_close(a, b)
 
     def test_normalize_device(self):
-        self.assertEqual(self._normalize_device('cuda:0'), 'gpu')
-        self.assertEqual(self._normalize_device('gpu'), 'gpu')
-        self.assertEqual(self._normalize_device('CUDA'), 'gpu')
-        self.assertEqual(self._normalize_device('cpu'), 'cpu')
+        self.assertEqual(_normalize_device('cuda:0'), 'cuda')
+        self.assertEqual(_normalize_device('gpu'), 'cuda')
+        self.assertEqual(_normalize_device('CUDA'), 'cuda')
+        self.assertEqual(_normalize_device('cpu'), 'cpu')
+        self.assertIsNone(_normalize_device(None))
 
 
 if __name__ == '__main__':

--- a/skbio/util/tests/test_testing.py
+++ b/skbio/util/tests/test_testing.py
@@ -34,6 +34,7 @@ from skbio.util._testing import (
     xp_assert_equal,
     array_backends,
     ArrayAPITestMixin,
+    _device_specs_match
 )
 
 
@@ -789,12 +790,27 @@ class TestArrayAPITestMixin(unittest.TestCase, ArrayAPITestMixin):
         with self.assertRaises(AssertionError):
             self.assert_close(a, b)
 
-    def test_normalize_device(self):
-        self.assertEqual(_normalize_device('cuda:0'), 'cuda')
-        self.assertEqual(_normalize_device('gpu'), 'cuda')
-        self.assertEqual(_normalize_device('CUDA'), 'cuda')
-        self.assertEqual(_normalize_device('cpu'), 'cpu')
-        self.assertIsNone(_normalize_device(None))
+    def test_device_specs_match(self):
+        # Same string matches itself.
+        self.assertTrue(_device_specs_match('cuda', 'cuda'))
+        self.assertTrue(_device_specs_match('cpu', 'cpu'))
+
+        # GPU aliases match each other.
+        self.assertTrue(_device_specs_match('gpu', 'cuda'))
+        self.assertTrue(_device_specs_match('cuda', 'gpu'))
+
+        # Case-insensitive.
+        self.assertTrue(_device_specs_match('CUDA', 'cuda'))
+        self.assertTrue(_device_specs_match('GPU', 'CUDA'))
+
+        # Different hardware doesn't match.
+        self.assertFalse(_device_specs_match('cpu', 'cuda'))
+        self.assertFalse(_device_specs_match('cpu', 'gpu'))
+
+        # None handling: matches only None.
+        self.assertTrue(_device_specs_match(None, None))
+        self.assertFalse(_device_specs_match(None, 'cpu'))
+        self.assertFalse(_device_specs_match('cuda', None))
 
 
 if __name__ == '__main__':

--- a/skbio/util/tests/test_testing.py
+++ b/skbio/util/tests/test_testing.py
@@ -14,10 +14,11 @@ from unittest.mock import patch
 import pandas as pd
 import numpy as np
 import numpy.testing as npt
+import array_api_compat as aac
 
 from skbio import OrdinationResults
 from skbio.util import (get_data_path, assert_ordination_results_equal,
-                        assert_data_frame_almost_equal)
+                        assert_data_frame_almost_equal, get_package, _is_usable)
 from skbio.util._testing import (
     _normalize_signs,
     assert_series_almost_equal,
@@ -34,8 +35,24 @@ from skbio.util._testing import (
     xp_assert_equal,
     array_backends,
     ArrayAPITestMixin,
-    _device_specs_match
+    _device_specs_match,
+    _on_device
 )
+
+# import optional dependencies
+cp = get_package("cupy", raise_error=False)
+jax = get_package("jax", raise_error=False)
+torch = get_package("torch", raise_error=False)
+xr = get_package("xarray", raise_error=False)
+da = get_package("dask.array", raise_error=False)
+
+CUPY_OK = _is_usable(cp, lambda: cp.arange(1))
+TORCH_OK = _is_usable(torch, lambda: torch.arange(1))
+JAX_OK = _is_usable(jax, lambda: jax.numpy.arange(1))
+DASK_OK = _is_usable(da, lambda: da.arange(1, chunks=1).compute())
+XARRAY_OK = _is_usable(xr, lambda: xr.DataArray([1]))
+
+np_xp = aac.array_namespace(np.empty(0))
 
 
 class TestGetDataPath(unittest.TestCase):
@@ -812,6 +829,131 @@ class TestArrayAPITestMixin(unittest.TestCase, ArrayAPITestMixin):
         self.assertFalse(_device_specs_match(None, 'cpu'))
         self.assertFalse(_device_specs_match('cuda', None))
 
+class TestOnDevice(unittest.TestCase):
+    """Tests for ``_on_device``."""
+
+    # ---- NumPy: always CPU ----
+
+    def test_numpy_cpu_matches(self):
+        arr = np.arange(5)
+        self.assertTrue(_on_device(arr, np_xp, "cpu"))
+
+    def test_numpy_none_matches(self):
+        # None is treated as "cpu".
+        arr = np.arange(5)
+        self.assertTrue(_on_device(arr, np_xp, None))
+
+    def test_numpy_cuda_does_not_match(self):
+        arr = np.arange(5)
+        self.assertFalse(_on_device(arr, np_xp, "cuda"))
+
+    def test_numpy_gpu_does_not_match(self):
+        arr = np.arange(5)
+        self.assertFalse(_on_device(arr, np_xp, "gpu"))
+
+    # ---- CuPy: always GPU ----
+
+    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
+    def test_cupy_cuda_matches(self):
+        arr = cp.arange(5)
+        xp = aac.array_namespace(arr)
+        self.assertTrue(_on_device(arr, xp, "cuda"))
+
+    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
+    def test_cupy_gpu_matches(self):
+        # "gpu" is an alias for "cuda".
+        arr = cp.arange(5)
+        xp = aac.array_namespace(arr)
+        self.assertTrue(_on_device(arr, xp, "gpu"))
+
+    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
+    def test_cupy_cpu_does_not_match(self):
+        arr = cp.arange(5)
+        xp = aac.array_namespace(arr)
+        self.assertFalse(_on_device(arr, xp, "cpu"))
+
+    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
+    def test_cupy_none_does_not_match(self):
+        arr = cp.arange(5)
+        xp = aac.array_namespace(arr)
+        self.assertFalse(_on_device(arr, xp, None))
+
+    # ---- PyTorch: inspects arr.device.type ----
+
+    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
+    def test_torch_cpu_matches(self):
+        ten = torch.arange(5)  # default device is cpu
+        xp = aac.array_namespace(ten)
+        self.assertTrue(_on_device(ten, xp, "cpu"))
+
+    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
+    def test_torch_none_matches_cpu(self):
+        ten = torch.arange(5)
+        xp = aac.array_namespace(ten)
+        self.assertTrue(_on_device(ten, xp, None))
+
+    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
+    def test_torch_cpu_does_not_match_cuda(self):
+        ten = torch.arange(5)
+        xp = aac.array_namespace(ten)
+        self.assertFalse(_on_device(ten, xp, "cuda"))
+
+    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
+            "PyTorch CUDA is not usable.")
+    def test_torch_cuda_matches(self):
+        ten = torch.arange(5).to("cuda")
+        xp = aac.array_namespace(ten)
+        self.assertTrue(_on_device(ten, xp, "cuda"))
+
+    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
+            "PyTorch CUDA is not usable.")
+    def test_torch_cuda_matches_gpu_alias(self):
+        ten = torch.arange(5).to("cuda")
+        xp = aac.array_namespace(ten)
+        self.assertTrue(_on_device(ten, xp, "gpu"))
+
+    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
+            "PyTorch CUDA is not usable.")
+    def test_torch_cuda_does_not_match_cpu(self):
+        ten = torch.arange(5).to("cuda")
+        xp = aac.array_namespace(ten)
+        self.assertFalse(_on_device(ten, xp, "cpu"))
+
+    # ---- JAX: inspects arr.device.platform ----
+
+    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
+    def test_jax_cpu_matches(self):
+        arr = jax.numpy.arange(5)
+        xp = aac.array_namespace(arr)
+        # JAX defaults to whatever device is available; on CPU-only
+        # machines this is "cpu".
+        if arr.device.platform == "cpu":
+            self.assertTrue(_on_device(arr, xp, "cpu"))
+
+    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
+    def test_jax_none_matches_cpu(self):
+        arr = jax.numpy.arange(5)
+        xp = aac.array_namespace(arr)
+        if arr.device.platform == "cpu":
+            self.assertTrue(_on_device(arr, xp, None))
+
+    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
+    def test_jax_gpu_when_cpu_does_not_match(self):
+        arr = jax.numpy.arange(5)
+        xp = aac.array_namespace(arr)
+        if arr.device.platform == "cpu":
+            self.assertFalse(_on_device(arr, xp, "gpu"))
+            self.assertFalse(_on_device(arr, xp, "cuda"))
+
+    # ---- Unknown backend ----
+
+    def test_unknown_backend_raises(self):
+        # Build a fake namespace that _get_backend_name doesn't recognize.
+        class FakeXP:
+            __name__ = "not_a_real_array_lib"
+
+        with self.assertRaises(NotImplementedError):
+            _on_device(np.arange(1), FakeXP(), "cpu")
 
 if __name__ == '__main__':
     unittest.main()

--- a/skbio/util/tests/test_testing.py
+++ b/skbio/util/tests/test_testing.py
@@ -10,6 +10,7 @@ import os
 import itertools
 import unittest
 from unittest.mock import patch
+from types import SimpleNamespace
 
 import pandas as pd
 import numpy as np
@@ -39,21 +40,7 @@ from skbio.util._testing import (
     _on_device
 )
 
-# import optional dependencies
-cp = get_package("cupy", raise_error=False)
-jax = get_package("jax", raise_error=False)
-torch = get_package("torch", raise_error=False)
-xr = get_package("xarray", raise_error=False)
-da = get_package("dask.array", raise_error=False)
-
-CUPY_OK = _is_usable(cp, lambda: cp.arange(1))
-TORCH_OK = _is_usable(torch, lambda: torch.arange(1))
-JAX_OK = _is_usable(jax, lambda: jax.numpy.arange(1))
-DASK_OK = _is_usable(da, lambda: da.arange(1, chunks=1).compute())
-XARRAY_OK = _is_usable(xr, lambda: xr.DataArray([1]))
-
 np_xp = aac.array_namespace(np.empty(0))
-
 
 class TestGetDataPath(unittest.TestCase):
     def test_get_data_path(self):
@@ -830,16 +817,16 @@ class TestArrayAPITestMixin(unittest.TestCase, ArrayAPITestMixin):
         self.assertFalse(_device_specs_match('cuda', None))
 
 class TestOnDevice(unittest.TestCase):
-    """Tests for ``_on_device``."""
+    """Tests for ``_on_device``. Uses mocking so it runs without optional
+    backends installed."""
 
-    # ---- NumPy: always CPU ----
+    # ---- NumPy: no mocking needed, numpy is always available ----
 
     def test_numpy_cpu_matches(self):
         arr = np.arange(5)
         self.assertTrue(_on_device(arr, np_xp, "cpu"))
 
     def test_numpy_none_matches(self):
-        # None is treated as "cpu".
         arr = np.arange(5)
         self.assertTrue(_on_device(arr, np_xp, None))
 
@@ -851,109 +838,97 @@ class TestOnDevice(unittest.TestCase):
         arr = np.arange(5)
         self.assertFalse(_on_device(arr, np_xp, "gpu"))
 
-    # ---- CuPy: always GPU ----
+    # ---- CuPy: always GPU. Mock the backend name. ----
 
-    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_cuda_matches(self):
-        arr = cp.arange(5)
-        xp = aac.array_namespace(arr)
-        self.assertTrue(_on_device(arr, xp, "cuda"))
+        fake_xp = object()
+        fake_arr = object()
+        with patch("skbio.util._testing._get_backend_name", return_value="cupy"):
+            self.assertTrue(_on_device(fake_arr, fake_xp, "cuda"))
 
-    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_gpu_matches(self):
-        # "gpu" is an alias for "cuda".
-        arr = cp.arange(5)
-        xp = aac.array_namespace(arr)
-        self.assertTrue(_on_device(arr, xp, "gpu"))
+        fake_xp = object()
+        fake_arr = object()
+        with patch("skbio.util._testing._get_backend_name", return_value="cupy"):
+            self.assertTrue(_on_device(fake_arr, fake_xp, "gpu"))
 
-    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_cpu_does_not_match(self):
-        arr = cp.arange(5)
-        xp = aac.array_namespace(arr)
-        self.assertFalse(_on_device(arr, xp, "cpu"))
+        fake_xp = object()
+        fake_arr = object()
+        with patch("skbio.util._testing._get_backend_name", return_value="cupy"):
+            self.assertFalse(_on_device(fake_arr, fake_xp, "cpu"))
 
-    @unittest.skipIf(not CUPY_OK, "CuPy is not usable.")
     def test_cupy_none_does_not_match(self):
-        arr = cp.arange(5)
-        xp = aac.array_namespace(arr)
-        self.assertFalse(_on_device(arr, xp, None))
+        fake_xp = object()
+        fake_arr = object()
+        with patch("skbio.util._testing._get_backend_name", return_value="cupy"):
+            self.assertFalse(_on_device(fake_arr, fake_xp, None))
 
     # ---- PyTorch: inspects arr.device.type ----
 
-    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_cpu_matches(self):
-        ten = torch.arange(5)  # default device is cpu
-        xp = aac.array_namespace(ten)
-        self.assertTrue(_on_device(ten, xp, "cpu"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertTrue(_on_device(fake_arr, object(), "cpu"))
 
-    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
-    def test_torch_none_matches_cpu(self):
-        ten = torch.arange(5)
-        xp = aac.array_namespace(ten)
-        self.assertTrue(_on_device(ten, xp, None))
+    def test_torch_cpu_none_matches(self):
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertTrue(_on_device(fake_arr, object(), None))
 
-    @unittest.skipIf(not TORCH_OK, "PyTorch is not usable.")
     def test_torch_cpu_does_not_match_cuda(self):
-        ten = torch.arange(5)
-        xp = aac.array_namespace(ten)
-        self.assertFalse(_on_device(ten, xp, "cuda"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertFalse(_on_device(fake_arr, object(), "cuda"))
 
-    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
-            "PyTorch CUDA is not usable.")
     def test_torch_cuda_matches(self):
-        ten = torch.arange(5).to("cuda")
-        xp = aac.array_namespace(ten)
-        self.assertTrue(_on_device(ten, xp, "cuda"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cuda"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertTrue(_on_device(fake_arr, object(), "cuda"))
 
-    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
-            "PyTorch CUDA is not usable.")
     def test_torch_cuda_matches_gpu_alias(self):
-        ten = torch.arange(5).to("cuda")
-        xp = aac.array_namespace(ten)
-        self.assertTrue(_on_device(ten, xp, "gpu"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cuda"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertTrue(_on_device(fake_arr, object(), "gpu"))
 
-    @unittest.skipIf(not TORCH_OK or not torch.cuda.is_available(),
-            "PyTorch CUDA is not usable.")
     def test_torch_cuda_does_not_match_cpu(self):
-        ten = torch.arange(5).to("cuda")
-        xp = aac.array_namespace(ten)
-        self.assertFalse(_on_device(ten, xp, "cpu"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(type="cuda"))
+        with patch("skbio.util._testing._get_backend_name", return_value="torch"):
+            self.assertFalse(_on_device(fake_arr, object(), "cpu"))
 
     # ---- JAX: inspects arr.device.platform ----
 
-    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
     def test_jax_cpu_matches(self):
-        arr = jax.numpy.arange(5)
-        xp = aac.array_namespace(arr)
-        # JAX defaults to whatever device is available; on CPU-only
-        # machines this is "cpu".
-        if arr.device.platform == "cpu":
-            self.assertTrue(_on_device(arr, xp, "cpu"))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(platform="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="jax"):
+            self.assertTrue(_on_device(fake_arr, object(), "cpu"))
 
-    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
     def test_jax_none_matches_cpu(self):
-        arr = jax.numpy.arange(5)
-        xp = aac.array_namespace(arr)
-        if arr.device.platform == "cpu":
-            self.assertTrue(_on_device(arr, xp, None))
+        fake_arr = SimpleNamespace(device=SimpleNamespace(platform="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="jax"):
+            self.assertTrue(_on_device(fake_arr, object(), None))
 
-    @unittest.skipIf(not JAX_OK, "JAX is not usable.")
-    def test_jax_gpu_when_cpu_does_not_match(self):
-        arr = jax.numpy.arange(5)
-        xp = aac.array_namespace(arr)
-        if arr.device.platform == "cpu":
-            self.assertFalse(_on_device(arr, xp, "gpu"))
-            self.assertFalse(_on_device(arr, xp, "cuda"))
+    def test_jax_gpu_matches(self):
+        fake_arr = SimpleNamespace(device=SimpleNamespace(platform="gpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="jax"):
+            self.assertTrue(_on_device(fake_arr, object(), "gpu"))
 
-    # ---- Unknown backend ----
+    def test_jax_gpu_matches_cuda_alias(self):
+        fake_arr = SimpleNamespace(device=SimpleNamespace(platform="gpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="jax"):
+            self.assertTrue(_on_device(fake_arr, object(), "cuda"))
+
+    def test_jax_cpu_does_not_match_gpu(self):
+        fake_arr = SimpleNamespace(device=SimpleNamespace(platform="cpu"))
+        with patch("skbio.util._testing._get_backend_name", return_value="jax"):
+            self.assertFalse(_on_device(fake_arr, object(), "gpu"))
+
+    # ---- Unknown backend raises ----
 
     def test_unknown_backend_raises(self):
-        # Build a fake namespace that _get_backend_name doesn't recognize.
-        class FakeXP:
-            __name__ = "not_a_real_array_lib"
-
-        with self.assertRaises(NotImplementedError):
-            _on_device(np.arange(1), FakeXP(), "cpu")
+        with patch("skbio.util._testing._get_backend_name", return_value="weird_lib"):
+            with self.assertRaises(NotImplementedError):
+                _on_device(object(), object(), "cpu")
 
 if __name__ == '__main__':
     unittest.main()

--- a/web/contribute.rst
+++ b/web/contribute.rst
@@ -34,6 +34,7 @@ In addition, there are separate documents covering advanced topics:
    devdoc/new_module
    devdoc/review
    devdoc/release
+   devdoc/array_api
 
 
 Ask a question
@@ -283,6 +284,11 @@ Alternatively, you may run all unit tests in a Python session (including Jupyter
 
     >>> from skbio.test import pytestrunner
     >>> pytestrunner()
+
+GPU Tests
+.........
+
+If you are incorporating Python Array API support or GPU support into scikit-bio, please review the :doc:`devdoc/array_api` page for specific information.
 
 Code coverage
 ^^^^^^^^^^^^^

--- a/web/devdoc/array_api.rst
+++ b/web/devdoc/array_api.rst
@@ -1,0 +1,217 @@
+Array API and GPU support
+=========================
+
+Scikit-bio is gradually adopting the `Python array API standard
+<https://data-apis.org/array-api/latest/>`_ to allow functions to work
+across multiple array libraries (NumPy, PyTorch, JAX, CuPy) and run on
+GPUs where supported. This page covers what contributors need to know
+to write, test, and run array-API-compatible code.
+
+Overview
+--------
+
+The array API standard defines a common interface that several array
+libraries implement. Functions written against this standard accept
+arrays from any compliant library and dispatch to that library's
+implementation — meaning the same function can run on CPU via NumPy,
+on GPU via PyTorch or CuPy, or on TPU via JAX.
+
+Currently supported backends:
+
+- **numpy** (CPU only) — the default, always available
+- **torch** — CPU or CUDA
+- **jax** — CPU or GPU
+- **cupy** — CUDA only
+
+Only a small fraction of scikit-bio currently has array-API support.
+Most functions still operate on NumPy arrays exclusively. This is being
+expanded over time.
+
+
+Writing array-API-compatible library code
+-----------------------------------------
+
+Use ``ingest_array`` at function entry points to obtain the array
+namespace (``xp``) and a converted array:
+
+.. code-block:: python
+
+   from skbio.util._array import ingest_array
+
+   def my_function(arr):
+       xp, arr = ingest_array(arr)
+       result = xp.sum(arr, axis=0)
+       return result
+
+The returned ``xp`` is the namespace corresponding to the input array's
+backend. Use ``xp.func()`` for all array operations rather than
+``np.func()`` — this is what makes the function backend-agnostic.
+
+If a function only supports certain backends, declare them explicitly:
+
+.. code-block:: python
+
+   from skbio.util._array import _check_array_api_backend
+
+   def my_function(arr):
+       xp, arr = ingest_array(arr)
+       _check_array_api_backend(xp, ["numpy", "torch"], "my_function")
+       ...
+
+This raises ``TypeError`` for unsupported backends with a clear error
+message.
+
+**Things to avoid:**
+
+- Hardcoded ``np.func()`` calls (use ``xp.func()`` instead)
+- Backend-specific methods like ``arr.numpy()`` or ``arr.get()``
+- In-place modification (JAX arrays are immutable)
+- Assuming ``float64`` is the default dtype (PyTorch defaults to
+  ``float32``)
+
+
+Writing tests for array-API code
+--------------------------------
+
+Tests that exercise array-API code paths use the
+``ArrayAPITestMixin`` and the ``@array_backends`` decorator. Write the
+test once; the decorator runs it across every supported backend:
+
+.. code-block:: python
+
+   from unittest import TestCase
+   from skbio.util._testing import ArrayAPITestMixin, array_backends
+
+   class TestMyFunction(TestCase, ArrayAPITestMixin):
+
+       @array_backends("numpy", "torch", "jax", "cupy")
+       def test_my_function(self, xp, device):
+           data = [[1.0, 2.0], [3.0, 4.0]]
+           arr = self.make_array(xp, device, data)
+           result = my_function(arr)
+           expected = self.make_array(xp, device, [[4.0, 6.0]])
+           self.assert_close(result, expected)
+           self.assert_type_preserved(result, xp, device)
+
+The decorator injects ``xp`` (the array namespace) and ``device`` (the
+target device) into the test method. ``ArrayAPITestMixin`` provides:
+
+- ``make_array(xp, device, data)`` — create a test array on the right
+  backend and device
+- ``assert_close(actual, expected)`` — numerical comparison that works
+  across backends
+- ``assert_type_preserved(result, xp, device)`` — verify the result
+  came back on the expected backend and device
+
+**When to use ``@array_backends``:** decorate tests that exercise the
+array computation itself. Tests for input validation, error handling,
+or pure-Python logic don't need it — those should remain standard
+``TestCase`` methods.
+
+
+Running tests locally
+---------------------
+
+Two environment variables control which backend and device tests use:
+
+- ``SKBIO_ARRAY_BACKEND``: ``numpy`` (default), ``torch``, ``jax``,
+  ``cupy``, or ``all``
+- ``SKBIO_DEVICE``: ``cpu`` (default), ``cuda``, or ``gpu``
+
+Common invocations:
+
+.. code-block:: bash
+
+   # Default: numpy on CPU
+   pytest skbio/stats/composition/tests/test_base.py
+
+   # Single backend on CPU (no GPU needed)
+   SKBIO_ARRAY_BACKEND=torch pytest skbio/stats/composition/tests/test_base.py
+
+   # All available backends on CPU and GPU (if available)
+   SKBIO_ARRAY_BACKEND=all pytest skbio/stats/composition/tests/test_base.py
+
+   # Run only array-API tests across the package
+   pytest -m array_api skbio/
+
+   # GPU run (requires CUDA-capable hardware)
+   SKBIO_ARRAY_BACKEND=torch SKBIO_DEVICE=cuda pytest -m array_api skbio/
+
+Tests for unavailable backends skip cleanly — you don't need every
+backend installed. CuPy is GPU-only and will skip on machines without
+CUDA.
+
+The ``-m array_api`` marker filters to tests decorated with
+``@array_backends``. Without it, pytest runs the full suite.
+
+
+Continuous integration
+----------------------
+
+GPU testing happens in the ``Array API Compatibility`` workflow
+(``.github/workflows/array-api.yml``), which runs on a T4 GPU runner
+against the ``torch``, ``jax``, and ``cupy`` backends with CUDA.
+
+**Triggers:**
+
+- **Weekly cron**: every Monday at 06:00 UTC, catching regressions
+  from upstream changes in array libraries
+- **Manual dispatch**: via the Actions tab on GitHub
+- **``gpu-ci`` label on a PR**: applies the label to a PR to trigger
+  the workflow; pushes to the labeled PR will re-trigger it
+
+Reviewers should apply the ``gpu-ci`` label to any PR that modifies
+array-API code paths. Most PRs do not need GPU validation and the
+workflow has a non-trivial cost, so it is not run on every PR
+automatically.
+
+**What the workflow verifies:**
+
+- Each backend installs successfully with CUDA support
+- The GPU is visible to each backend at import time
+- Decorated tests pass with arrays placed on CUDA, and results remain
+  on CUDA after computation
+
+**What it does not verify:**
+
+- Code paths not covered by ``@array_backends``-decorated tests
+- Subtle silent CPU fallback within individual operations
+- Correctness on GPU architectures other than T4
+
+
+Backend-specific gotchas
+------------------------
+
+A few cross-backend differences come up often enough to call out:
+
+**PyTorch**
+
+- Defaults to ``float32``, not ``float64``. Specify dtypes explicitly
+  if precision matters.
+- Tensors with ``requires_grad=True`` cannot be converted directly to
+  NumPy; ``_to_numpy`` handles this by calling ``.detach()``.
+
+**JAX**
+
+- Arrays are immutable. In-place updates (``arr[i] = x``) raise an
+  error; use ``arr.at[i].set(x)`` instead.
+- Silently falls back to CPU if no GPU is detected at import time.
+  Always check ``jax.devices("gpu")`` before assuming GPU execution.
+- Uses ``"gpu"`` as its device string where Torch and CuPy use
+  ``"cuda"``. These are treated as equivalent by
+  ``_device_specs_match``.
+
+**CuPy**
+
+- GPU-only — there is no CPU mode. ``cupy.ndarray`` is always on a
+  CUDA device.
+- Requires a CUDA driver matching the installed CuPy build (e.g.
+  ``cupy-cuda12x`` requires a CUDA 12-capable driver).
+
+**General**
+
+- Integer division and dtype promotion rules differ subtly across
+  backends. When in doubt, cast explicitly.
+- Some array API standard functions are unimplemented in certain
+  backends. Check the library's documentation if you hit
+  ``AttributeError`` on ``xp``.

--- a/web/devdoc/array_api.rst
+++ b/web/devdoc/array_api.rst
@@ -3,7 +3,7 @@ Array API and GPU support
 
 Scikit-bio is gradually adopting the `Python array API standard
 <https://data-apis.org/array-api/latest/>`_ to allow functions to work
-across multiple array libraries (NumPy, PyTorch, JAX, CuPy) and run on
+across multiple array libraries (NumPy, PyTorch, JAX, CuPy, Dask) and run on
 GPUs where supported. This page covers what contributors need to know
 to write, test, and run array-API-compatible code.
 
@@ -18,17 +18,17 @@ on GPU via PyTorch or CuPy, or on TPU via JAX.
 
 Currently supported backends:
 
-- **numpy** (CPU only) — the default, always available
-- **torch** — CPU or CUDA
-- **jax** — CPU or GPU
-- **cupy** — CUDA only
+- **NumPy** (CPU only) — the default, always available
+- **Torch** — CPU or CUDA
+- **Jax** — CPU or GPU
+- **CuPy** — CUDA only
 
 Only a small fraction of scikit-bio currently has array-API support.
 Most functions still operate on NumPy arrays exclusively. This is being
 expanded over time.
 
 
-Writing array-API-compatible library code
+Writing array API compatible code
 -----------------------------------------
 
 Use ``ingest_array`` at function entry points to obtain the array
@@ -47,30 +47,24 @@ The returned ``xp`` is the namespace corresponding to the input array's
 backend. Use ``xp.func()`` for all array operations rather than
 ``np.func()`` — this is what makes the function backend-agnostic.
 
-If a function only supports certain backends, declare them explicitly:
-
 .. code-block:: python
-
-   from skbio.util._array import _check_array_api_backend
 
    def my_function(arr):
        xp, arr = ingest_array(arr)
-       _check_array_api_backend(xp, ["numpy", "torch"], "my_function")
+       return xp.sum(arr)
        ...
 
-This raises ``TypeError`` for unsupported backends with a clear error
-message.
 
 **Things to avoid:**
 
-- Hardcoded ``np.func()`` calls (use ``xp.func()`` instead)
-- Backend-specific methods like ``arr.numpy()`` or ``arr.get()``
-- In-place modification (JAX arrays are immutable)
+- Hardcoded ``np.func()`` calls (use ``xp.func()`` instead).
+- Backend-specific methods like ``torch.numpy()`` or ``cupy.get()`` (both return a NumPy array).
+- In-place modification when supporting JAX arrays. They are immutable.
 - Assuming ``float64`` is the default dtype (PyTorch defaults to
-  ``float32``)
+  ``float32``).
 
 
-Writing tests for array-API code
+Writing tests for array API code
 --------------------------------
 
 Tests that exercise array-API code paths use the
@@ -157,7 +151,7 @@ against the ``torch``, ``jax``, and ``cupy`` backends with CUDA.
 - **Weekly cron**: every Monday at 06:00 UTC, catching regressions
   from upstream changes in array libraries
 - **Manual dispatch**: via the Actions tab on GitHub
-- **``gpu-ci`` label on a PR**: applies the label to a PR to trigger
+- **`gpu-ci` label on a PR**: applies the label to a PR to trigger
   the workflow; pushes to the labeled PR will re-trigger it
 
 Reviewers should apply the ``gpu-ci`` label to any PR that modifies

--- a/web/devdoc/review.rst
+++ b/web/devdoc/review.rst
@@ -81,6 +81,7 @@ Continuous integration (CI)
 
 - Make sure GitHub Actions CI is passing before merging a pull request.
 - Make sure coverage doesn't drop. Strive to have 100% coverage for new code being merged.
+- If changes involve Python Array API support, consider adding the `gpu-ci` label to the PR. See :doc:`array_api` for more details.
 
 
 Unit testing


### PR DESCRIPTION
## Add GPU/Array API CI workflow

Adds a new GitHub Actions workflow (`array-api.yml`) that runs array-API-decorated tests on a T4 GPU runner against PyTorch, JAX, and CuPy with CUDA. Tests are filtered via a new `array_api` pytest marker so only relevant tests run.

### Changes

- **New workflow** (`array-api.yml`): runs weekly (Mondays 06:00 UTC), on manual dispatch, or when a PR is labeled `gpu-ci`. Verifies each backend sees the GPU at install time, then runs `pytest -m array_api`.
- **`@array_backends` decorator** now applies a `pytest.mark.array_api` marker so CI can filter on it. Marker registered in `pyproject.toml`.
- **Skip guards tightened** in `test_array.py`: replaced "is the module importable" checks with usability probes that actually exercise the backend. Fixes spurious errors when a library installs but can't allocate (e.g., CuPy without a GPU).
- **`_normalize_device` replaced** with `_device_specs_match` and `_on_device`. The old function blurred two concerns; the new split distinguishes "do these spec strings refer to the same hardware" from "is this array actually on that hardware."
- **`assert_type_preserved`** now uses `_on_device` to inspect real array device placement instead of string-comparing device reprs.
- **Developer docs**: new `devdoc/array_api.rst` covering how to write array-API library code and tests, run them locally, and use the `gpu-ci` label.

### Notes

- Dask was considered but excluded. Its support in scikit-bio is dev-only and not fully built out; adding CI commitment now would be premature.
- Workflow is intentionally not a required check — GPU runners can be flaky, and most PRs don't touch array code. Reviewers apply the `gpu-ci` label when validation is needed.
- Only 16 tests are currently decorated (in `composition` and `ordination`). Coverage will grow as more of the package adopts the array API.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [x] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [ ] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
