### PR TITLE
MAINT: Restrict GITHUB_TOKEN permissions to read-only in workflows

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -12,6 +12,11 @@ on:
 env:
   latest_python: "3.13"  # torch has no 3.14 wheels yet
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). This workflow only checks out the repo and runs tests.
+permissions:
+  contents: read
+
 jobs:
   test-cpu:
     name: Array API (${{ matrix.backend }}, cpu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ env:
   latest_python: "3.14"
   supported_pythons: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). No job uses the token to write to this repository:
+# documentation is deployed to the website repo via an SSH deploy key.
+permissions:
+  contents: read
+
 jobs:
   conf:
     # This job is needed to route the global environment variables into

--- a/.github/workflows/numba.yml
+++ b/.github/workflows/numba.yml
@@ -12,6 +12,12 @@ on:
 env:
   latest_python: "3.14"
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). This workflow only checks out the repo, runs tests, and
+# uploads coverage to Codecov via CODECOV_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   conf:
     # This job is needed to route the global environment variables into

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ env:
   earliest_python: "3.10"
   latest_python: "3.14"
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). No job uses the token to write to this repository:
+# documentation is deployed to the website repo via an SSH deploy key and the
+# package is published to PyPI via an API token (see wheels.yml).
+permissions:
+  contents: read
+
 jobs:
   # Trigger wheel building workflow
   build_and_publish:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,6 +11,12 @@ on:
 env:
   latest_python: "3.14"
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). The website is deployed to the website repo via an SSH
+# deploy key, not the GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,6 +11,12 @@ on:
 env:
   latest_python: "3.14"
 
+# Limit the automatically-provided GITHUB_TOKEN to read-only access (principle
+# of least privilege). Publishing to PyPI uses an API token (PYPI_API_TOKEN),
+# not the GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Closes #2492.

GitHub Advanced Security flags that the project's Actions workflows don't restrict the permissions of the automatically-provided `GITHUB_TOKEN`. When no `permissions` block is set, the token defaults to broad read/write scopes. This PR adds a top-level

```yaml
permissions:
  contents: read
```

to all five workflows (`array-api.yml`, `ci.yml`, `release.yml`, `website.yml`, `wheels.yml`), following the principle of least privilege as suggested by the security bot and #2490.

## Why read-only is sufficient

I checked every job in every workflow — none uses `GITHUB_TOKEN` to write to this repository:

| Operation | Workflow(s) | Mechanism (not `GITHUB_TOKEN`) |
|---|---|---|
| Deploy docs / website to `scikit-bio.github.io` | `ci.yml`, `release.yml`, `website.yml` | SSH deploy key (`SSH_DEPLOY_KEY`) |
| Publish package to PyPI | `wheels.yml` (via `release.yml`) | API token (`PYPI_API_TOKEN`) |
| Upload coverage | `ci.yml` | Codecov token (`CODECOV_TOKEN`) |
| Artifact upload/download | `ci.yml`, `wheels.yml`, `website.yml` | Works within the run under `contents: read` |
| Checkout / tests / lint / build | all | Read-only |

The reusable-workflow call `release.yml` → `wheels.yml` (`secrets: inherit`) stays consistent: both declare `contents: read`, which is within the caller's bounds, and PyPI publishing relies on the inherited token secret rather than `GITHUB_TOKEN`.

If a future job needs elevated access, it should request the specific scope at the job level rather than widening the workflow default.

## Checklist

- [x] I have read the contribution guidelines.
- [x] No public-facing changes, so no changelog entry is needed (CI-only hardening).
- [x] This pull request does not include code, documentation, or other content derived from external source(s).