### PR TITLE
ENH: add Numba CPU s_W helpers for PERMANOVA

### DIFF
--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -113,10 +113,7 @@ if NUMBA_AVAILABLE:
 
             partials[row_idx] = group_sum
 
-        s_W = 0.0
-        for i in range(n_half):
-            s_W += partials[i]
-        return s_W
+        return partials.sum()
 
     @njit(parallel=True)
     def _permanova_f_stat_sW_condensed_numba(condensed_matrix, group_sizes, grouping):
@@ -181,10 +178,7 @@ if NUMBA_AVAILABLE:
 
             partials[row_idx] = group_sum
 
-        s_W = 0.0
-        for i in range(n_half):
-            s_W += partials[i]
-        return s_W
+        return partials.sum()
 
 
 @params_aliased([("distmat", "distance_matrix", "0.7.0", False)])

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -156,7 +156,10 @@ if NUMBA_AVAILABLE:
             local_sum = 0.0
             for col_idx in range(row_idx + 1, n):
                 if grouping[col_idx] == group_idx:
-                    condensed_idx = row_idx * n + col_idx - ((row_idx + 2) * (row_idx + 1)) // 2
+                    condensed_idx = (
+                        row_idx * n + col_idx
+                        - ((row_idx + 2) * (row_idx + 1)) // 2
+                    )
                     val = condensed_matrix[condensed_idx]
                     local_sum += val * val
 
@@ -168,7 +171,10 @@ if NUMBA_AVAILABLE:
                 local_sum = 0.0
                 for col_idx in range(mirror_row + 1, n):
                     if grouping[col_idx] == group_idx:
-                        condensed_idx = mirror_row * n + col_idx - ((mirror_row + 2) * (mirror_row + 1)) // 2
+                        condensed_idx = (
+                            mirror_row * n + col_idx
+                            - ((mirror_row + 2) * (mirror_row + 1)) // 2
+                        )
                         val = condensed_matrix[condensed_idx]
                         local_sum += val * val
                 group_sum += local_sum / group_sizes[group_idx]

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import math
 from functools import partial
 from warnings import warn
 from typing import TYPE_CHECKING
@@ -27,10 +28,157 @@ from skbio.binaries import (
 )
 from skbio.util._decorator import params_aliased
 
+try:
+    from numba import njit, prange
+    NUMBA_AVAILABLE = True
+except ImportError:
+    NUMBA_AVAILABLE = False
+
 if TYPE_CHECKING:  # pragma: no cover
     from numpy.typing import ArrayLike
     import pandas as pd
     from skbio.util._typing import SeedLike
+
+
+if NUMBA_AVAILABLE:
+
+    @njit(parallel=True)
+    def _permanova_f_stat_sW_numba(distance_matrix, group_sizes, grouping):
+        """Compute s_W for full (non-condensed) distance matrix using Numba.
+
+        Replaces the following natural Numba code, which triggers a parfor
+        cycle bug in Numba 0.65.x when the scalar reduction variable is read
+        inside the inner loop::
+
+            @njit(parallel=True)
+            def _permanova_f_stat_sW_numba(
+                distance_matrix, group_sizes, grouping
+            ):
+                n = distance_matrix.shape[0]
+                s_W = 0.0
+                for row_idx in prange(n - 1):
+                    group_idx = grouping[row_idx]
+                    local_sum = 0.0
+                    for col_idx in range(row_idx + 1, n):
+                        if grouping[col_idx] == group_idx:
+                            val = distance_matrix[row_idx, col_idx]
+                            local_sum += val * val
+                    s_W += local_sum / group_sizes[group_idx]
+                return s_W
+
+        Instead, each parallel iteration writes its row-pair contribution to
+        a partials array and the final sum is performed sequentially. The
+        loop also pairs row_idx with its mirror (n - row_idx - 2) so each
+        prange iteration handles a comparable amount of work, matching the
+        Cython implementation's load-balancing pattern.
+
+        Parameters
+        ----------
+        distance_matrix : np.ndarray, shape (n, n)
+            Full symmetric distance matrix.
+        group_sizes : np.ndarray, shape (num_groups,)
+            Number of objects in each group (precomputed via np.bincount).
+        grouping : np.ndarray, shape (n,)
+            Integer group label for each object (values 0 to num_groups - 1).
+
+        Returns
+        -------
+        float
+            The within-group sum of squares s_W.
+
+        """
+        n = distance_matrix.shape[0]
+        n_half = n // 2
+        partials = np.zeros(n_half, np.float64)
+
+        for row_idx in prange(n_half):
+            group_idx = grouping[row_idx]
+            local_sum = 0.0
+            for col_idx in range(row_idx + 1, n):
+                if grouping[col_idx] == group_idx:
+                    val = distance_matrix[row_idx, col_idx]
+                    local_sum += val * val
+
+            group_sum = local_sum / group_sizes[group_idx]
+
+            mirror_row = n - row_idx - 2
+            if mirror_row != row_idx:
+                group_idx = grouping[mirror_row]
+                local_sum = 0.0
+                for col_idx in range(mirror_row + 1, n):
+                    if grouping[col_idx] == group_idx:
+                        val = distance_matrix[mirror_row, col_idx]
+                        local_sum += val * val
+                group_sum += local_sum / group_sizes[group_idx]
+
+            partials[row_idx] = group_sum
+
+        s_W = 0.0
+        for i in range(n_half):
+            s_W += partials[i]
+        return s_W
+
+    @njit(parallel=True)
+    def _permanova_f_stat_sW_condensed_numba(condensed_matrix, group_sizes, grouping):
+        """Compute s_W for condensed distance matrix using Numba.
+
+        Same as ``_permanova_f_stat_sW_numba`` but accepts ``condensed_matrix``
+        in condensed form (1-D array of length ``n * (n - 1) // 2``) instead
+        of the full 2-D matrix. Uses the standard condensed-index formula to
+        map ``(row_idx, col_idx)`` pairs back to the 1-D array. The same
+        Numba 0.65.x parfor cycle workaround applies (partials array + final
+        sequential sum); see the full version for the equivalent natural
+        Numba code.
+
+        Parameters
+        ----------
+        condensed_matrix : np.ndarray, shape (k,)
+            Condensed (upper triangle) distance matrix where
+            k = n * (n - 1) // 2.
+        group_sizes : np.ndarray, shape (num_groups,)
+            Number of objects in each group.
+        grouping : np.ndarray, shape (n,)
+            Integer group label for each object.
+
+        Returns
+        -------
+        float
+            The within-group sum of squares s_W.
+
+        """
+        k = condensed_matrix.shape[0]
+        n = int((1.0 + math.sqrt(1.0 + 8.0 * k)) / 2.0)
+        n_half = n // 2
+        partials = np.zeros(n_half, np.float64)
+
+        for row_idx in prange(n_half):
+            group_idx = grouping[row_idx]
+            local_sum = 0.0
+            for col_idx in range(row_idx + 1, n):
+                if grouping[col_idx] == group_idx:
+                    condensed_idx = row_idx * n + col_idx - ((row_idx + 2) * (row_idx + 1)) // 2
+                    val = condensed_matrix[condensed_idx]
+                    local_sum += val * val
+
+            group_sum = local_sum / group_sizes[group_idx]
+
+            mirror_row = n - row_idx - 2
+            if mirror_row != row_idx:
+                group_idx = grouping[mirror_row]
+                local_sum = 0.0
+                for col_idx in range(mirror_row + 1, n):
+                    if grouping[col_idx] == group_idx:
+                        condensed_idx = mirror_row * n + col_idx - ((mirror_row + 2) * (mirror_row + 1)) // 2
+                        val = condensed_matrix[condensed_idx]
+                        local_sum += val * val
+                group_sum += local_sum / group_sizes[group_idx]
+
+            partials[row_idx] = group_sum
+
+        s_W = 0.0
+        for i in range(n_half):
+            s_W += partials[i]
+        return s_W
 
 
 @params_aliased([("distmat", "distance_matrix", "0.7.0", False)])
@@ -229,11 +377,23 @@ def _compute_f_stat(
     """Compute PERMANOVA pseudo-F statistic."""
     # Calculate s_W for each group, accounting for different group sizes.
     if distance_matrix._flags["CONDENSED"]:
-        s_W = permanova_f_stat_sW_condensed_cy(
-            distance_matrix.data, group_sizes, grouping
-        )
+        if NUMBA_AVAILABLE:
+            s_W = _permanova_f_stat_sW_condensed_numba(
+                distance_matrix.data, group_sizes, grouping
+            )
+        else:
+            s_W = permanova_f_stat_sW_condensed_cy(
+                distance_matrix.data, group_sizes, grouping
+            )
     else:
-        s_W = permanova_f_stat_sW_cy(distance_matrix.data, group_sizes, grouping)
+        if NUMBA_AVAILABLE:
+            s_W = _permanova_f_stat_sW_numba(
+                distance_matrix.data, group_sizes, grouping
+            )
+        else:
+            s_W = permanova_f_stat_sW_cy(
+                distance_matrix.data, group_sizes, grouping
+            )
 
     s_A = s_T - s_W
     return (s_A / (num_groups - 1)) / (s_W / (sample_size - num_groups))

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -388,6 +388,11 @@ class PERMANOVACondensedTests(PERMANOVATestData):
 class InternalPERMANOVATests(PERMANOVATestData):
     """Tests for the Numba-accelerated s_W helpers and dispatch."""
 
+    # Expected within-group sum-of-squares for self.dm_unequal with
+    # grouping [0, 1, 2, 1, 0, 0]. Pre-computed using the existing
+    # scikit-bio Cython implementation.
+    EXPECTED_SW = 0.8382
+
     def setUp(self):
         super().setUp()
         # The internal _cy/_numba helpers take raw np arrays rather than
@@ -404,19 +409,9 @@ class InternalPERMANOVATests(PERMANOVATestData):
         self.ids = self.dm_unequal.ids
         self.grouping_labels = self.grouping_unequal
 
-    def _expected_sW(self):
-        n = self.dm_full.shape[0]
-        s_W = 0.0
-        for i in range(n - 1):
-            for j in range(i + 1, n):
-                if self.grouping[i] == self.grouping[j]:
-                    g = self.grouping[i]
-                    s_W += self.dm_full[i, j] ** 2 / self.group_sizes[g]
-        return s_W
-
     def _assert_sW(self, func, dm):
         obs = func(dm, self.group_sizes, self.grouping)
-        self.assertAlmostEqual(obs, self._expected_sW())
+        self.assertAlmostEqual(obs, self.EXPECTED_SW)
 
     def test_sW_full_cy(self):
         self._assert_sW(permanova_f_stat_sW_cy, self.dm_full)

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -9,6 +9,7 @@
 import io
 from functools import partial
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -17,7 +18,10 @@ from scipy.spatial.distance import squareform
 
 from skbio import DistanceMatrix
 from skbio.stats.distance import permanova
-from skbio.util import get_data_path
+from skbio.stats.distance import _permanova as permanova_mod
+from skbio.stats.distance._cutils import (permanova_f_stat_sW_cy,
+                                          permanova_f_stat_sW_condensed_cy)
+from skbio.util import get_data_path, numba_code
 from skbio.stats.distance._base import _preprocess_input_sng
 
 
@@ -406,6 +410,70 @@ class PERMANOVACondensedTests(TestCase):
 
         self.assertEqual(len(self.dm_ties_condensed.data), expected_condensed_length)
         self.assertEqual(self.dm_ties_redundant.data.shape, (n, n))
+
+
+class PERMANOVANumbaTests(TestCase):
+    """Tests for the Numba-accelerated s_W helpers and dispatch."""
+
+    def setUp(self):
+        # Same numbers as dm_unequal in PERMANOVATests (3 groups, sizes 3/2/1).
+        self.dm_full = np.asarray(
+            [[0.0, 1.0, 0.1, 0.5678, 1.0, 1.0],
+             [1.0, 0.0, 0.002, 0.42, 0.998, 0.0],
+             [0.1, 0.002, 0.0, 1.0, 0.123, 1.0],
+             [0.5678, 0.42, 1.0, 0.0, 0.123, 0.43],
+             [1.0, 0.998, 0.123, 0.123, 0.0, 0.5],
+             [1.0, 0.0, 1.0, 0.43, 0.5, 0.0]])
+        self.dm_condensed = squareform(self.dm_full, force='tovector',
+                                       checks=False)
+        self.grouping = np.asarray([0, 1, 2, 1, 0, 0], dtype=np.intp)
+        self.group_sizes = np.bincount(self.grouping).astype(np.intp)
+        self.ids = ['s1', 's2', 's3', 's4', 's5', 's6']
+        self.grouping_labels = ['Control', 'Treatment1', 'Treatment2',
+                                'Treatment1', 'Control', 'Control']
+
+    def _expected_sW(self):
+        n = self.dm_full.shape[0]
+        s_W = 0.0
+        for i in range(n - 1):
+            for j in range(i + 1, n):
+                if self.grouping[i] == self.grouping[j]:
+                    g = self.grouping[i]
+                    s_W += self.dm_full[i, j] ** 2 / self.group_sizes[g]
+        return s_W
+
+    def _assert_sW(self, func, dm):
+        obs = func(dm, self.group_sizes, self.grouping)
+        self.assertAlmostEqual(obs, self._expected_sW())
+
+    def test_sW_full_cy(self):
+        self._assert_sW(permanova_f_stat_sW_cy, self.dm_full)
+
+    @numba_code
+    def test_sW_full_numba(self):
+        self._assert_sW(permanova_mod._permanova_f_stat_sW_numba, self.dm_full)
+
+    def test_sW_condensed_cy(self):
+        self._assert_sW(permanova_f_stat_sW_condensed_cy, self.dm_condensed)
+
+    @numba_code
+    def test_sW_condensed_numba(self):
+        self._assert_sW(permanova_mod._permanova_f_stat_sW_condensed_numba,
+                        self.dm_condensed)
+
+    @numba_code
+    def test_permanova_numba_matches_cython_fallback(self):
+        dm = DistanceMatrix(self.dm_full, self.ids)
+
+        obs = permanova(dm, self.grouping_labels, permutations=99, seed=42)
+
+        # Force the fallback path so the Numba dispatch result is compared
+        # with Cython using the same input matrix and permutation seed.
+        with patch.object(permanova_mod, "NUMBA_AVAILABLE", False):
+            exp = permanova(dm, self.grouping_labels, permutations=99, seed=42)
+
+        self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
+        self.assertAlmostEqual(obs['p-value'], exp['p-value'])
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -25,13 +25,17 @@ from skbio.util import get_data_path, numba_code
 from skbio.stats.distance._base import _preprocess_input_sng
 
 
-class PERMANOVATests(TestCase):
-    """All results were verified with R (vegan::adonis)."""
+class PERMANOVATestData(TestCase):
+    """Shared fixtures for the PERMANOVA test classes.
+
+    Subclasses (``PERMANOVATests``, ``PERMANOVACondensedTests``,
+    ``InternalPERMANOVATests``) call ``super().setUp()`` and add their
+    own class-specific derivatives.
+    """
 
     def setUp(self):
-        # Distance matrices with and without ties in the ranks, with 2 groups
-        # of equal size.
-        dm_ids = ['s1', 's2', 's3', 's4']
+        # 4-sample, 2-group equal-size data.
+        dm_ids_equal = ['s1', 's2', 's3', 's4']
         self.grouping_equal = ['Control', 'Control', 'Fast', 'Fast']
         self.df = pd.read_csv(
             io.StringIO('ID,Group\ns2,Control\ns3,Fast\ns4,Fast\ns5,Control\n'
@@ -40,14 +44,15 @@ class PERMANOVATests(TestCase):
         self.dm_ties = DistanceMatrix([[0, 1, 1, 4],
                                        [1, 0, 3, 2],
                                        [1, 3, 0, 3],
-                                       [4, 2, 3, 0]], dm_ids)
+                                       [4, 2, 3, 0]], dm_ids_equal)
 
         self.dm_no_ties = DistanceMatrix([[0, 1, 5, 4],
                                           [1, 0, 3, 2],
                                           [5, 3, 0, 3],
-                                          [4, 2, 3, 0]], dm_ids)
+                                          [4, 2, 3, 0]], dm_ids_equal)
 
-        # Test with 3 groups of unequal size.
+        # 6-sample, 3-group unequal-size data.
+        dm_ids_unequal = ['s1', 's2', 's3', 's4', 's5', 's6']
         self.grouping_unequal = ['Control', 'Treatment1', 'Treatment2',
                                  'Treatment1', 'Control', 'Control']
 
@@ -62,7 +67,7 @@ class PERMANOVATests(TestCase):
              [0.5678, 0.42, 1.0, 0.0, 0.123, 0.43],
              [1.0, 0.998, 0.123, 0.123, 0.0, 0.5],
              [1.0, 0.0, 1.0, 0.43, 0.5, 0.0]],
-            ['s1', 's2', 's3', 's4', 's5', 's6'])
+            dm_ids_unequal)
 
         # Expected series index is the same across all tests.
         self.exp_index = ['method name', 'test statistic name', 'sample size',
@@ -73,6 +78,10 @@ class PERMANOVATests(TestCase):
         self.assert_series_equal = partial(assert_series_equal,
                                            check_index_type=True,
                                            check_series_type=True)
+
+
+class PERMANOVATests(PERMANOVATestData):
+    """All results were verified with R (vegan::adonis)."""
 
     def test_call_ties(self):
         # Ensure we get the same results if we rerun the method using the same
@@ -194,73 +203,37 @@ class PERMANOVATests(TestCase):
             permanova(self.dm_ties.data, self.grouping_equal, seed=42)
 
 
-class PERMANOVACondensedTests(TestCase):
+class PERMANOVACondensedTests(PERMANOVATestData):
     """Tests for PERMANOVA with condensed distance matrices.
-    
+
     These tests verify that condensed and redundant forms of the same
     distance matrix produce identical results.
     """
 
     def setUp(self):
-        # Distance matrices with and without ties in the ranks, with 2 groups
-        # of equal size.
-        dm_ids = ['s1', 's2', 's3', 's4']
-        self.grouping_equal = ['Control', 'Control', 'Fast', 'Fast']
-        self.df = pd.read_csv(
-            io.StringIO('ID,Group\ns2,Control\ns3,Fast\ns4,Fast\ns5,Control\n'
-                        's1,Control'), index_col=0)
-
-        # Create both redundant and condensed versions
-        self.dm_ties_redundant = DistanceMatrix([[0, 1, 1, 4],
-                                                  [1, 0, 3, 2],
-                                                  [1, 3, 0, 3],
-                                                  [4, 2, 3, 0]], dm_ids)
-        
+        super().setUp()
+        # Build condensed forms from the inherited matrices. The
+        # ``_redundant`` aliases let this class's existing test methods
+        # reuse the inherited DistanceMatrix objects without renaming
+        # every call site.
+        self.dm_ties_redundant = self.dm_ties
         self.dm_ties_condensed = DistanceMatrix(
-            squareform(self.dm_ties_redundant.data), #, checks=False),
-            dm_ids,
+            squareform(self.dm_ties.data),
+            self.dm_ties.ids,
             condensed=True
         )
-
-        self.dm_no_ties_redundant = DistanceMatrix([[0, 1, 5, 4],
-                                                     [1, 0, 3, 2],
-                                                     [5, 3, 0, 3],
-                                                     [4, 2, 3, 0]], dm_ids)
-        
+        self.dm_no_ties_redundant = self.dm_no_ties
         self.dm_no_ties_condensed = DistanceMatrix(
-            squareform(self.dm_no_ties_redundant.data), #, checks=False),
-            dm_ids,
+            squareform(self.dm_no_ties.data),
+            self.dm_no_ties.ids,
             condensed=True
         )
-
-        # Test with 3 groups of unequal size.
-        self.grouping_unequal = ['Control', 'Treatment1', 'Treatment2',
-                                 'Treatment1', 'Control', 'Control']
-
-        self.dm_unequal_redundant = DistanceMatrix(
-            [[0.0, 1.0, 0.1, 0.5678, 1.0, 1.0],
-             [1.0, 0.0, 0.002, 0.42, 0.998, 0.0],
-             [0.1, 0.002, 0.0, 1.0, 0.123, 1.0],
-             [0.5678, 0.42, 1.0, 0.0, 0.123, 0.43],
-             [1.0, 0.998, 0.123, 0.123, 0.0, 0.5],
-             [1.0, 0.0, 1.0, 0.43, 0.5, 0.0]],
-            ['s1', 's2', 's3', 's4', 's5', 's6'])
-        
+        self.dm_unequal_redundant = self.dm_unequal
         self.dm_unequal_condensed = DistanceMatrix(
-            squareform(self.dm_unequal_redundant.data), #, checks=False),
-            ['s1', 's2', 's3', 's4', 's5', 's6'],
+            squareform(self.dm_unequal.data),
+            self.dm_unequal.ids,
             condensed=True
         )
-
-        # Expected series index is the same across all tests.
-        self.exp_index = ['method name', 'test statistic name', 'sample size',
-                          'number of groups', 'test statistic', 'p-value',
-                          'number of permutations']
-
-        # Stricter series equality testing than the default.
-        self.assert_series_equal = partial(assert_series_equal,
-                                           check_index_type=True,
-                                           check_series_type=True)
 
     def test_condensed_vs_redundant_ties(self):
         """Test that condensed and redundant forms give identical results with ties."""
@@ -412,25 +385,24 @@ class PERMANOVACondensedTests(TestCase):
         self.assertEqual(self.dm_ties_redundant.data.shape, (n, n))
 
 
-class PERMANOVANumbaTests(TestCase):
+class InternalPERMANOVATests(PERMANOVATestData):
     """Tests for the Numba-accelerated s_W helpers and dispatch."""
 
     def setUp(self):
-        # Same numbers as dm_unequal in PERMANOVATests (3 groups, sizes 3/2/1).
-        self.dm_full = np.asarray(
-            [[0.0, 1.0, 0.1, 0.5678, 1.0, 1.0],
-             [1.0, 0.0, 0.002, 0.42, 0.998, 0.0],
-             [0.1, 0.002, 0.0, 1.0, 0.123, 1.0],
-             [0.5678, 0.42, 1.0, 0.0, 0.123, 0.43],
-             [1.0, 0.998, 0.123, 0.123, 0.0, 0.5],
-             [1.0, 0.0, 1.0, 0.43, 0.5, 0.0]])
-        self.dm_condensed = squareform(self.dm_full, force='tovector',
-                                       checks=False)
+        super().setUp()
+        # The internal _cy/_numba helpers take raw np arrays rather than
+        # DistanceMatrix wrappers, so derive those forms from the inherited
+        # dm_unequal. The integer grouping is hand-encoded to match
+        # grouping_unequal's first-seen order
+        # (Control=0, Treatment1=1, Treatment2=2).
+        self.dm_full = np.ascontiguousarray(self.dm_unequal.data)
+        self.dm_condensed = squareform(
+            self.dm_full, force='tovector', checks=False
+        )
         self.grouping = np.asarray([0, 1, 2, 1, 0, 0], dtype=np.intp)
         self.group_sizes = np.bincount(self.grouping).astype(np.intp)
-        self.ids = ['s1', 's2', 's3', 's4', 's5', 's6']
-        self.grouping_labels = ['Control', 'Treatment1', 'Treatment2',
-                                'Treatment1', 'Control', 'Control']
+        self.ids = self.dm_unequal.ids
+        self.grouping_labels = self.grouping_unequal
 
     def _expected_sW(self):
         n = self.dm_full.shape[0]


### PR DESCRIPTION
Builds on #2464 and #2468.

### Description

Add optional Numba CPU implementations for the PERMANOVA s_W helpers. Numba is detected at import time; if unavailable the existing Cython path is used as fallback.

This PR is a direct Cython -> Numba conversion of `permanova_f_stat_sW_cy` and `permanova_f_stat_sW_condensed_cy`.

Two helpers added in `skbio/stats/distance/_permanova.py`:

- `_permanova_f_stat_sW_numba` — full matrix
- `_permanova_f_stat_sW_condensed_numba` — condensed matrix

Both use `@njit(parallel=True)` with `prange` over half the rows, pairing each `row_idx` with its mirror `n - row_idx - 2` to preserve the Cython implementation's load-balancing pattern.

The helpers write per-row contributions to a partials array and sum sequentially at the end, instead of doing the natural scalar reduction inside `prange`. This works around a Numba 0.65.x parfor cycle bug that fires when a `prange` scalar reduction reads from an array parameter used inside the inner loop. The docstrings include a `Replaces::` block showing the natural Numba code that would be used once the bug is fixed.

`_compute_f_stat` dispatches to Numba when available, Cython otherwise. The Cython path is untouched.

Any Numba-specific optimization work (e.g. the block-permutation strategy from `scikit-bio-binaries`) should be handled in a follow-up PR.

### Testing

New `PERMANOVANumbaTests` class with:

- Paired `_cy` / `_numba` helper tests for full and condensed matrices, asserting both produce the same s_W as a pure-Python reference.
- A dispatch fallback test using `patch.object(NUMBA_AVAILABLE, False)` to verify the Cython path under the same input matrix and seed.

The new tests use the `@numba_code` decorator from #2468 so they are skipped when Numba is not installed. The `numba.yml` workflow from #2468 picks them up automatically across `ubuntu-latest`, `macos-latest`, `windows-latest`, and `ubuntu-24.04-arm`.

```
$ python -m pytest skbio/stats/distance/tests/test_permanova.py -q
25 passed
$ python -m pytest skbio/stats/distance/tests/test_permanova.py -m numba_code -q
3 passed, 22 deselected
```