### PR TITLE
PERF: parallelize PERMANOVA Numba engine across the permutation axis

### DIFF
--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -26,11 +26,12 @@ from skbio.binaries import (
     permanova_available as _skbb_permanova_available,
     permanova as _skbb_permanova,
 )
+from skbio.util import get_rng
 from skbio.util._decorator import params_aliased
 from skbio._config import _resolve_engine
 
 try:
-    from numba import njit, prange
+    from numba import njit, prange, get_num_threads
     NUMBA_AVAILABLE = True
 except ImportError:
     NUMBA_AVAILABLE = False
@@ -97,7 +98,9 @@ if NUMBA_AVAILABLE:
             local_sum = 0.0
             for col_idx in range(row_idx + 1, n):
                 if grouping[col_idx] == group_idx:
-                    val = distance_matrix[row_idx, col_idx]
+                    # promote to float64 before squaring to match the Cython
+                    # ``double`` accumulator (matters for float32 input)
+                    val = np.float64(distance_matrix[row_idx, col_idx])
                     local_sum += val * val
 
             group_sum = local_sum / group_sizes[group_idx]
@@ -108,7 +111,7 @@ if NUMBA_AVAILABLE:
                 local_sum = 0.0
                 for col_idx in range(mirror_row + 1, n):
                     if grouping[col_idx] == group_idx:
-                        val = distance_matrix[mirror_row, col_idx]
+                        val = np.float64(distance_matrix[mirror_row, col_idx])
                         local_sum += val * val
                 group_sum += local_sum / group_sizes[group_idx]
 
@@ -158,7 +161,7 @@ if NUMBA_AVAILABLE:
                         row_idx * n + col_idx
                         - ((row_idx + 2) * (row_idx + 1)) // 2
                     )
-                    val = condensed_matrix[condensed_idx]
+                    val = np.float64(condensed_matrix[condensed_idx])
                     local_sum += val * val
 
             group_sum = local_sum / group_sizes[group_idx]
@@ -180,6 +183,125 @@ if NUMBA_AVAILABLE:
             partials[row_idx] = group_sum
 
         return partials.sum()
+
+    @njit(parallel=True)
+    def _permanova_f_stat_sW_parallel_nb(
+        distance_matrix, group_sizes, groupings_2d, out_sW
+    ):
+        """Compute s_W for all permutations in parallel over the permutation axis.
+
+        Parallelises across permutations rather than within a single
+        permutation, matching the primary optimisation in scikit-bio-binaries
+        (the ``#pragma omp parallel for`` over ``gblock`` in
+        ``permanova_dyn_impl.hpp``).  Each parallel worker computes one
+        complete f_stat independently with no cross-thread dependency.
+
+        Parameters
+        ----------
+        distance_matrix : np.ndarray, shape (n, n)
+            Full symmetric distance matrix.
+        group_sizes : np.ndarray, shape (num_groups,)
+            Number of objects per group.
+        groupings_2d : np.ndarray, shape (n_perm, n)
+            Pre-generated permuted groupings for this batch, row-major. The
+            driver may call this kernel on successive chunks of permutations.
+        out_sW : np.ndarray, shape (n_perm,)
+            Output array; ``out_sW[i]`` receives the within-group sum of
+            squares for permutation ``i`` of the batch.
+
+        """
+        n = distance_matrix.shape[0]
+
+        for perm_idx in prange(groupings_2d.shape[0]):
+            s_W = 0.0
+            for row in range(n - 1):
+                group_idx = groupings_2d[perm_idx, row]
+                local_sum = 0.0
+                for col in range(row + 1, n):
+                    if groupings_2d[perm_idx, col] == group_idx:
+                        # promote to float64 before squaring to match the
+                        # Cython ``double`` accumulator (matters for float32)
+                        val = np.float64(distance_matrix[row, col])
+                        local_sum += val * val
+                s_W += local_sum / group_sizes[group_idx]
+            out_sW[perm_idx] = s_W
+
+    def _run_permanova_parallel_nb(
+        distmat, grouping, group_sizes, s_T, num_groups, sample_size,
+        permutations, seed
+    ):
+        """Run PERMANOVA with parallelism across the permutation axis.
+
+        Generates the ``permutations + 1`` groupings in fixed-size chunks and
+        computes s_W for each chunk in parallel via
+        ``_permanova_f_stat_sW_parallel_nb``, then assembles the F-statistics
+        and p-value in NumPy. Chunking bounds peak memory to ``CHUNK x n``
+        independent of the permutation count; permutations are drawn in the
+        same RNG order as the sequential Monte Carlo path, so results match.
+
+        Parameters
+        ----------
+        distmat : DistanceMatrix
+            Full (non-condensed) distance matrix.
+        grouping : np.ndarray, shape (n,)
+            Integer group labels (0-indexed).
+        group_sizes : np.ndarray, shape (num_groups,)
+            Number of objects per group.
+        s_T : float
+            Total sum of squares, precomputed by the caller.
+        num_groups : int
+            Number of distinct groups.
+        sample_size : int
+            Number of objects (n).
+        permutations : int
+            Number of Monte Carlo permutations.
+        seed : int, Generator, or None
+            Random seed passed to ``get_rng``.
+
+        Returns
+        -------
+        stat : float
+            Observed pseudo-F statistic.
+        p_value : float
+            Permutation p-value.
+
+        """
+        if permutations < 0:
+            raise ValueError(
+                "Number of permutations must be greater than or equal to zero."
+            )
+
+        rng = get_rng(seed)
+        n_total = permutations + 1
+        out_sW = np.empty(n_total, np.float64)
+
+        # Process permutations in chunks sized to the available parallelism so
+        # each worker handles a small batch whose active grouping rows stay
+        # resident in its per-core cache (scikit-bio-binaries uses 32
+        # permutations per worker). Chunking also bounds peak memory to
+        # (CHUNK x n) rather than the full permutation count (n_total x n).
+        # Permutations are generated in the same RNG order as the sequential
+        # Monte Carlo path, so p-values are unchanged.
+        CHUNK = 32 * get_num_threads()
+        buf = np.empty((min(CHUNK, n_total), sample_size), dtype=np.intp)
+        for start in range(0, n_total, CHUNK):
+            end = min(start + CHUNK, n_total)
+            for i in range(start, end):
+                if i == 0:
+                    buf[0] = grouping
+                else:
+                    buf[i - start] = rng.permutation(grouping)
+            _permanova_f_stat_sW_parallel_nb(
+                distmat.data, group_sizes, buf[: end - start], out_sW[start:end]
+            )
+
+        s_A = s_T - out_sW
+        f_stats = (s_A / (num_groups - 1)) / (out_sW / (sample_size - num_groups))
+        stat = f_stats[0]
+        if permutations == 0:
+            return stat, np.nan
+        p_value = (1.0 + np.sum(f_stats[1:] >= stat)) / (1.0 + permutations)
+        return stat, p_value
 
 
 @params_aliased([("distmat", "distance_matrix", "0.7.0", False)])
@@ -368,12 +490,18 @@ def permanova(
         # so cut in half
         s_T /= 2.0
 
-    test_stat_function = partial(
-        _compute_f_stat, sample_size, num_groups, distmat, group_sizes, s_T, engine
-    )
-    stat, p_value = _run_monte_carlo_stats(
-        test_stat_function, grouping, permutations, seed
-    )
+    if engine == "numba" and not distmat._flags["CONDENSED"]:
+        stat, p_value = _run_permanova_parallel_nb(
+            distmat, grouping, group_sizes, s_T,
+            num_groups, sample_size, permutations, seed
+        )
+    else:
+        test_stat_function = partial(
+            _compute_f_stat, sample_size, num_groups, distmat, group_sizes, s_T, engine
+        )
+        stat, p_value = _run_monte_carlo_stats(
+            test_stat_function, grouping, permutations, seed
+        )
 
     return _build_results(
         "PERMANOVA", "pseudo-F", sample_size, num_groups, stat, p_value, permutations

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -446,6 +446,68 @@ class InternalPERMANOVATests(PERMANOVATestData):
         with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):
             permanova(dm, self.grouping_labels, permutations=0, engine="julia")
 
+    @numba_code
+    def test_permanova_float32_matches_cython(self):
+        # On float32 input the Numba kernel must agree with Cython: both
+        # promote distances to float64 before squaring. Guards against a
+        # float32-accumulation regression in the squaring step.
+        dm32 = DistanceMatrix(self.dm_full.astype(np.float32), self.ids)
+        obs = permanova(dm32, self.grouping_labels, permutations=99,
+                        seed=42, engine="numba")
+        exp = permanova(dm32, self.grouping_labels, permutations=99,
+                        seed=42, engine="cython")
+        # float32 input -> agreement at float32 precision (Cython returns a
+        # float32 statistic; Numba accumulates in float64). 5 places is well
+        # within float32's ~7 significant digits.
+        self.assertAlmostEqual(obs['test statistic'], exp['test statistic'],
+                               places=5)
+        self.assertAlmostEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_permanova_parallel_nb_no_permutations(self):
+        # permutations=0 must yield a nan p-value, matching the cython path
+        dm = DistanceMatrix(self.dm_full, self.ids)
+        obs = permanova(dm, self.grouping_labels, permutations=0,
+                        engine="numba")
+        exp = permanova(dm, self.grouping_labels, permutations=0,
+                        engine="cython")
+        self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
+        self.assertTrue(np.isnan(obs['p-value']))
+        self.assertTrue(np.isnan(exp['p-value']))
+
+    @numba_code
+    def test_permanova_parallel_nb_negative_permutations_raises(self):
+        dm = DistanceMatrix(self.dm_full, self.ids)
+        with self.assertRaisesRegex(ValueError, "greater than or equal to zero"):
+            permanova(dm, self.grouping_labels, permutations=-1,
+                      engine="numba")
+
+    @numba_code
+    def test_permanova_parallel_nb_condensed_falls_back(self):
+        # condensed matrix must use the single-perm path, not the parallel path
+        dm_condensed = DistanceMatrix(
+            squareform(self.dm_full), self.ids, condensed=True
+        )
+        obs = permanova(dm_condensed, self.grouping_labels, permutations=99,
+                        seed=42, engine="numba")
+        exp = permanova(dm_condensed, self.grouping_labels, permutations=99,
+                        seed=42, engine="cython")
+        self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
+        self.assertAlmostEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_permanova_parallel_nb_crosses_chunk_boundary(self):
+        # permutations > the driver's internal CHUNK (512) exercises multiple
+        # batches; the RNG must stay in sync across chunks so the result is
+        # still identical to the cython engine.
+        dm = DistanceMatrix(self.dm_full, self.ids)
+        obs = permanova(dm, self.grouping_labels, permutations=600, seed=42,
+                        engine="numba")
+        exp = permanova(dm, self.grouping_labels, permutations=600, seed=42,
+                        engine="cython")
+        self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
+        self.assertAlmostEqual(obs['p-value'], exp['p-value'])
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
cc @sfiligoi

### What

The full-matrix `engine="numba"` path for `permanova()` previously called the
single-permutation s_W kernel once per permutation via the Python Monte Carlo
loop. This PR adds `_permanova_f_stat_sW_parallel_nb`, which computes s_W for
all `permutations + 1` groupings in a single Numba kernel that parallelises
across the permutation axis (`prange` over permutations). This is the
"running many f_stats in parallel" approach.

Condensed matrices and the Cython engine are unchanged — they still go through
the existing Monte Carlo path. (Parallelising the condensed numba path is a
natural follow-up; condensed already produces correct numba results today.)

Memory is bounded: permutations are processed in chunks (CHUNK x n buffer
reused), so peak memory does not grow with the permutation count.

### Benchmarks

Igor's node: AMD Ryzen 9 7940HS (8 cores / 8 threads used), Ubuntu 22.04,
GCC 11.4, `OMP_NUM_THREADS=8 NUMBA_NUM_THREADS=8`. Cython is OpenMP-enabled
(`libgomp`). EMP UniFrac DMs, **float32**. Min of repeated runs.

**5k²:**

| matrix | nperm | Cython (s) | Numba (s) | speedup |
|---|---:|---:|---:|---:|
| uw_emp_5k | 999 | 1.26 | 0.86 | 1.47× |
| uw_emp_5k | 9999 | 12.58 | 8.79 | 1.43× |
| wn_emp_5k | 999 | 1.28 | 0.88 | 1.45× |
| wn_emp_5k | 9999 | 12.85 | 8.86 | 1.45× |

**25k² — 3-way same-session run:**

| matrix | nperm | Binaries (s) | Cython (s) | Numba (s) | vs Cython |
|---|---:|---:|---:|---:|---:|
| uw_emp_25k | 999 | 2.23 | 42.03 | 18.77 | **2.24×** |
| uw_emp_25k | 9999 | 21.45 | 427.41 | 189.84 | **2.25×** |
| wn_emp_25k | 999 | 2.25 | 43.36 | 19.97 | **2.17×** |
| wn_emp_25k | 9999 | 22.37 | 436.93 | 194.35 | **2.25×** |

Speedup grows with problem size (better load balance across the permutation axis
amortises overhead at scale). scikit-bio-binaries remains ~8.7× faster via
hand-tuned AVX-512; that gap is expected for CPU Numba and is the motivation for
the GPU `@cuda.jit` path in follow-up work.

### Correctness

- **float64 input:** numba and cython are byte-identical — same statistic and
  p-value for the same seed (kernel consumes permutations in the same RNG order
  as `_run_monte_carlo_stats`). Verified across 72 configurations (sizes × group
  counts × permutation counts).
- **float32 input:** the numba kernel accumulates in float64 (promoting distances
  before squaring), whereas the cython kernel returns a float32 statistic.
  Because pseudo-F is built from `s_A = s_T - s_W` (small difference of large
  sums), that precision gap amplifies into the statistic's ~4th–5th digit
  (F differs ~1e-4). The numba value is the more precise of the two. p-values
  match except where float32 rounding flips a borderline permutation at large n
  — observed ≤0.002 at 25k², well below MC standard error (~0.016 at 999 perms).
- New tests: float32 agreement vs Cython, `permutations=0` → nan, negative
  permutations → `ValueError`, condensed falls back to the single-perm path,
  and a >CHUNK permutation count to verify RNG continuity across batches.
  Full PERMANOVA suite: 31/31 pass.

### Notes

- This is an engine optimisation, not a fresh conversion; the single-perm
  kernels remain for the condensed and Cython-fallback paths.