### PR TITLE
ENH: Add inplace parameter to TreeNode.prune and bifurcate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Add optional support for the Numba backend [#2483](https://github.com/scikit-bio/scikit-bio/pull/2483), with Permanova and Mantel currently using it [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488)and [#2464](https://github.com/scikit-bio/scikit-bio/pull/2464).
+* `TreeNode.prune` and `TreeNode.bifurcate` now accept an `inplace` parameter (default `True`, preserving the previous in-place behavior) and return the resulting tree. This makes them consistent with other whole-tree methods such as `shear` and `root_at_midpoint`. Set `inplace=False` to leave the original tree unchanged and operate on a copy ([#2495](https://github.com/scikit-bio/scikit-bio/pull/2495)).
 
 ### Performance enhancements
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -1603,7 +1603,7 @@ class TreeNode(SkbioObject):
             if func(node):
                 node.parent.remove(node, uncache=False)  # type: ignore[union-attr]
 
-    def prune(self, uncache: bool = True):
+    def prune(self, inplace: bool = True, uncache: bool = True) -> TreeNode:
         r"""Collapse single-child nodes in the tree.
 
         Internal nodes with only one child will be removed, and direct connections will
@@ -1613,11 +1613,25 @@ class TreeNode(SkbioObject):
 
         Parameters
         ----------
+        inplace : bool, optional
+            Whether to modify the tree in place (True, default) or to create a modified
+            copy of the tree (False).
+
+            .. versionadded:: 0.7.4
+
         uncache : bool, optional
             Whether to clear caches of the tree if present (default: True). See
-            :meth:`details <has_caches>`.
+            :meth:`details <has_caches>`. Only applicable when ``inplace`` is True.
 
             .. versionadded:: 0.6.3
+
+        Returns
+        -------
+        TreeNode
+            The resulting tree.
+
+            .. versionchanged:: 0.7.4
+                Now returns the tree. Previously the method returned nothing.
 
         See Also
         --------
@@ -1649,7 +1663,7 @@ class TreeNode(SkbioObject):
                   \k------- /j-------|
                                       \-i
 
-        >>> tree.prune()
+        >>> tree = tree.prune()
         >>> print(tree.ascii_art())
                                       /-a
                             /c-------|
@@ -1662,14 +1676,15 @@ class TreeNode(SkbioObject):
                             \-i
 
         """
-        if uncache:
-            self.clear_caches()
+        tree = self if inplace else self.copy()
+        if inplace and uncache:
+            tree.clear_caches()
 
         # build up the list of nodes to remove so the topology is not altered
         # while traversing
         nodes_to_remove: list[TreeNode] = []
         nodes_to_remove_append = nodes_to_remove.append
-        for node in self.traverse(include_self=False):
+        for node in tree.traverse(include_self=False):
             if len(node.children) == 1:
                 nodes_to_remove_append(node)
 
@@ -1688,18 +1703,20 @@ class TreeNode(SkbioObject):
 
         # If there is a single descendent from the root, the root will adopt the
         # child's properties. We can't "delete" the root as that would be deleting
-        # self.
-        if len(self.children) == 1:
-            child = self.children[0]
-            if child.length is None or self.length is None:
-                self.length = self.length or child.length
+        # the tree itself.
+        if len(tree.children) == 1:
+            child = tree.children[0]
+            if child.length is None or tree.length is None:
+                tree.length = tree.length or child.length
             else:
-                self.length += child.length
+                tree.length += child.length
             for key, value in child.__dict__.items():
                 if key not in ("length", "parent", "children"):
-                    self.__dict__[key] = value
-            self.remove(child, uncache=False)
-            self.extend(child.children, uncache=False)
+                    tree.__dict__[key] = value
+            tree.remove(child, uncache=False)
+            tree.extend(child.children, uncache=False)
+
+        return tree
 
     def shear(
         self,
@@ -1942,8 +1959,9 @@ class TreeNode(SkbioObject):
         self,
         insert_length: int | None = None,
         include_self: bool = True,
+        inplace: bool = True,
         uncache: bool = True,
-    ):
+    ) -> TreeNode:
         r"""Convert the tree into a bifurcating tree.
 
         All nodes that have more than two children will have additional intermediate
@@ -1959,11 +1977,25 @@ class TreeNode(SkbioObject):
 
             .. versionadded:: 0.6.3
 
+        inplace : bool, optional
+            Whether to modify the tree in place (True, default) or to create a modified
+            copy of the tree (False).
+
+            .. versionadded:: 0.7.4
+
         uncache : bool, optional
             Whether to clear caches of the tree if present (default: True). See
-            :meth:`details <has_caches>`.
+            :meth:`details <has_caches>`. Only applicable when ``inplace`` is True.
 
             .. versionadded:: 0.6.3
+
+        Returns
+        -------
+        TreeNode
+            The resulting tree.
+
+            .. versionchanged:: 0.7.4
+                Now returns the tree. Previously the method returned nothing.
 
         See Also
         --------
@@ -1994,7 +2026,7 @@ class TreeNode(SkbioObject):
                   \f-------|
                             \-e
 
-        >>> tree.bifurcate()
+        >>> tree = tree.bifurcate()
         >>> print(tree.ascii_art())
                             /-h
                   /c-------|
@@ -2009,10 +2041,11 @@ class TreeNode(SkbioObject):
                             \-e
 
         """
-        if uncache:
-            self.clear_caches()
-        treenode = self.__class__
-        for node in self.traverse(include_self=include_self):
+        tree = self if inplace else self.copy()
+        if inplace and uncache:
+            tree.clear_caches()
+        treenode = tree.__class__
+        for node in tree.traverse(include_self=include_self):
             if len(node.children) > 2:
                 stack = node.children
                 while len(stack) > 2:
@@ -2022,6 +2055,8 @@ class TreeNode(SkbioObject):
                     for child in stack:
                         node.remove(child, uncache=False)
                     node.extend([ind, interm], uncache=False)
+
+        return tree
 
     @params_aliased([("shuffler", "shuffle_f", "0.6.3", True)])
     def shuffle(

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -723,6 +723,30 @@ class TreeTests(TestCase):
         self.assertIs(n.parent, c)
         self.assertAlmostEqual(n.length, 6)
 
+    def test_prune_inplace(self):
+        """prune supports the inplace parameter and returns the tree."""
+        exp_before = "((a,b)c)extra;\n"
+        exp_after = "(a,b)c;\n"
+
+        # inplace=True (default): mutates self and returns self
+        t = TreeNode.read(["((a,b)c)extra;"])
+        obs = t.prune()
+        self.assertIs(obs, t)
+        self.assertEqual(str(t), exp_after)
+
+        # inplace=True explicitly
+        t = TreeNode.read(["((a,b)c)extra;"])
+        obs = t.prune(inplace=True)
+        self.assertIs(obs, t)
+        self.assertEqual(str(t), exp_after)
+
+        # inplace=False: original is untouched and a pruned copy is returned
+        t = TreeNode.read(["((a,b)c)extra;"])
+        obs = t.prune(inplace=False)
+        self.assertIsNot(obs, t)
+        self.assertEqual(str(t), exp_before)
+        self.assertEqual(str(obs), exp_after)
+
     def test_shear(self):
         """Shear tree to keep given tips."""
         # LCA is root, and root is retained
@@ -951,6 +975,30 @@ class TreeTests(TestCase):
 
         for node in tree.traverse():
             self.assertIs(type(node), TreeNodeSubclass)
+
+    def test_bifurcate_inplace(self):
+        """bifurcate supports the inplace parameter and returns the tree."""
+        exp_before = "((a,b,c));\n"
+        exp_after = "((c,(a,b)));\n"
+
+        # inplace=True (default): mutates self and returns self
+        t = TreeNode.read(["((a,b,c));"])
+        obs = t.bifurcate()
+        self.assertIs(obs, t)
+        self.assertEqual(str(t), exp_after)
+
+        # inplace=True explicitly
+        t = TreeNode.read(["((a,b,c));"])
+        obs = t.bifurcate(inplace=True)
+        self.assertIs(obs, t)
+        self.assertEqual(str(t), exp_after)
+
+        # inplace=False: original is untouched and a bifurcated copy is returned
+        t = TreeNode.read(["((a,b,c));"])
+        obs = t.bifurcate(inplace=False)
+        self.assertIsNot(obs, t)
+        self.assertEqual(str(t), exp_before)
+        self.assertEqual(str(obs), exp_after)
 
     def test_shuffle(self):
         # default behavior: all tips are shuffled, only one tree is yielded


### PR DESCRIPTION
## Summary

Closes #1571.

Several `TreeNode` methods that manipulate the whole tree behave inconsistently: `shear`, `root`, `root_at_midpoint`, and `root_by_outgroup` accept an `inplace` argument and **return** the resulting tree, whereas `prune` and `bifurcate` only ever modify the tree in place and return `None`.

This PR closes that gap by giving `prune` and `bifurcate` the same `inplace` interface as the other whole-tree methods:

* Add an `inplace: bool` parameter to both methods.
* Both methods now **return the resulting tree** (previously they returned `None`).
* With `inplace=False`, the original tree is left untouched and the operation is performed on a copy (mirroring `shear`).

### Backward compatibility

`inplace` defaults to **`True`**, which preserves the existing in-place behavior. Existing calls like `tree.prune()` and `tree.bifurcate()` keep mutating the tree exactly as before; they simply now also return it (callers that ignore the return value are unaffected). No existing call sites in the codebase rely on the old `None` return.

I chose `inplace=True` as the default specifically to avoid a silent breaking change. The other whole-tree methods default to `inplace=False`, so this leaves a small residual difference in defaults — happy to flip `prune`/`bifurcate` to `inplace=False` instead if maintainers prefer full consistency and are comfortable with the (breaking) behavior change, in which case I'd add a deprecation path.

## Testing

* Added `test_prune_inplace` and `test_bifurcate_inplace` covering: the default in-place behavior returns `self`; explicit `inplace=True` returns `self`; and `inplace=False` leaves the original unchanged and returns a modified copy.
* Full `skbio/tree` test suite passes locally (165 passed).
* `prune`/`bifurcate` doctests updated (they now capture the returned tree) and pass.
* `ruff check` is clean on the modified module.

## Checklist

- [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
- [x] This pull request includes a `CHANGELOG.md` entry (under 0.7.4-dev, Features).
- [x] This pull request does not include code, documentation, or other content derived from external source(s).
