### PR TITLE
ENH: add Numba CPU permuted Pearson helpers for Mantel

### DIFF
--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -21,11 +21,138 @@ from ._cutils import mantel_perm_pearsonr_cy, mantel_perm_pearsonr_condensed_cy
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
 
+try:
+    from numba import njit, prange
+    NUMBA_AVAILABLE = True
+except ImportError:
+    NUMBA_AVAILABLE = False
+
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
     from ._base import DistanceMatrix
     from numpy.typing import ArrayLike
     from skbio.util._typing import SeedLike
+
+
+if NUMBA_AVAILABLE:
+
+    @njit(parallel=True)
+    def _mantel_perm_pearsonr_numba(
+        x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+    ):
+        """Fused permute, normalize, and Pearson correlation for Mantel test.
+
+        Replaces the following Python code::
+
+            def _mantel_perm_pearsonr_one(x_flat, xmean, normxm, ym_normalized):
+                xm_normalized = (x_flat - xmean) / normxm
+                one_stat = np.dot(xm_normalized, ym_normalized)
+                one_stat = max(min(one_stat, 1.0), -1.0)
+                return one_stat
+
+            permuted_stats = np.array([
+                _mantel_perm_pearsonr_one(
+                    distmat_reorder_condensed(x._data, perm_order[p]), ...
+                ) for p in range(permutations)
+            ])
+
+        Takes a pre-computed permutation order matrix and normalizes values on
+        the fly using mul and add (derived from xmean and normxm) instead of
+        materializing the full permuted matrix. Each permutation is independent
+        and computed in parallel via prange.
+
+        Parameters
+        ----------
+        x_data : 2D array_like
+            Full distance matrix (n x n).
+        perm_order : 2D array_like
+            Permutation index array (n_perm x n). Each row is a permutation
+            of range(n) specifying the reordering of rows and columns.
+        xmean : float
+            Mean of the condensed form of x.
+        normxm : float
+            Norm of (x_flat - xmean).
+        ym_normalized : 1D array_like
+            (y_flat - ymean) / normym, pre-normalized.
+        permuted_stats : 1D array_like
+            Output array (n_perm,) to write correlation coefficients into.
+
+        """
+        n = x_data.shape[0]
+        n_perm = perm_order.shape[0]
+        mul = 1.0 / normxm
+        add = -xmean / normxm
+
+        for p in prange(n_perm):
+            my_ps = 0.0
+            for row in range(n - 1):
+                vrow = perm_order[p, row]
+                row_start = row * (n - 1) - ((row - 1) * row) // 2
+                for icol in range(n - row - 1):
+                    col = icol + row + 1
+                    yval = ym_normalized[row_start + icol]
+                    xval = x_data[vrow, perm_order[p, col]] * mul + add
+                    my_ps = yval * xval + my_ps
+
+            if my_ps > 1.0:
+                my_ps = 1.0
+            elif my_ps < -1.0:
+                my_ps = -1.0
+            permuted_stats[p] = my_ps
+
+    @njit(parallel=True)
+    def _mantel_perm_pearsonr_condensed_numba(
+        x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+    ):
+        """Fused permute, normalize, and Pearson for condensed Mantel test.
+
+        Same as _mantel_perm_pearsonr_numba but accepts x_data in condensed
+        form (1D array of length n*(n-1)/2) instead of the full 2D matrix.
+        Uses condensed_index formula to map (vrow, vcol) pairs from the
+        permuted ordering back to the 1D condensed array.
+
+        Parameters
+        ----------
+        x_data : 1D array_like
+            Condensed distance matrix (lower triangle only).
+        perm_order : 2D array_like
+            Permutation index array (n_perm x n).
+        xmean : float
+            Mean of the condensed form of x.
+        normxm : float
+            Norm of (x_flat - xmean).
+        ym_normalized : 1D array_like
+            (y_flat - ymean) / normym, pre-normalized.
+        permuted_stats : 1D array_like
+            Output array (n_perm,) to write correlation coefficients into.
+
+        """
+        n_perm = perm_order.shape[0]
+        n = perm_order.shape[1]
+        mul = 1.0 / normxm
+        add = -xmean / normxm
+
+        for p in prange(n_perm):
+            my_ps = 0.0
+            for row in range(n - 1):
+                vrow = perm_order[p, row]
+                row_start = row * (n - 1) - ((row - 1) * row) // 2
+                for icol in range(n - row - 1):
+                    col = icol + row + 1
+                    vcol = perm_order[p, col]
+                    if vrow < vcol:
+                        x_idx = vrow * n + vcol - ((vrow + 2) * (vrow + 1)) // 2
+                    else:
+                        x_idx = vcol * n + vrow - ((vcol + 2) * (vcol + 1)) // 2
+                    yval = ym_normalized[row_start + icol]
+                    xval = x_data[x_idx] * mul + add
+                    my_ps = yval * xval + my_ps
+
+            if my_ps > 1.0:
+                my_ps = 1.0
+            elif my_ps < -1.0:
+                my_ps = -1.0
+            permuted_stats[p] = my_ps
 
 
 def mantel(
@@ -430,13 +557,23 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None):
 
         permuted_stats = np.empty(permutations + 1, dtype=x_data.dtype)
         if x._flags["CONDENSED"]:
-            mantel_perm_pearsonr_condensed_cy(
-                x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
-            )
+            if NUMBA_AVAILABLE:
+                _mantel_perm_pearsonr_condensed_numba(
+                    x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+                )
+            else:
+                mantel_perm_pearsonr_condensed_cy(
+                    x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+                )
         else:
-            mantel_perm_pearsonr_cy(
-                x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
-            )
+            if NUMBA_AVAILABLE:
+                _mantel_perm_pearsonr_numba(
+                    x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+                )
+            else:
+                mantel_perm_pearsonr_cy(
+                    x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+                )
         comp_stat = permuted_stats[0]
         permuted_stats = permuted_stats[1:]
 


### PR DESCRIPTION
Add optional Numba CPU implementations for the Mantel Pearson permutation
helpers. Numba is detected at import time; if unavailable the existing Cython
path is used as fallback.

## Implementation

This PR is a direct Cython -> Numba conversion of the Mantel Pearson
permutation helpers.

Two helpers added:
- `_mantel_perm_pearsonr_numba` — full matrix
- `_mantel_perm_pearsonr_condensed_numba` — condensed matrix

Both use `@njit(parallel=True)` with `prange` over independent permutations.
Each permutation writes to its own `permuted_stats[p]` slot, so there is no
shared reduction. The implementation follows the same loop structure and
numerical operations as the Cython helpers.

Any Numba-specific optimization work should be handled in a follow-up PR.

## Testing

```
$ python -m pytest skbio/stats/distance/tests/test_mantel.py -x -q
61 passed in 11.13s
```

## Benchmark Correction

The earlier local benchmark that showed a large Numba CPU speedup used a local
macOS editable build where the Cython extension had been built with Apple Clang
and was not OpenMP-enabled. That comparison was not a fair optimized-Cython
baseline.

I reran the benchmark with corrected setups:
- local macOS rebuild using a conda OpenMP-capable toolchain, verifying that
  `_cutils` links against `libomp`
- fork-only GitHub Actions Linux runs using conda compilers and explicit
  `OMP_NUM_THREADS` / `NUMBA_NUM_THREADS` controls

## Corrected Controlled Results

Linux fork-only GitHub Actions results (`ubuntu-latest`, 4 CPU / 16 GB RAM):

| Form | n | Perms | `OMP_NUM_THREADS` | `NUMBA_NUM_THREADS` | Cython | Numba warm | Speedup | Max diff |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| full | 5000 | 999 | 8 | 8 | 14.878774s | 19.712725s | 0.75x | 0.000e+00 |
| full | 5000 | 9999 | 8 | 8 | 143.913849s | 188.065629s | 0.77x | 0.000e+00 |
| condensed | 5000 | 9999 | 8 | 8 | 1092.922673s | 648.562209s | 1.69x | 0.000e+00 |
| condensed | 25000 | 999 | 8 | 8 | 2956.519255s | 1802.022791s | 1.64x | 0.000e+00 |

Additional control runs confirmed:
- OpenMP helps the Cython path on the corrected Linux baseline.
- `NUMBA_NUM_THREADS` does control Numba thread count as expected.
- The current performance picture depends on matrix form: full-form Mantel is
  slower under this direct Numba port, while condensed-form Mantel can be
  faster at larger scales.

Experimental `condensed`, `n=25000`, `permutations=9999` did not finish on the
public GitHub runner within about 6 hours.