### PR TITLE
MAINT: Fix missing variable declarations in Cython code

### DIFF
--- a/skbio/stats/distance/_cutils.pyx
+++ b/skbio/stats/distance/_cutils.pyx
@@ -435,7 +435,7 @@ def permanova_f_stat_sW_condensed_cy(TReal[::1] distance_matrix,
     cdef double local_s_W
     cdef double val
 
-    cdef Py_ssize_t row, col, rowi, coli, row1
+    cdef Py_ssize_t row, col, rowi, coli, row1, idx_
     cdef Py_ssize_t in_n_2 = n//2
 
     for rowi in prange(in_n_2, nogil=True):

--- a/skbio/tree/_c_me.pyx
+++ b/skbio/tree/_c_me.pyx
@@ -2125,7 +2125,7 @@ def _bal_update_spine(
     This trivial function has to be executed after chunking and before filling.
 
     """
-    cdef Py_ssize_t i
+    cdef Py_ssize_t i, anc
     cdef Py_ssize_t size_3 = sizes[tag] + 3
 
     for i in range(deep):
@@ -2896,6 +2896,7 @@ def _ols_corner_swaps(
 
     """
     cdef Py_ssize_t m = tacts[0] + 1
+    cdef Py_ssize_t node
     cdef Py_ssize_t i, left, right, parent, sibling
 
     # update four corner branches if they are internal

--- a/skbio/tree/_c_me.pyx
+++ b/skbio/tree/_c_me.pyx
@@ -980,6 +980,7 @@ def _bal_min_branch_p(
     cdef Py_ssize_t icla = 0  # current clade index
     cdef Py_ssize_t nchu = 1  # current number of chunks
     cdef Py_ssize_t ichu      # current chunk index
+    cdef Py_ssize_t j
 
     # Serial phase: Traverse the tree from root and identify clades to parallelize on,
     # while doing calculations for nodes outside those clades.
@@ -2245,7 +2246,7 @@ def _bal_avgdist_nest(
     cdef Py_ssize_t iseg  # segment index
     cdef Py_ssize_t seg   # segment bound
 
-    cdef floating diff
+    cdef floating npot, diff
     cdef floating* adm_0 = &adm[0, 0]
     cdef floating* adm_a
     cdef floating* npots_2 = &npots[2]


### PR DESCRIPTION
This PR addresses #2487 . There are three cases of undefined variables within Cython nogil loops, which causes compile error in certain Cython versions.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
