### PR TITLE
TEST: add Numba-aware Mantel tests

### DIFF
--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -7,12 +7,22 @@ on:
   workflow_dispatch:
 
 env:
-  latest_python: "3.13"
+  latest_python: "3.14"
 
 jobs:
   test:
-    name: Numba CPU
-    runs-on: ubuntu-latest
+    name: Numba (${{ env.latest_python }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-15-intel is omitted: Numba and llvmlite no longer ship macOS
+        # x86_64 wheels, so `pip install numba` would fall back to a source
+        # build requiring an LLVM toolchain.
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -1,0 +1,31 @@
+name: Numba
+
+on:
+  pull_request:
+    branches: [ development_numba ]
+    paths-ignore: ["web/**", "**.md", "README.rst"]
+  workflow_dispatch:
+
+env:
+  latest_python: "3.13"
+
+jobs:
+  test:
+    name: Numba CPU
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.latest_python }}
+
+      - name: Install scikit-bio + Numba
+        run: |
+          python -m ensurepip
+          pip install --prefer-binary -r ci/requirements.txt -r ci/requirements.test.txt
+          pip install numba
+          pip install --no-deps .
+          pip list
+
+      - name: Run Numba tests
+        run: cd ci && pytest -m numba_code --pyargs skbio

--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -27,5 +27,8 @@ jobs:
           pip install --no-deps .
           pip list
 
-      - name: Run Numba tests
+      - name: Run Numba-marked tests
         run: cd ci && pytest -m numba_code --pyargs skbio
+
+      - name: Run full test suite with Numba installed
+        run: make test

--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -10,8 +10,22 @@ env:
   latest_python: "3.14"
 
 jobs:
+  conf:
+    # This job is needed to route the global environment variables into
+    # a context that's available for matrix (and name, but that's unimportant)
+    name: Prepare Numba Test Plan
+    runs-on: ubuntu-latest
+    outputs:
+      latest_python: ${{ steps.set-vars.outputs.latest_python }}
+    steps:
+      - name: Report Plan
+        id: set-vars
+        run: |
+          echo "latest_python=$latest_python" >> $GITHUB_OUTPUT
+
   test:
-    name: Numba (${{ env.latest_python }}, ${{ matrix.os }})
+    name: Numba (${{ needs.conf.outputs.latest_python }}, ${{ matrix.os }})
+    needs: conf
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -27,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.latest_python }}
+          python-version: ${{ needs.conf.outputs.latest_python }}
 
       - name: Install scikit-bio + Numba
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ doctest_optionflags = [
 ]
 markers = [
     "array_api: tests that exercise the Array API across backends",
+    "numba_code: tests that exercise optional Numba-accelerated code paths",
 ]
 
 [tool.check-manifest]

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -90,6 +90,7 @@ class InternalMantelTests(MantelTestData):
             self.assertAlmostEqual(permuted_stats[i], exp_res)
 
     def _perm_pearsonr3_inputs(self):
+        # data pre-computed using released code
         x_data = np.asarray([[0., 1., 3.],
                              [1., 0., 2.],
                              [3., 2., 0.]])
@@ -104,6 +105,7 @@ class InternalMantelTests(MantelTestData):
         return x_data, perm_order, xmean, normxm, ym_normalized
 
     def _perm_pearsonr6_inputs(self):
+        # data pre-computed using released code
         x_data = np.asarray([[0., 0.62381864, 0.75001543,
                               0.58520119, 0.72902358, 0.65213559],
                              [0.62381864, 0., 0.97488122,

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -19,12 +20,13 @@ from scipy.stats import pearsonr, spearmanr, ConstantInputWarning, NearConstantI
 from skbio import DistanceMatrix
 from skbio.stats.distance import (PairwiseMatrixError,
                                   DistanceMatrixError, mantel, pwmantel)
+from skbio.stats.distance import _mantel as mantel_mod
 from skbio.stats.distance._mantel import _order_dms
 from skbio.stats.distance._mantel import _mantel_stats_pearson
 from skbio.stats.distance._mantel import _mantel_stats_spearman
 from skbio.stats.distance._cutils import mantel_perm_pearsonr_cy
 from skbio.stats.distance._utils import distmat_reorder_condensed
-from skbio.util import get_data_path, assert_data_frame_almost_equal
+from skbio.util import get_data_path, assert_data_frame_almost_equal, numba_code
 from skbio.util._testing import _data_frame_to_default_int_type
 
 
@@ -76,6 +78,90 @@ class InternalMantelTests(MantelTestData):
         one_stat = np.dot(xm_normalized, ym_normalized)
         one_stat = max(min(one_stat, 1.0), -1.0)
         return one_stat
+
+    def _numba_test_inputs(self):
+        x_data = np.asarray([[0., 1., 4., 7.],
+                             [1., 0., 2., 5.],
+                             [4., 2., 0., 3.],
+                             [7., 5., 3., 0.]])
+        y_data = np.asarray([[0., 2., 6., 8.],
+                             [2., 0., 1., 4.],
+                             [6., 1., 0., 9.],
+                             [8., 4., 9., 0.]])
+        perm_order = np.asarray([[0, 1, 2, 3],
+                                 [2, 0, 3, 1],
+                                 [3, 2, 1, 0]], dtype=np.intp)
+
+        x_flat = squareform(x_data, force='tovector', checks=False)
+        y_flat = squareform(y_data, force='tovector', checks=False)
+        xmean = x_flat.mean()
+        xm = x_flat - xmean
+        normxm = np.linalg.norm(xm)
+        ymean = y_flat.mean()
+        ym = y_flat - ymean
+        ym_normalized = ym / np.linalg.norm(ym)
+
+        return x_data, x_flat, perm_order, xmean, normxm, ym_normalized
+
+    @numba_code
+    def test_perm_pearsonr_numba_full(self):
+        x_data, _, perm_order, xmean, normxm, ym_normalized = \
+            self._numba_test_inputs()
+        permuted_stats = np.empty(len(perm_order), dtype=x_data.dtype)
+
+        mantel_mod._mantel_perm_pearsonr_numba(
+            x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
+        )
+
+        exp = np.asarray([
+            self._compute_perf_one(x_data, order, xmean, normxm, ym_normalized)
+            for order in perm_order
+        ])
+        npt.assert_allclose(permuted_stats, exp)
+
+    @numba_code
+    def test_perm_pearsonr_numba_condensed(self):
+        x_data, x_flat, perm_order, xmean, normxm, ym_normalized = \
+            self._numba_test_inputs()
+        permuted_stats = np.empty(len(perm_order), dtype=x_flat.dtype)
+
+        mantel_mod._mantel_perm_pearsonr_condensed_numba(
+            x_flat, perm_order, xmean, normxm, ym_normalized, permuted_stats
+        )
+
+        exp = np.asarray([
+            self._compute_perf_one(x_data, order, xmean, normxm, ym_normalized)
+            for order in perm_order
+        ])
+        npt.assert_allclose(permuted_stats, exp)
+
+    @numba_code
+    def test_pearson_flat_dispatches_to_numba_helpers(self):
+        y_flat = self.miny_dm.condensed_form()
+        calls = []
+
+        def full_spy(x_data, perm_order, xmean, normxm,
+                     ym_normalized, permuted_stats):
+            calls.append("full")
+            permuted_stats[:] = 0.0
+
+        def condensed_spy(x_data, perm_order, xmean, normxm,
+                          ym_normalized, permuted_stats):
+            calls.append("condensed")
+            permuted_stats[:] = 0.0
+
+        with patch.object(mantel_mod, "_mantel_perm_pearsonr_numba",
+                          side_effect=full_spy), \
+             patch.object(mantel_mod, "_mantel_perm_pearsonr_condensed_numba",
+                          side_effect=condensed_spy):
+            mantel_mod._mantel_stats_pearson_flat(
+                self.minx_dm, y_flat, 1, seed=0
+            )
+            mantel_mod._mantel_stats_pearson_flat(
+                self.minx_cond, y_flat, 1, seed=0
+            )
+
+        self.assertEqual(calls, ["full", "condensed"])
 
     def test_perm_pearsonr3(self):
         # data pre-computed using released code

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -24,7 +24,8 @@ from skbio.stats.distance import _mantel as mantel_mod
 from skbio.stats.distance._mantel import _order_dms
 from skbio.stats.distance._mantel import _mantel_stats_pearson
 from skbio.stats.distance._mantel import _mantel_stats_spearman
-from skbio.stats.distance._cutils import mantel_perm_pearsonr_cy
+from skbio.stats.distance._cutils import (mantel_perm_pearsonr_cy,
+                                          mantel_perm_pearsonr_condensed_cy)
 from skbio.stats.distance._utils import distmat_reorder_condensed
 from skbio.util import get_data_path, assert_data_frame_almost_equal, numba_code
 from skbio.util._testing import _data_frame_to_default_int_type
@@ -79,92 +80,16 @@ class InternalMantelTests(MantelTestData):
         one_stat = max(min(one_stat, 1.0), -1.0)
         return one_stat
 
-    def _numba_test_inputs(self):
-        x_data = np.asarray([[0., 1., 4., 7.],
-                             [1., 0., 2., 5.],
-                             [4., 2., 0., 3.],
-                             [7., 5., 3., 0.]])
-        y_data = np.asarray([[0., 2., 6., 8.],
-                             [2., 0., 1., 4.],
-                             [6., 1., 0., 9.],
-                             [8., 4., 9., 0.]])
-        perm_order = np.asarray([[0, 1, 2, 3],
-                                 [2, 0, 3, 1],
-                                 [3, 2, 1, 0]], dtype=np.intp)
-
-        x_flat = squareform(x_data, force='tovector', checks=False)
-        y_flat = squareform(y_data, force='tovector', checks=False)
-        xmean = x_flat.mean()
-        xm = x_flat - xmean
-        normxm = np.linalg.norm(xm)
-        ymean = y_flat.mean()
-        ym = y_flat - ymean
-        ym_normalized = ym / np.linalg.norm(ym)
-
-        return x_data, x_flat, perm_order, xmean, normxm, ym_normalized
-
-    @numba_code
-    def test_perm_pearsonr_numba_full(self):
-        x_data, _, perm_order, xmean, normxm, ym_normalized = \
-            self._numba_test_inputs()
+    def _assert_perm_pearsonr(self, func, x_data, perm_order, xmean, normxm,
+                              ym_normalized):
         permuted_stats = np.empty(len(perm_order), dtype=x_data.dtype)
+        func(x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats)
+        for i in range(len(perm_order)):
+            exp_res = self._compute_perf_one(x_data, perm_order[i, :],
+                                             xmean, normxm, ym_normalized)
+            self.assertAlmostEqual(permuted_stats[i], exp_res)
 
-        mantel_mod._mantel_perm_pearsonr_numba(
-            x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
-        )
-
-        exp = np.asarray([
-            self._compute_perf_one(x_data, order, xmean, normxm, ym_normalized)
-            for order in perm_order
-        ])
-        npt.assert_allclose(permuted_stats, exp)
-
-    @numba_code
-    def test_perm_pearsonr_numba_condensed(self):
-        x_data, x_flat, perm_order, xmean, normxm, ym_normalized = \
-            self._numba_test_inputs()
-        permuted_stats = np.empty(len(perm_order), dtype=x_flat.dtype)
-
-        mantel_mod._mantel_perm_pearsonr_condensed_numba(
-            x_flat, perm_order, xmean, normxm, ym_normalized, permuted_stats
-        )
-
-        exp = np.asarray([
-            self._compute_perf_one(x_data, order, xmean, normxm, ym_normalized)
-            for order in perm_order
-        ])
-        npt.assert_allclose(permuted_stats, exp)
-
-    @numba_code
-    def test_pearson_flat_dispatches_to_numba_helpers(self):
-        y_flat = self.miny_dm.condensed_form()
-        calls = []
-
-        def full_spy(x_data, perm_order, xmean, normxm,
-                     ym_normalized, permuted_stats):
-            calls.append("full")
-            permuted_stats[:] = 0.0
-
-        def condensed_spy(x_data, perm_order, xmean, normxm,
-                          ym_normalized, permuted_stats):
-            calls.append("condensed")
-            permuted_stats[:] = 0.0
-
-        with patch.object(mantel_mod, "_mantel_perm_pearsonr_numba",
-                          side_effect=full_spy), \
-             patch.object(mantel_mod, "_mantel_perm_pearsonr_condensed_numba",
-                          side_effect=condensed_spy):
-            mantel_mod._mantel_stats_pearson_flat(
-                self.minx_dm, y_flat, 1, seed=0
-            )
-            mantel_mod._mantel_stats_pearson_flat(
-                self.minx_cond, y_flat, 1, seed=0
-            )
-
-        self.assertEqual(calls, ["full", "condensed"])
-
-    def test_perm_pearsonr3(self):
-        # data pre-computed using released code
+    def _perm_pearsonr3_inputs(self):
         x_data = np.asarray([[0., 1., 3.],
                              [1., 0., 2.],
                              [3., 2., 0.]])
@@ -176,17 +101,9 @@ class InternalMantelTests(MantelTestData):
         xmean = 2.0
         normxm = 1.4142135623730951
         ym_normalized = np.asarray([-0.80178373, 0.26726124, 0.53452248])
+        return x_data, perm_order, xmean, normxm, ym_normalized
 
-        permuted_stats = np.empty(len(perm_order), dtype=x_data.dtype)
-        mantel_perm_pearsonr_cy(x_data, perm_order, xmean, normxm,
-                                ym_normalized, permuted_stats)
-        for i in range(len(perm_order)):
-            exp_res = self._compute_perf_one(x_data, perm_order[i, :],
-                                             xmean, normxm, ym_normalized)
-            self.assertAlmostEqual(permuted_stats[i], exp_res)
-
-    def test_perm_pearsonr6(self):
-        # data pre-computed using released code
+    def _perm_pearsonr6_inputs(self):
         x_data = np.asarray([[0., 0.62381864, 0.75001543,
                               0.58520119, 0.72902358, 0.65213559],
                              [0.62381864, 0., 0.97488122,
@@ -212,16 +129,9 @@ class InternalMantelTests(MantelTestData):
                                     -0.08230374, 0.33992794, -0.14964257,
                                     0.04340053, -0.35527798, 0.15597541,
                                     -0.0523679, -0.04451187, 0.35308828])
+        return x_data, perm_order, xmean, normxm, ym_normalized
 
-        permuted_stats = np.empty(len(perm_order), dtype=x_data.dtype)
-        mantel_perm_pearsonr_cy(x_data, perm_order, xmean, normxm,
-                                ym_normalized, permuted_stats)
-        for i in range(len(perm_order)):
-            exp_res = self._compute_perf_one(x_data, perm_order[i, :],
-                                             xmean, normxm, ym_normalized)
-            self.assertAlmostEqual(permuted_stats[i], exp_res)
-
-    def test_perm_pearsonr_full(self):
+    def _perm_pearsonr_full_inputs(self):
         x = DistanceMatrix.read(get_data_path('dm2.txt'))
         y = DistanceMatrix.read(get_data_path('dm3.txt'))
         x_data = x._data
@@ -260,14 +170,74 @@ class InternalMantelTests(MantelTestData):
                                  [5, 0, 2, 3, 1, 4]], dtype=np.intp)
 
         ym_normalized = ym/normym
+        return x_data, perm_order, xmean, normxm, ym_normalized
 
-        permuted_stats = np.empty(len(perm_order), dtype=x_data.dtype)
-        mantel_perm_pearsonr_cy(x_data, perm_order, xmean, normxm,
-                                ym_normalized, permuted_stats)
+    def _assert_perm_pearsonr_condensed(self, func, x_data, perm_order, xmean,
+                                        normxm, ym_normalized):
+        x_flat = squareform(x_data, force='tovector', checks=False)
+        permuted_stats = np.empty(len(perm_order), dtype=x_flat.dtype)
+        func(x_flat, perm_order, xmean, normxm, ym_normalized, permuted_stats)
         for i in range(len(perm_order)):
             exp_res = self._compute_perf_one(x_data, perm_order[i, :],
                                              xmean, normxm, ym_normalized)
             self.assertAlmostEqual(permuted_stats[i], exp_res)
+
+    def test_perm_pearsonr3_cy(self):
+        self._assert_perm_pearsonr(
+            mantel_perm_pearsonr_cy, *self._perm_pearsonr3_inputs())
+
+    @numba_code
+    def test_perm_pearsonr3_numba(self):
+        self._assert_perm_pearsonr(
+            mantel_mod._mantel_perm_pearsonr_numba,
+            *self._perm_pearsonr3_inputs())
+
+    def test_perm_pearsonr6_cy(self):
+        self._assert_perm_pearsonr(
+            mantel_perm_pearsonr_cy, *self._perm_pearsonr6_inputs())
+
+    @numba_code
+    def test_perm_pearsonr6_numba(self):
+        self._assert_perm_pearsonr(
+            mantel_mod._mantel_perm_pearsonr_numba,
+            *self._perm_pearsonr6_inputs())
+
+    def test_perm_pearsonr_full_cy(self):
+        self._assert_perm_pearsonr(
+            mantel_perm_pearsonr_cy, *self._perm_pearsonr_full_inputs())
+
+    @numba_code
+    def test_perm_pearsonr_full_numba(self):
+        self._assert_perm_pearsonr(
+            mantel_mod._mantel_perm_pearsonr_numba,
+            *self._perm_pearsonr_full_inputs())
+
+    def test_perm_pearsonr_condensed_cy(self):
+        self._assert_perm_pearsonr_condensed(
+            mantel_perm_pearsonr_condensed_cy,
+            *self._perm_pearsonr_full_inputs())
+
+    @numba_code
+    def test_perm_pearsonr_condensed_numba(self):
+        self._assert_perm_pearsonr_condensed(
+            mantel_mod._mantel_perm_pearsonr_condensed_numba,
+            *self._perm_pearsonr_full_inputs())
+
+    @numba_code
+    def test_pearson_flat_numba_matches_cython_fallback(self):
+        y_flat = self.miny_dm.condensed_form()
+
+        for x in (self.minx_dm, self.minx_cond):
+            obs = mantel_mod._mantel_stats_pearson_flat(x, y_flat, 3, seed=0)
+
+            # Force the fallback path so the Numba dispatch result is compared
+            # with Cython using the same input matrix and permutation seed.
+            with patch.object(mantel_mod, "NUMBA_AVAILABLE", False):
+                exp = mantel_mod._mantel_stats_pearson_flat(x, y_flat, 3, seed=0)
+
+            self.assertAlmostEqual(obs[0], exp[0])
+            self.assertAlmostEqual(obs[1], exp[1])
+            npt.assert_allclose(obs[2], exp[2])
 
     def test_pearsonr_full(self):
         """

--- a/skbio/util/__init__.py
+++ b/skbio/util/__init__.py
@@ -90,6 +90,7 @@ from ._testing import (
     xp_assert_close,
     xp_assert_equal,
     array_backends,
+    numba_code,
     ArrayAPITestMixin,
     pytestrunner,
 )
@@ -132,5 +133,6 @@ __all__ = [
     "xp_assert_close",
     "xp_assert_equal",
     "array_backends",
+    "numba_code",
     "ArrayAPITestMixin",
 ]

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -730,6 +730,23 @@ def array_backends(*backend_names, cpu_only=False):
     return decorator
 
 
+def numba_code(test_func):
+    """Decorator: mark a test as requiring optional Numba support."""
+    try:
+        import pytest
+
+        test_func = pytest.mark.numba_code(test_func)
+    except ImportError:
+        pass
+
+    try:
+        import numba  # noqa: F401
+    except ImportError:
+        test_func = unittest.skip("Numba is not installed.")(test_func)
+
+    return test_func
+
+
 class ArrayAPITestMixin:
     """Mixin providing array-API test helpers for ``unittest.TestCase``.
 


### PR DESCRIPTION
## Summary
- Add a `numba_code` pytest marker and test decorator for optional Numba-specific tests.
- Add Mantel tests that explicitly exercise the full, condensed, and dispatch Numba paths.
- Add a dedicated CPU Numba workflow that installs Numba and runs only marked tests.

## Tests
- `python -m pytest skbio/stats/distance/tests/test_mantel.py -m numba_code -q`
- `python -m pytest skbio/stats/distance/tests/test_mantel.py -q`
- `cd ci && python -m pytest -m numba_code --pyargs skbio -q`
- `ruff check skbio/util/_testing.py skbio/util/__init__.py`