### PR TITLE
PERF: single-pass row-tile PERMANOVA Numba kernel

### DIFF
--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -31,7 +31,7 @@ from skbio.util._decorator import params_aliased
 from skbio._config import _resolve_engine
 
 try:
-    from numba import njit, prange, get_num_threads
+    from numba import njit, prange
     NUMBA_AVAILABLE = True
 except ImportError:
     NUMBA_AVAILABLE = False
@@ -192,15 +192,18 @@ if NUMBA_AVAILABLE:
 
         Parallelises over distance-matrix rows (each paired with its mirror row
         ``n - row - 2`` for load balance, as in ``_permanova_f_stat_sW_nb``)
-        rather than over permutations. Each row is owned by one worker, so the
-        matrix is read from memory only once per chunk, whereas the
-        per-permutation kernel has every worker stream the whole matrix. This
-        follows the cross-thread cache reuse of scikit-bio-binaries'
-        ``pmn_f_stat_sW_cpu`` in ``permanova_dyn_impl.hpp``.
+        rather than over permutations. Each row is owned by one worker, so each
+        distance is read from memory once per chunk and reused across all
+        permutations of the chunk, instead of streaming the whole matrix once
+        per permutation. The kernel is memory-bound, so this reuse -- not the
+        arithmetic -- is what determines its speed; it mirrors the cache reuse
+        of scikit-bio-binaries' ``pmn_f_stat_sW_cpu`` in
+        ``permanova_dyn_impl.hpp``.
 
-        The permutation loop is branchless so Numba can vectorise it, and
-        ``groupings_T`` is sample-major ``int32`` so the loop reads contiguous,
-        low-bandwidth windows.
+        The permutation loop is kept branchless (a uniform read-and-accumulate
+        over the grouping windows, with no data-dependent control flow), and
+        ``groupings_T`` is sample-major ``int32`` so each permutation's labels
+        are read as a contiguous, low-bandwidth window.
 
         Parameters
         ----------
@@ -211,20 +214,25 @@ if NUMBA_AVAILABLE:
         inv_group_sizes : np.ndarray, shape (num_groups,)
             Reciprocal group sizes (``1.0 / group_sizes``), precomputed so the
             hot loop multiplies instead of dividing.
-        partials : np.ndarray, shape (n // 2, n_perm)
-            Output, zeroed by the caller; ``partials[i]`` receives the s_W
-            contribution of the mirror-pair handled by iteration ``i``. The
-            caller sums over axis 0 to obtain s_W per permutation.
+        partials : np.ndarray, shape (n // 2, C) with C >= n_perm
+            Reused scratch (allocated once by the caller). Each iteration zeros
+            and fills the first ``n_perm`` entries of its own row ``partials[i]``
+            with the s_W contribution of the mirror-pair it handles. The caller
+            sums the first ``n_perm`` columns over axis 0 to obtain s_W per
+            permutation.
 
         """
         n = distance_matrix.shape[0]
         n_perm = groupings_T.shape[1]
         n_half = n // 2
 
-        # Each worker owns one row (and its mirror for load balance), so the
-        # distance matrix is read from memory only once per chunk.
+        # Each worker owns one row (and its mirror for load balance), so each
+        # distance is read once per chunk and reused across all permutations.
         for row_idx in prange(n_half):
+            # partials is reused across chunks, so zero this row's accumulator.
             local_sW = partials[row_idx]
+            for p in range(n_perm):
+                local_sW[p] = 0.0
             rsum = np.empty(n_perm, np.float64)
 
             for p in range(n_perm):
@@ -234,8 +242,10 @@ if NUMBA_AVAILABLE:
                 # ``double`` accumulator (matters for float32 input)
                 val = np.float64(distance_matrix[row_idx, col])
                 val2 = val * val
-                # branchless: add val2 only where both ends share a group
-                # (multiply by the 0/1 comparison) so Numba vectorises the loop
+                # branchless: scale val2 by the 0/1 group-match instead of an
+                # if, so the loop is a uniform read-accumulate over the grouping
+                # window (no data-dependent control flow) -- val2 stays in a
+                # register and is reused for every permutation
                 for p in range(n_perm):
                     rsum[p] += val2 * np.float64(
                         groupings_T[col, p] == groupings_T[row_idx, p]
@@ -316,15 +326,21 @@ if NUMBA_AVAILABLE:
         inv_group_sizes = 1.0 / group_sizes.astype(np.float64)
         n_half = sample_size // 2
 
-        # Same chunk size as the per-permutation path (32 per worker), which on
-        # this kernel keeps each worker's active grouping window in L1; chunks
-        # larger than this were measurably slower. Chunking also bounds peak
-        # memory to (CHUNK x n) regardless of the permutation count.
-        CHUNK = 32 * get_num_threads()
-        # Perm-major buffer for generation: rng.permutation fills a row, so row
-        # writes are sequential. Transposed to sample-major int32 per chunk for
-        # the kernel (see _permanova_f_stat_sW_rowtile_nb).
-        buf = np.empty((min(CHUNK, n_total), sample_size), dtype=np.intp)
+        # CHUNK is the number of permutations processed per pass over the
+        # matrix. It is not a parallelism knob (the kernel parallelises over
+        # matrix rows); it sizes each worker's private working set -- its rsum
+        # accumulator and the grouping windows it reads -- so it is a fixed
+        # constant chosen to keep that set in L1, not scaled with the thread
+        # count. It also bounds peak memory to (CHUNK x n) regardless of the
+        # permutation count.
+        CHUNK = 256
+        width = min(CHUNK, n_total)
+        # Permutation-major int32 buffer; rng.permutation fills a row, so the
+        # writes are sequential. Allocated once and reused across chunks.
+        buf = np.empty((width, sample_size), dtype=np.int32)
+        # Kernel scratch, allocated once and reused (the kernel zeros its own
+        # rows); max width is CHUNK.
+        partials = np.empty((n_half, width), np.float64)
         for start in range(0, n_total, CHUNK):
             end = min(start + CHUNK, n_total)
             chunk_size = end - start
@@ -334,15 +350,16 @@ if NUMBA_AVAILABLE:
                 else:
                     buf[i - start] = rng.permutation(grouping)
 
-            groupings_T = np.ascontiguousarray(
-                buf[:chunk_size].T, dtype=np.int32
-            )
-            partials = np.zeros((n_half, chunk_size), np.float64)
+            # Transpose to sample-major so the kernel reads each permutation's
+            # labels as a contiguous window; buf is permutation-major and buf.T
+            # is a non-contiguous view, so this materialises the C-contiguous
+            # copy the kernel needs.
+            groupings_T = np.ascontiguousarray(buf[:chunk_size].T)
             _permanova_f_stat_sW_rowtile_nb(
                 distmat.data, groupings_T, inv_group_sizes, partials
             )
             # sum each row-pair's partial contribution into s_W per permutation
-            out_sW[start:end] = partials.sum(axis=0)
+            out_sW[start:end] = partials[:, :chunk_size].sum(axis=0)
 
         s_A = s_T - out_sW
         f_stats = (s_A / (num_groups - 1)) / (out_sW / (sample_size - num_groups))

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -185,59 +185,98 @@ if NUMBA_AVAILABLE:
         return partials.sum()
 
     @njit(parallel=True)
-    def _permanova_f_stat_sW_parallel_nb(
-        distance_matrix, group_sizes, groupings_2d, out_sW
+    def _permanova_f_stat_sW_rowtile_nb(
+        distance_matrix, groupings_T, inv_group_sizes, partials
     ):
-        """Compute s_W for all permutations in parallel over the permutation axis.
+        """Compute partial s_W for a chunk of permutations in one matrix pass.
 
-        Parallelises across permutations rather than within a single
-        permutation, matching the primary optimisation in scikit-bio-binaries
-        (the ``#pragma omp parallel for`` over ``gblock`` in
-        ``permanova_dyn_impl.hpp``).  Each parallel worker computes one
-        complete f_stat independently with no cross-thread dependency.
+        Parallelises over distance-matrix rows (each paired with its mirror row
+        ``n - row - 2`` for load balance, as in ``_permanova_f_stat_sW_nb``)
+        rather than over permutations. Each row is owned by one worker, so the
+        matrix is read from memory only once per chunk, whereas the
+        per-permutation kernel has every worker stream the whole matrix. This
+        follows the cross-thread cache reuse of scikit-bio-binaries'
+        ``pmn_f_stat_sW_cpu`` in ``permanova_dyn_impl.hpp``.
+
+        The permutation loop is branchless so Numba can vectorise it, and
+        ``groupings_T`` is sample-major ``int32`` so the loop reads contiguous,
+        low-bandwidth windows.
 
         Parameters
         ----------
         distance_matrix : np.ndarray, shape (n, n)
             Full symmetric distance matrix.
-        group_sizes : np.ndarray, shape (num_groups,)
-            Number of objects per group.
-        groupings_2d : np.ndarray, shape (n_perm, n)
-            Pre-generated permuted groupings for this batch, row-major. The
-            driver may call this kernel on successive chunks of permutations.
-        out_sW : np.ndarray, shape (n_perm,)
-            Output array; ``out_sW[i]`` receives the within-group sum of
-            squares for permutation ``i`` of the batch.
+        groupings_T : np.ndarray, shape (n, n_perm), int32
+            Permuted groupings, sample-major (transposed) and C-contiguous.
+        inv_group_sizes : np.ndarray, shape (num_groups,)
+            Reciprocal group sizes (``1.0 / group_sizes``), precomputed so the
+            hot loop multiplies instead of dividing.
+        partials : np.ndarray, shape (n // 2, n_perm)
+            Output, zeroed by the caller; ``partials[i]`` receives the s_W
+            contribution of the mirror-pair handled by iteration ``i``. The
+            caller sums over axis 0 to obtain s_W per permutation.
 
         """
         n = distance_matrix.shape[0]
+        n_perm = groupings_T.shape[1]
+        n_half = n // 2
 
-        for perm_idx in prange(groupings_2d.shape[0]):
-            s_W = 0.0
-            for row in range(n - 1):
-                group_idx = groupings_2d[perm_idx, row]
-                local_sum = 0.0
-                for col in range(row + 1, n):
-                    if groupings_2d[perm_idx, col] == group_idx:
-                        # promote to float64 before squaring to match the
-                        # Cython ``double`` accumulator (matters for float32)
-                        val = np.float64(distance_matrix[row, col])
-                        local_sum += val * val
-                s_W += local_sum / group_sizes[group_idx]
-            out_sW[perm_idx] = s_W
+        # Each worker owns one row (and its mirror for load balance), so the
+        # distance matrix is read from memory only once per chunk.
+        for row_idx in prange(n_half):
+            local_sW = partials[row_idx]
+            rsum = np.empty(n_perm, np.float64)
 
-    def _run_permanova_parallel_nb(
+            for p in range(n_perm):
+                rsum[p] = 0.0
+            for col in range(row_idx + 1, n):
+                # promote to float64 before squaring to match the Cython
+                # ``double`` accumulator (matters for float32 input)
+                val = np.float64(distance_matrix[row_idx, col])
+                val2 = val * val
+                # branchless: add val2 only where both ends share a group
+                # (multiply by the 0/1 comparison) so Numba vectorises the loop
+                for p in range(n_perm):
+                    rsum[p] += val2 * np.float64(
+                        groupings_T[col, p] == groupings_T[row_idx, p]
+                    )
+            for p in range(n_perm):
+                local_sW[p] += rsum[p] * inv_group_sizes[groupings_T[row_idx, p]]
+
+            mirror_row = n - row_idx - 2
+            if mirror_row != row_idx:
+                for p in range(n_perm):
+                    rsum[p] = 0.0
+                for col in range(mirror_row + 1, n):
+                    val = np.float64(distance_matrix[mirror_row, col])
+                    val2 = val * val
+                    for p in range(n_perm):
+                        rsum[p] += val2 * np.float64(
+                            groupings_T[col, p] == groupings_T[mirror_row, p]
+                        )
+                for p in range(n_perm):
+                    local_sW[p] += (
+                        rsum[p] * inv_group_sizes[groupings_T[mirror_row, p]]
+                    )
+
+    def _run_permanova_rowtile_nb(
         distmat, grouping, group_sizes, s_T, num_groups, sample_size,
         permutations, seed
     ):
-        """Run PERMANOVA with parallelism across the permutation axis.
+        """Run PERMANOVA with the row-tile (single matrix pass) strategy.
 
-        Generates the ``permutations + 1`` groupings in fixed-size chunks and
-        computes s_W for each chunk in parallel via
-        ``_permanova_f_stat_sW_parallel_nb``, then assembles the F-statistics
-        and p-value in NumPy. Chunking bounds peak memory to ``CHUNK x n``
-        independent of the permutation count; permutations are drawn in the
-        same RNG order as the sequential Monte Carlo path, so results match.
+        Generates the ``permutations + 1`` groupings in fixed-size chunks and,
+        for each chunk, computes s_W via ``_permanova_f_stat_sW_rowtile_nb``,
+        which reads the distance matrix only once per chunk (parallelism is over
+        matrix rows, not permutations).  This is the cross-thread cache-reuse
+        path of scikit-bio-binaries; it is markedly faster than the
+        per-permutation kernel on large matrices, which are memory-bound.
+
+        Groupings are transposed to sample-major ``int32`` once per chunk so the
+        kernel's permutation loop reads contiguous, low-bandwidth windows; the
+        transpose costs a small fraction of the matrix scan.  Permutations are
+        drawn in the same RNG order as the sequential Monte Carlo path, so
+        p-values are unchanged.
 
         Parameters
         ----------
@@ -274,26 +313,36 @@ if NUMBA_AVAILABLE:
         rng = get_rng(seed)
         n_total = permutations + 1
         out_sW = np.empty(n_total, np.float64)
+        inv_group_sizes = 1.0 / group_sizes.astype(np.float64)
+        n_half = sample_size // 2
 
-        # Process permutations in chunks sized to the available parallelism so
-        # each worker handles a small batch whose active grouping rows stay
-        # resident in its per-core cache (scikit-bio-binaries uses 32
-        # permutations per worker). Chunking also bounds peak memory to
-        # (CHUNK x n) rather than the full permutation count (n_total x n).
-        # Permutations are generated in the same RNG order as the sequential
-        # Monte Carlo path, so p-values are unchanged.
+        # Same chunk size as the per-permutation path (32 per worker), which on
+        # this kernel keeps each worker's active grouping window in L1; chunks
+        # larger than this were measurably slower. Chunking also bounds peak
+        # memory to (CHUNK x n) regardless of the permutation count.
         CHUNK = 32 * get_num_threads()
+        # Perm-major buffer for generation: rng.permutation fills a row, so row
+        # writes are sequential. Transposed to sample-major int32 per chunk for
+        # the kernel (see _permanova_f_stat_sW_rowtile_nb).
         buf = np.empty((min(CHUNK, n_total), sample_size), dtype=np.intp)
         for start in range(0, n_total, CHUNK):
             end = min(start + CHUNK, n_total)
+            chunk_size = end - start
             for i in range(start, end):
                 if i == 0:
                     buf[0] = grouping
                 else:
                     buf[i - start] = rng.permutation(grouping)
-            _permanova_f_stat_sW_parallel_nb(
-                distmat.data, group_sizes, buf[: end - start], out_sW[start:end]
+
+            groupings_T = np.ascontiguousarray(
+                buf[:chunk_size].T, dtype=np.int32
             )
+            partials = np.zeros((n_half, chunk_size), np.float64)
+            _permanova_f_stat_sW_rowtile_nb(
+                distmat.data, groupings_T, inv_group_sizes, partials
+            )
+            # sum each row-pair's partial contribution into s_W per permutation
+            out_sW[start:end] = partials.sum(axis=0)
 
         s_A = s_T - out_sW
         f_stats = (s_A / (num_groups - 1)) / (out_sW / (sample_size - num_groups))
@@ -491,7 +540,7 @@ def permanova(
         s_T /= 2.0
 
     if engine == "numba" and not distmat._flags["CONDENSED"]:
-        stat, p_value = _run_permanova_parallel_nb(
+        stat, p_value = _run_permanova_rowtile_nb(
             distmat, grouping, group_sizes, s_T,
             num_groups, sample_size, permutations, seed
         )

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -464,7 +464,7 @@ class InternalPERMANOVATests(PERMANOVATestData):
         self.assertAlmostEqual(obs['p-value'], exp['p-value'])
 
     @numba_code
-    def test_permanova_parallel_nb_no_permutations(self):
+    def test_permanova_rowtile_nb_no_permutations(self):
         # permutations=0 must yield a nan p-value, matching the cython path
         dm = DistanceMatrix(self.dm_full, self.ids)
         obs = permanova(dm, self.grouping_labels, permutations=0,
@@ -476,15 +476,15 @@ class InternalPERMANOVATests(PERMANOVATestData):
         self.assertTrue(np.isnan(exp['p-value']))
 
     @numba_code
-    def test_permanova_parallel_nb_negative_permutations_raises(self):
+    def test_permanova_rowtile_nb_negative_permutations_raises(self):
         dm = DistanceMatrix(self.dm_full, self.ids)
         with self.assertRaisesRegex(ValueError, "greater than or equal to zero"):
             permanova(dm, self.grouping_labels, permutations=-1,
                       engine="numba")
 
     @numba_code
-    def test_permanova_parallel_nb_condensed_falls_back(self):
-        # condensed matrix must use the single-perm path, not the parallel path
+    def test_permanova_rowtile_nb_condensed_falls_back(self):
+        # condensed matrix must use the single-perm path, not the row-tile path
         dm_condensed = DistanceMatrix(
             squareform(self.dm_full), self.ids, condensed=True
         )
@@ -496,10 +496,10 @@ class InternalPERMANOVATests(PERMANOVATestData):
         self.assertAlmostEqual(obs['p-value'], exp['p-value'])
 
     @numba_code
-    def test_permanova_parallel_nb_crosses_chunk_boundary(self):
-        # permutations > the driver's internal CHUNK (512) exercises multiple
-        # batches; the RNG must stay in sync across chunks so the result is
-        # still identical to the cython engine.
+    def test_permanova_rowtile_nb_crosses_chunk_boundary(self):
+        # permutations exceeding the driver's internal chunk size exercises
+        # multiple batches; the RNG must stay in sync across chunks so the
+        # result is still identical to the cython engine.
         dm = DistanceMatrix(self.dm_full, self.ids)
         obs = permanova(dm, self.grouping_labels, permutations=600, seed=42,
                         engine="numba")


### PR DESCRIPTION
This replaces the per-permutation Numba engine added in #2484 with a single-pass row-tile kernel, following up on the chunking/cache discussion there.

### Approach

The per-permutation kernel parallelises across permutations, so every worker streams the whole distance matrix — it is memory-bound on large matrices, which is why it plateaued around 2x. This kernel instead parallelises over **distance-matrix rows** and processes a whole chunk of permutations against each matrix element while it is loaded. Each row is owned by exactly one worker, so the matrix is read from memory once per chunk rather than once per worker. This is the cross-thread cache reuse the scikit-bio-binaries CPU path relies on (`pmn_f_stat_sW_cpu` in `permanova_dyn_impl.hpp`).

Details:
- The permutation loop is **branchless** (`rsum[p] += val2 * (groupings_T[col, p] == groupings_T[row, p])`) so Numba auto-vectorises it. The branchy form used in the C++ does not vectorise under Numba — I confirmed in the generated LLVM IR that the faithful port (and a branchless `NBLOCK=16` block variant, with and without `fastmath`) stays scalar, while this long branchless loop vectorises to AVX-512 on the test machine.
- Groupings are passed **sample-major `int32`** so the loop reads contiguous, low-bandwidth windows (int32 measured ~2.9x faster than int64 at 25k²).
- Rows are **mirror-paired** (`row` with `n - row - 2`) for load balance, matching `_permanova_f_stat_sW_nb`.
- `CHUNK = 32 * get_num_threads()` (same as before); larger chunks were measurably slower, consistent with keeping each worker's active grouping window in L1.
- Permutations are drawn in the same RNG order as before, so p-values are unchanged for float64 input.

### Benchmarks

EMP UniFrac DMs, AMD Ryzen 9 7940HS (8 threads), GCC/OpenMP, 999 / 9999 permutations. skbio-binaries (`libskbb.so`, x86-64-v4/AVX-512) shown for reference:

| matrix | perms | cython (s) | numba row-tile (s) | skbio-binaries (s) | numba vs cython | numba vs binaries |
|---|---:|---:|---:|---:|---:|---:|
| uw_emp_5k | 999 | 1.35 | 0.23 | 0.14 | 5.9x | 1.6x slower |
| uw_emp_5k | 9999 | 12.51 | 2.31 | 1.35 | 5.4x | 1.7x slower |
| wn_emp_5k | 999 | 1.31 | 0.24 | 0.14 | 5.5x | 1.7x slower |
| wn_emp_5k | 9999 | 12.75 | 2.23 | 1.35 | 5.7x | 1.7x slower |
| uw_emp_25k | 999 | 42.63 | 5.50 | 2.18 | 7.8x | 2.5x slower |
| uw_emp_25k | 9999 | 429.36 | 53.26 | 21.53 | 8.1x | 2.5x slower |
| wn_emp_25k | 999 | 42.96 | 5.51 | 2.21 | 7.8x | 2.5x slower |
| wn_emp_25k | 9999 | 434.86 | 52.19 | 21.61 | 8.3x | 2.4x slower |

At 25k²/9999 this is ~3.6x faster than the per-permutation engine (~191s) and ~2.5x off skbio-binaries; on the cache-resident 5k matrices binaries' lead narrows to ~1.6-1.7x. All three agree on the F-statistic (binaries also float32). Closing the remaining gap is the GPU `@cuda.jit` follow-up.

### Numerical agreement

Statistic and p-value are identical to the cython engine for float64 input. For float32 input the statistic differs at the ~1e-4 level because the Numba kernels accumulate in float64 (the cython path does not), so the p-value can differ by Monte-Carlo noise; this matches the existing per-permutation engine's behaviour.

### Notes

- Removes the now-unused `_permanova_f_stat_sW_parallel_nb` / `_run_permanova_parallel_nb`; the corresponding tests were renamed and still cover permutations=0, negative-raises, condensed fallback, and chunk-boundary behaviour.
- 31 tests pass with the JIT enabled and with `NUMBA_DISABLE_JIT=1`.

@sfiligoi
