### PR TITLE
MAINT: measure Numba code coverage by disabling the JIT

### DIFF
--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -56,3 +56,23 @@ jobs:
 
       - name: Run full test suite with Numba installed
         run: make test
+
+      # coverage.py cannot trace JIT-compiled kernels, so re-run the suite
+      # with the JIT disabled (kernels run as plain Python). Linux x86_64 only,
+      # matching ci.yml; Codecov merges this report with the main one.
+      - name: Run unit tests with coverage (Numba JIT disabled)
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        env:
+          WITH_COVERAGE: "TRUE"
+          NUMBA_DISABLE_JIT: "1"
+        run: make test
+      - name: Generate coverage reports
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        run: |
+          cd ci && coverage lcov --rcfile ../.coveragerc
+      - name: Upload coverage reports to Codecov
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: scikit-bio/scikit-bio


### PR DESCRIPTION
Follow-up to #2484.

`coverage.py` cannot trace JIT-compiled `@njit` kernels, so the Numba implementations show up as uncovered in the coverage report even though the test suite exercises them. The job that uploads coverage (`ci.yml`) also runs without Numba installed, so those paths are never counted at all.

## What this does

The Numba CI job re-runs the suite with `NUMBA_DISABLE_JIT=1`, which turns `@njit` into a pass-through so the kernel bodies execute as plain Python and can be traced by `coverage.py`. Coverage is collected and uploaded only on Linux x86_64, matching `ci.yml`; Codecov merges this report with the main one so the Numba paths are counted.

The existing JIT-enabled `make test` run is kept, so the compiled kernels are still exercised for correctness — the new run is purely for coverage.

## Result

Locally this takes `skbio/stats/distance/_permanova.py` from 49% to 97% line coverage (the remaining lines are the `except ImportError` fallback and one unreachable branch).

@sfiligoi
