### PR TITLE
ENH: add engine= selector to mantel and permanova

### DIFF
--- a/skbio/_config.py
+++ b/skbio/_config.py
@@ -18,10 +18,14 @@ Functions
 
 Configuration options
 ---------------------
-At present, only one configuration option is available:
 
 **table_output** : *{"pandas", "numpy", "polars"}, default="pandas"*
     The preferred output format of tables. See :ref:`details <table_output>`.
+
+**engine** : *{"cython", "numba"}, default="cython"*
+    The default compute engine for functions that support multiple engines.
+    Functions accept an ``engine`` argument to override this per call. The
+    ``"numba"`` engine requires the optional Numba dependency.
 
 """  # noqa: D205, D415
 
@@ -38,6 +42,7 @@ from typing import Any
 
 _SKBIO_OPTIONS = {
     "table_output": "pandas",
+    "engine": "cython",
 }
 
 
@@ -74,6 +79,10 @@ def set_config(option: str, value: Any):
             pos_opts = ["pandas", "polars", "numpy"]  # , "biom"]
             if value not in pos_opts:
                 raise ValueError(f"Unsupported value '{value}' for '{option}'.")
+        case "engine":
+            pos_opts = ["cython", "numba"]
+            if value not in pos_opts:
+                raise ValueError(f"Unsupported value '{value}' for '{option}'.")
 
     _SKBIO_OPTIONS[option] = value
 
@@ -96,3 +105,43 @@ def get_config(option: str) -> Any:
         return _SKBIO_OPTIONS[option]
     except KeyError:
         raise KeyError(f"Unknown option: '{option}'.")
+
+
+def _resolve_engine(engine, supported):
+    """Resolve the compute engine for a function call.
+
+    Parameters
+    ----------
+    engine : str or None
+        The engine requested by the caller. If None, the global default
+        (``get_config("engine")``) is used.
+    supported : tuple of str
+        The engines this function supports (e.g. ``("cython", "numba")``).
+
+    Returns
+    -------
+    str
+        The resolved engine name.
+
+    Raises
+    ------
+    ValueError
+        If the resolved engine is not in ``supported``.
+    ImportError
+        If ``"numba"`` is requested but Numba is not installed.
+
+    """
+    if engine is None:
+        engine = get_config("engine")
+    if engine not in supported:
+        raise ValueError(
+            f"engine='{engine}' is not supported here; choose from {supported}."
+        )
+    if engine == "numba":
+        try:
+            import numba  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "engine='numba' requires the optional numba dependency."
+            )
+    return engine

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -20,6 +20,7 @@ from scipy.stats import kendalltau, ConstantInputWarning, NearConstantInputWarni
 from ._cutils import mantel_perm_pearsonr_cy, mantel_perm_pearsonr_condensed_cy
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
+from skbio._config import _resolve_engine
 
 try:
     from numba import njit, prange
@@ -37,7 +38,7 @@ if TYPE_CHECKING:  # pragma: no cover
 if NUMBA_AVAILABLE:
 
     @njit(parallel=True)
-    def _mantel_perm_pearsonr_numba(
+    def _mantel_perm_pearsonr_nb(
         x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
     ):
         """Fused permute, normalize, and Pearson correlation for Mantel test.
@@ -101,12 +102,12 @@ if NUMBA_AVAILABLE:
             permuted_stats[p] = my_ps
 
     @njit(parallel=True)
-    def _mantel_perm_pearsonr_condensed_numba(
+    def _mantel_perm_pearsonr_condensed_nb(
         x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
     ):
         """Fused permute, normalize, and Pearson for condensed Mantel test.
 
-        Same as _mantel_perm_pearsonr_numba but accepts x_data in condensed
+        Same as _mantel_perm_pearsonr_nb but accepts x_data in condensed
         form (1D array of length n*(n-1)/2) instead of the full 2D matrix.
         Uses condensed_index formula to map (vrow, vcol) pairs from the
         permuted ordering back to the 1D condensed array.
@@ -164,6 +165,7 @@ def mantel(
     strict: bool = True,
     lookup: dict[str, str] | None = None,
     seed: SeedLike | None = None,
+    engine: str | None = None,
 ) -> tuple[float, float, int]:
     r"""Compute correlation between distance matrices using the Mantel test.
 
@@ -252,6 +254,12 @@ def mantel(
         :func:`details <skbio.util.get_rng>`.
 
         .. versionadded:: 0.6.3
+    engine : {"cython", "numba"}, optional
+        Compute engine to use. ``"cython"`` (default) uses the Cython
+        implementation. ``"numba"`` uses the optional Numba implementation
+        and requires Numba to be installed. If not provided, the global
+        default is used (see :func:`skbio.set_config`). Only applies to the
+        ``"pearson"`` and ``"spearman"`` methods.
 
     Returns
     -------
@@ -414,6 +422,8 @@ def mantel(
     else:
         raise ValueError("Invalid correlation method '%s'." % method)
 
+    engine = _resolve_engine(engine, ("cython", "numba"))
+
     if permutations < 0:
         raise ValueError(
             "Number of permutations must be greater than or equal to zero."
@@ -433,11 +443,11 @@ def mantel(
     if special:
         if method == "pearson":
             orig_stat, comp_stat, permuted_stats = _mantel_stats_pearson(
-                x, y, permutations, rng
+                x, y, permutations, rng, engine
             )
         else:
             orig_stat, comp_stat, permuted_stats = _mantel_stats_spearman(
-                x, y, permutations, rng
+                x, y, permutations, rng, engine
             )
 
     else:
@@ -472,7 +482,7 @@ def mantel(
     return orig_stat, p_value, n
 
 
-def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None):
+def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None, engine="cython"):
     """Compute original and permuted stats using pearsonr.
 
     Parameters
@@ -557,8 +567,8 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None):
 
         permuted_stats = np.empty(permutations + 1, dtype=x_data.dtype)
         if x._flags["CONDENSED"]:
-            if NUMBA_AVAILABLE:
-                _mantel_perm_pearsonr_condensed_numba(
+            if engine == "numba":
+                _mantel_perm_pearsonr_condensed_nb(
                     x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
                 )
             else:
@@ -566,8 +576,8 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None):
                     x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
                 )
         else:
-            if NUMBA_AVAILABLE:
-                _mantel_perm_pearsonr_numba(
+            if engine == "numba":
+                _mantel_perm_pearsonr_nb(
                     x_data, perm_order, xmean, normxm, ym_normalized, permuted_stats
                 )
             else:
@@ -580,7 +590,7 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None):
     return orig_stat, comp_stat, permuted_stats
 
 
-def _mantel_stats_pearson(x, y, permutations, seed=None):
+def _mantel_stats_pearson(x, y, permutations, seed=None, engine="cython"):
     """Compute original and permuted stats using pearsonr.
 
     Parameters
@@ -609,10 +619,10 @@ def _mantel_stats_pearson(x, y, permutations, seed=None):
 
     """
     y_flat = y.condensed_form()
-    return _mantel_stats_pearson_flat(x, y_flat, permutations, seed)
+    return _mantel_stats_pearson_flat(x, y_flat, permutations, seed, engine)
 
 
-def _mantel_stats_spearman(x, y, permutations, seed=None):
+def _mantel_stats_spearman(x, y, permutations, seed=None, engine="cython"):
     """Compute original and permuted stats using spearmanr.
 
     Parameters
@@ -658,7 +668,7 @@ def _mantel_stats_spearman(x, y, permutations, seed=None):
     del x_rank
 
     # for our purposes, spearman is just pearson on rankdata
-    return _mantel_stats_pearson_flat(x_rank_matrix, y_rank, permutations, seed)
+    return _mantel_stats_pearson_flat(x_rank_matrix, y_rank, permutations, seed, engine)
 
 
 def pwmantel(

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -482,7 +482,7 @@ def mantel(
     return orig_stat, p_value, n
 
 
-def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None, engine="cython"):
+def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None, engine=None):
     """Compute original and permuted stats using pearsonr.
 
     Parameters
@@ -590,7 +590,7 @@ def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None, engine="cytho
     return orig_stat, comp_stat, permuted_stats
 
 
-def _mantel_stats_pearson(x, y, permutations, seed=None, engine="cython"):
+def _mantel_stats_pearson(x, y, permutations, seed=None, engine=None):
     """Compute original and permuted stats using pearsonr.
 
     Parameters
@@ -622,7 +622,7 @@ def _mantel_stats_pearson(x, y, permutations, seed=None, engine="cython"):
     return _mantel_stats_pearson_flat(x, y_flat, permutations, seed, engine)
 
 
-def _mantel_stats_spearman(x, y, permutations, seed=None, engine="cython"):
+def _mantel_stats_spearman(x, y, permutations, seed=None, engine=None):
     """Compute original and permuted stats using spearmanr.
 
     Parameters

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -27,6 +27,7 @@ from skbio.binaries import (
     permanova as _skbb_permanova,
 )
 from skbio.util._decorator import params_aliased
+from skbio._config import _resolve_engine
 
 try:
     from numba import njit, prange
@@ -43,7 +44,7 @@ if TYPE_CHECKING:  # pragma: no cover
 if NUMBA_AVAILABLE:
 
     @njit(parallel=True)
-    def _permanova_f_stat_sW_numba(distance_matrix, group_sizes, grouping):
+    def _permanova_f_stat_sW_nb(distance_matrix, group_sizes, grouping):
         """Compute s_W for full (non-condensed) distance matrix using Numba.
 
         Replaces the following natural Numba code, which triggers a parfor
@@ -51,7 +52,7 @@ if NUMBA_AVAILABLE:
         inside the inner loop::
 
             @njit(parallel=True)
-            def _permanova_f_stat_sW_numba(
+            def _permanova_f_stat_sW_nb(
                 distance_matrix, group_sizes, grouping
             ):
                 n = distance_matrix.shape[0]
@@ -116,10 +117,10 @@ if NUMBA_AVAILABLE:
         return partials.sum()
 
     @njit(parallel=True)
-    def _permanova_f_stat_sW_condensed_numba(condensed_matrix, group_sizes, grouping):
+    def _permanova_f_stat_sW_condensed_nb(condensed_matrix, group_sizes, grouping):
         """Compute s_W for condensed distance matrix using Numba.
 
-        Same as ``_permanova_f_stat_sW_numba`` but accepts ``condensed_matrix``
+        Same as ``_permanova_f_stat_sW_nb`` but accepts ``condensed_matrix``
         in condensed form (1-D array of length ``n * (n - 1) // 2``) instead
         of the full 2-D matrix. Uses the standard condensed-index formula to
         map ``(row_idx, col_idx)`` pairs back to the 1-D array. The same
@@ -188,6 +189,7 @@ def permanova(
     column: str | None = None,
     permutations: int = 999,
     seed: SeedLike | None = None,
+    engine: str | None = None,
 ) -> pd.Series:
     r"""Test for significant differences between groups using PERMANOVA.
 
@@ -256,6 +258,11 @@ def permanova(
         :func:`details <skbio.util.get_rng>`.
 
         .. versionadded:: 0.6.3
+    engine : {"cython", "numba"}, optional
+        Compute engine to use. ``"cython"`` (default) uses the Cython
+        implementation. ``"numba"`` uses the optional Numba implementation
+        and requires Numba to be installed. If not provided, the global
+        default is used (see :func:`skbio.set_config`).
 
     Returns
     -------
@@ -329,6 +336,8 @@ def permanova(
         distmat.ids, sample_size, grouping, column
     )
 
+    engine = _resolve_engine(engine, ("cython", "numba"))
+
     if _skbb_permanova_available(
         distmat, grouping, permutations, seed
     ):  # pragma: no cover
@@ -360,7 +369,7 @@ def permanova(
         s_T /= 2.0
 
     test_stat_function = partial(
-        _compute_f_stat, sample_size, num_groups, distmat, group_sizes, s_T
+        _compute_f_stat, sample_size, num_groups, distmat, group_sizes, s_T, engine
     )
     stat, p_value = _run_monte_carlo_stats(
         test_stat_function, grouping, permutations, seed
@@ -372,13 +381,13 @@ def permanova(
 
 
 def _compute_f_stat(
-    sample_size, num_groups, distance_matrix, group_sizes, s_T, grouping
+    sample_size, num_groups, distance_matrix, group_sizes, s_T, engine, grouping
 ):
     """Compute PERMANOVA pseudo-F statistic."""
     # Calculate s_W for each group, accounting for different group sizes.
     if distance_matrix._flags["CONDENSED"]:
-        if NUMBA_AVAILABLE:
-            s_W = _permanova_f_stat_sW_condensed_numba(
+        if engine == "numba":
+            s_W = _permanova_f_stat_sW_condensed_nb(
                 distance_matrix.data, group_sizes, grouping
             )
         else:
@@ -386,8 +395,8 @@ def _compute_f_stat(
                 distance_matrix.data, group_sizes, grouping
             )
     else:
-        if NUMBA_AVAILABLE:
-            s_W = _permanova_f_stat_sW_numba(
+        if engine == "numba":
+            s_W = _permanova_f_stat_sW_nb(
                 distance_matrix.data, group_sizes, grouping
             )
         else:

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
-from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -189,9 +188,9 @@ class InternalMantelTests(MantelTestData):
             mantel_perm_pearsonr_cy, *self._perm_pearsonr3_inputs())
 
     @numba_code
-    def test_perm_pearsonr3_numba(self):
+    def test_perm_pearsonr3_nb(self):
         self._assert_perm_pearsonr(
-            mantel_mod._mantel_perm_pearsonr_numba,
+            mantel_mod._mantel_perm_pearsonr_nb,
             *self._perm_pearsonr3_inputs())
 
     def test_perm_pearsonr6_cy(self):
@@ -199,9 +198,9 @@ class InternalMantelTests(MantelTestData):
             mantel_perm_pearsonr_cy, *self._perm_pearsonr6_inputs())
 
     @numba_code
-    def test_perm_pearsonr6_numba(self):
+    def test_perm_pearsonr6_nb(self):
         self._assert_perm_pearsonr(
-            mantel_mod._mantel_perm_pearsonr_numba,
+            mantel_mod._mantel_perm_pearsonr_nb,
             *self._perm_pearsonr6_inputs())
 
     def test_perm_pearsonr_full_cy(self):
@@ -209,9 +208,9 @@ class InternalMantelTests(MantelTestData):
             mantel_perm_pearsonr_cy, *self._perm_pearsonr_full_inputs())
 
     @numba_code
-    def test_perm_pearsonr_full_numba(self):
+    def test_perm_pearsonr_full_nb(self):
         self._assert_perm_pearsonr(
-            mantel_mod._mantel_perm_pearsonr_numba,
+            mantel_mod._mantel_perm_pearsonr_nb,
             *self._perm_pearsonr_full_inputs())
 
     def test_perm_pearsonr_condensed_cy(self):
@@ -220,26 +219,34 @@ class InternalMantelTests(MantelTestData):
             *self._perm_pearsonr_full_inputs())
 
     @numba_code
-    def test_perm_pearsonr_condensed_numba(self):
+    def test_perm_pearsonr_condensed_nb(self):
         self._assert_perm_pearsonr_condensed(
-            mantel_mod._mantel_perm_pearsonr_condensed_numba,
+            mantel_mod._mantel_perm_pearsonr_condensed_nb,
             *self._perm_pearsonr_full_inputs())
 
     @numba_code
-    def test_pearson_flat_numba_matches_cython_fallback(self):
+    def test_pearson_flat_engine_numba_matches_cython(self):
         y_flat = self.miny_dm.condensed_form()
 
         for x in (self.minx_dm, self.minx_cond):
-            obs = mantel_mod._mantel_stats_pearson_flat(x, y_flat, 3, seed=0)
-
-            # Force the fallback path so the Numba dispatch result is compared
-            # with Cython using the same input matrix and permutation seed.
-            with patch.object(mantel_mod, "NUMBA_AVAILABLE", False):
-                exp = mantel_mod._mantel_stats_pearson_flat(x, y_flat, 3, seed=0)
+            # The numba and cython engines should agree for the same input
+            # matrix and permutation seed.
+            obs = mantel_mod._mantel_stats_pearson_flat(
+                x, y_flat, 3, seed=0, engine="numba")
+            exp = mantel_mod._mantel_stats_pearson_flat(
+                x, y_flat, 3, seed=0, engine="cython")
 
             self.assertAlmostEqual(obs[0], exp[0])
             self.assertAlmostEqual(obs[1], exp[1])
             npt.assert_allclose(obs[2], exp[2])
+
+    def test_bad_engine_raises_for_all_methods(self):
+        # An unsupported engine is rejected up front, regardless of method
+        # (including kendalltau, which has no numba path).
+        for method in ("pearson", "spearman", "kendalltau"):
+            with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):
+                mantel(self.minx_dm, self.miny_dm, method=method,
+                       permutations=0, engine="julia")
 
     def test_pearsonr_full(self):
         """

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -9,7 +9,6 @@
 import io
 from functools import partial
 from unittest import TestCase, main
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -417,30 +416,35 @@ class InternalPERMANOVATests(PERMANOVATestData):
         self._assert_sW(permanova_f_stat_sW_cy, self.dm_full)
 
     @numba_code
-    def test_sW_full_numba(self):
-        self._assert_sW(permanova_mod._permanova_f_stat_sW_numba, self.dm_full)
+    def test_sW_full_nb(self):
+        self._assert_sW(permanova_mod._permanova_f_stat_sW_nb, self.dm_full)
 
     def test_sW_condensed_cy(self):
         self._assert_sW(permanova_f_stat_sW_condensed_cy, self.dm_condensed)
 
     @numba_code
-    def test_sW_condensed_numba(self):
-        self._assert_sW(permanova_mod._permanova_f_stat_sW_condensed_numba,
+    def test_sW_condensed_nb(self):
+        self._assert_sW(permanova_mod._permanova_f_stat_sW_condensed_nb,
                         self.dm_condensed)
 
     @numba_code
-    def test_permanova_numba_matches_cython_fallback(self):
+    def test_permanova_engine_numba_matches_cython(self):
         dm = DistanceMatrix(self.dm_full, self.ids)
 
-        obs = permanova(dm, self.grouping_labels, permutations=99, seed=42)
-
-        # Force the fallback path so the Numba dispatch result is compared
-        # with Cython using the same input matrix and permutation seed.
-        with patch.object(permanova_mod, "NUMBA_AVAILABLE", False):
-            exp = permanova(dm, self.grouping_labels, permutations=99, seed=42)
+        # The numba and cython engines should produce the same result for
+        # the same input matrix and permutation seed.
+        obs = permanova(dm, self.grouping_labels, permutations=99, seed=42,
+                        engine="numba")
+        exp = permanova(dm, self.grouping_labels, permutations=99, seed=42,
+                        engine="cython")
 
         self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
         self.assertAlmostEqual(obs['p-value'], exp['p-value'])
+
+    def test_bad_engine_raises(self):
+        dm = DistanceMatrix(self.dm_full, self.ids)
+        with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):
+            permanova(dm, self.grouping_labels, permutations=0, engine="julia")
 
 
 if __name__ == '__main__':

--- a/skbio/tests/test_config.py
+++ b/skbio/tests/test_config.py
@@ -7,11 +7,16 @@
 # ----------------------------------------------------------------------------
 
 from unittest import TestCase, main
+from unittest.mock import patch
 
-from skbio._config import get_config, set_config
+from skbio._config import get_config, set_config, _resolve_engine
 
 
 class TestOptions(TestCase):
+    def tearDown(self):
+        # Restore the default engine in case a test changed it.
+        set_config("engine", "cython")
+
     def test_set_config_bad_option(self):
         with self.assertRaisesRegex(KeyError, "Unknown option: 'nonsense'."):
             set_config("nonsense", "asdf")
@@ -25,6 +30,57 @@ class TestOptions(TestCase):
     def test_get_config_bad_option(self):
         with self.assertRaisesRegex(KeyError, "Unknown option: 'frontend'."):
             get_config("frontend")
+
+    def test_engine_default_is_cython(self):
+        self.assertEqual(get_config("engine"), "cython")
+
+    def test_set_engine_valid(self):
+        set_config("engine", "numba")
+        self.assertEqual(get_config("engine"), "numba")
+
+    def test_set_engine_bad_value(self):
+        with self.assertRaisesRegex(
+            ValueError, "Unsupported value 'julia' for 'engine'."
+        ):
+            set_config("engine", "julia")
+
+
+class TestResolveEngine(TestCase):
+    def setUp(self):
+        self._original = get_config("engine")
+
+    def tearDown(self):
+        set_config("engine", self._original)
+
+    def test_none_uses_global_default(self):
+        set_config("engine", "cython")
+        self.assertEqual(_resolve_engine(None, ("cython", "numba")), "cython")
+
+    def test_explicit_cython(self):
+        self.assertEqual(_resolve_engine("cython", ("cython", "numba")), "cython")
+
+    def test_unsupported_value_raises(self):
+        with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):
+            _resolve_engine("julia", ("cython", "numba"))
+
+    def test_engine_not_in_supported_raises(self):
+        with self.assertRaisesRegex(ValueError, "engine='numba' is not supported"):
+            _resolve_engine("numba", ("cython",))
+
+    def test_numba_requested_but_absent_raises(self):
+        # Simulate Numba not being installed.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "numba":
+                raise ImportError("no numba")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaisesRegex(ImportError, "requires the optional numba"):
+                _resolve_engine("numba", ("cython", "numba"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Builds on #2464, #2468, and #2470.

### Description

This makes the Numba implementations opt-in rather than automatically selected when Numba is installed, via an `engine=` selector on `mantel()` and `permanova()`.

- `engine={"cython", "numba"}` chooses the compute backend per call. It defaults to the global setting, which is configurable through `skbio._config` (`set_config("engine", ...)`) and is `"cython"` by default. `engine="numba"` requires the optional Numba dependency and raises `ImportError` if it is not installed.
- The internal Numba helper functions are renamed from the `_numba` suffix to `_nb`, matching the existing `_cy` (Cython) suffix.

The `engine=` value is currently a single string (`"cython"` or `"numba"`); the design leaves room to add a preference list and further backends later without breaking the API. The selector covers Mantel and PERMANOVA, the two functions that currently have Numba implementations.

### Testing

- New tests for the `engine` config option and the `_resolve_engine` helper (default resolution, unsupported values, and `engine="numba"` when Numba is absent).
- The existing Mantel and PERMANOVA dispatch tests now run both engines via `engine=` and assert they agree, replacing the previous `patch.object(..., NUMBA_AVAILABLE, False)` approach.
- `mantel` and `permanova` produce identical results with `engine="cython"` and `engine="numba"` on the EMP 5k UniFrac matrices (uw/wn), for both the F-statistic / correlation and the p-value.
