### PR TITLE
Update setup-miniconda version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # to prevent a "Git clone too shallow" warning by Sphinx
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
@@ -106,7 +106,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, macos-15-intel]
     steps:
       - uses: actions/checkout@v6
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}
@@ -159,7 +159,7 @@ jobs:
       # set up conda environment
       - name: Setup conda environment
         if: ${{ matrix.use_conda }}
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ env.latest_python }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ ignore = [
     ".dockerignore",
     ".editorconfig",
     "checklist.py",
-    # created by conda-incubator/setup-miniconda@v3 action
+    # created by conda-incubator/setup-miniconda@v4 action
     "ci/setup-miniconda-patched-conda_host_env.yml",
 ]
 


### PR DESCRIPTION
The following warning has been raised on the recent CI workflow runs:

```bash
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: conda-incubator/setup-miniconda@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This PR updates the version of `conda-incubator/setup-miniconda` to the most recent version.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
