### PR TITLE
MAINT: Clarify embedding length-mismatch error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.7.4-dev
 
+### Miscellaneous
+
+* Clarified the error message raised when an `Embedding` does not have one row per id. The message now states "The number of rows in the embedding (X) must match the number of ids (Y).", and `SequenceEmbedding`/`ProteinEmbedding` report "characters in the sequence" instead of "ids". The `ids` parameter is also better documented ([#2494](https://github.com/scikit-bio/scikit-bio/pull/2494)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/embedding/_embedding.py
+++ b/skbio/embedding/_embedding.py
@@ -36,9 +36,15 @@ class Embedding(SkbioObject):
     embedding : array_like
         Embedding matrix where the first axis is indexed by `ids`.
     ids : array_like
-        IDs of biological objects.
+        Identifiers of the biological objects being embedded, one per row of
+        ``embedding`` (e.g., the characters of a sequence, or sample or feature
+        names). The length of ``ids`` must equal the number of rows in
+        ``embedding``.
 
     """
+
+    # noun used in error messages to describe what each embedding row maps to
+    _obj_noun = "ids"
 
     read = Read()
     write = Write()
@@ -55,12 +61,12 @@ class Embedding(SkbioObject):
         return self._ids
 
     def __init__(self, embedding, ids, **kwargs):
-        # make sure that the embedding has the same length as the sequence
+        # the embedding must have exactly one row per id
         ids_len = len(ids)
         if embedding.shape[0] != ids_len:
             raise ValueError(
-                f"The embedding ({embedding.shape[0]}) must have the "
-                f"same length as the ids ({ids_len})."
+                f"The number of rows in the embedding ({embedding.shape[0]}) "
+                f"must match the number of {self._obj_noun} ({ids_len})."
             )
 
         self._embedding = np.asarray(embedding)
@@ -92,6 +98,8 @@ class SequenceEmbedding(Embedding):
     skbio.sequence.Sequence
 
     """
+
+    _obj_noun = "characters in the sequence"
 
     def __init__(self, embedding, sequence, **kwargs):
         if isinstance(sequence, Sequence):

--- a/skbio/embedding/tests/test_embedding.py
+++ b/skbio/embedding/tests/test_embedding.py
@@ -48,7 +48,10 @@ class EmbeddingTests(TestCase):
             Embedding(self.emb, self.seq).__str__()
 
     def test_assert_length(self):
-        msg = "The embedding (62) must have the same length as the ids (63)."
+        msg = (
+            "The number of rows in the embedding (62) must match the number "
+            "of ids (63)."
+        )
         with self.assertRaises(ValueError) as cm:
             Embedding(self.emb, self.seq + "A")
         self.assertEqual(str(cm.exception), msg)
@@ -99,7 +102,10 @@ class SequenceEmbeddingTests(TestCase):
         self.assertTupleEqual(p_emb.embedding.shape, (62, 10))
 
     def test_assert_length(self):
-        msg = "The embedding (62) must have the same length as the ids (63)."
+        msg = (
+            "The number of rows in the embedding (62) must match the number "
+            "of characters in the sequence (63)."
+        )
         with self.assertRaises(ValueError) as cm:
             SequenceEmbedding(self.emb, self.seq + "A")
         self.assertEqual(str(cm.exception), msg)

--- a/skbio/embedding/tests/test_protein.py
+++ b/skbio/embedding/tests/test_protein.py
@@ -77,8 +77,13 @@ class ProteinEmbeddingTests(TestCase):
         self.assertTupleEqual(p_emb.embedding.shape, (62, 1024))
 
     def test_assert_length(self):
-        with self.assertRaises(ValueError):
+        msg = (
+            "The number of rows in the embedding (62) must match the number "
+            "of characters in the sequence (63)."
+        )
+        with self.assertRaises(ValueError) as cm:
             ProteinEmbedding(self.emb, self.seq + "A")
+        self.assertEqual(str(cm.exception), msg)
 
     def test_invalid_sequence(self):
         emb, s = self.emb, self.invalid_seq


### PR DESCRIPTION
## Summary

Closes #2047.

The `Embedding` constructor raises a `ValueError` when the embedding does not have one row per id. As reported in #2047, the message was confusing:

```
ValueError: The embedding (62) must have the same length as the ids (63).
```

Two problems:
1. **"The embedding (62)"** reads as if the embedding *equals* 62, rather than *having 62 rows*.
2. `SequenceEmbedding` / `ProteinEmbedding` pass the **sequence** to the base class as `ids`, so a user who constructed a `SequenceEmbedding(embedding, sequence)` was told about "ids" — something they never passed.

## Changes

- Reworded the base message to be dimension-explicit:
  > The number of rows in the embedding (62) must match the number of ids (63).
- Sequence-based subclasses now substitute a sequence-appropriate noun via a small `_obj_noun` class attribute, so the same mismatch on a `SequenceEmbedding`/`ProteinEmbedding` reads:
  > The number of rows in the embedding (62) must match the number of characters in the sequence (63).
- Clarified the `ids` parameter docstring to explain what ids represent (one per row; e.g. sequence characters or sample/feature names) and the length constraint — addressing the reporter's "what are biological IDs in more general cases?" question.

`EmbeddingVector` / `SequenceVector` keep the generic "ids" wording, which is correct for them (one vector per object).

## Testing

- Updated `EmbeddingTests.test_assert_length` and `SequenceEmbeddingTests.test_assert_length` for the new messages.
- Strengthened `ProteinEmbeddingTests.test_assert_length` (previously only checked the exception type) to assert the inherited sequence-aware message.
- Full `skbio/embedding/` suite passes (35 tests); `ruff` clean.

## Checklist

- [x] I have read the contribution guidelines.
- [x] Documented in the changelog (Miscellaneous).
- [x] This pull request does not include code, documentation, or other content derived from external source(s).