### PR TITLE
BUG: Fix TreeNode.copy of attributes referencing other nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
 
+### Bug Fixes
+
+* Fixed `TreeNode.copy` (and `copy.copy`/`copy.deepcopy`) producing detached duplicate nodes, or recursing infinitely on cyclic references, when a node carried a custom attribute referencing another node in the same tree. Such references are now redirected to the corresponding nodes in the copy ([#2497](https://github.com/scikit-bio/scikit-bio/pull/2497)).
+
 ## Version 0.7.3
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,8 @@
 ### Performance enhancements
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
+* Improved `TreeNode.copy` such that it can handle node cross-references correctly: If a node attribute refers to another node in the tree, the copied node attribute will be redirected to the corresponding node in the new tree ([#2497](https://github.com/scikit-bio/scikit-bio/pull/2497)).
 
-### Bug Fixes
-
-* Fixed `TreeNode.copy` (and `copy.copy`/`copy.deepcopy`) producing detached duplicate nodes, or recursing infinitely on cyclic references, when a node carried a custom attribute referencing another node in the same tree. Such references are now redirected to the corresponding nodes in the copy ([#2497](https://github.com/scikit-bio/scikit-bio/pull/2497)).
 
 ## Version 0.7.3
 

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -217,10 +217,6 @@ class TreeNode(SkbioObject):
     def _copy(self, deep, memo):
         """Return a copy of self."""
 
-        # decide deep or shallow copy
-        _copy = deepcopy if deep else copy
-        _args = [memo] if deep else []
-
         # node attributes to exclude during copying
         # add any custom attributes that were registered as caches
         exclude_attrs = self._exclude_from_copy
@@ -237,9 +233,8 @@ class TreeNode(SkbioObject):
         # within a tree, so...
         treenode = self.__class__
 
-        def __copy_node(node, parent=None):
-            """Copy a node."""
-
+        def __copy_structure(node, parent=None):
+            """Copy a node's built-in attributes (but not custom ones)."""
             # create a new instance by transferring built-in attributes, which can be
             # directly assigned
             res = treenode(
@@ -250,20 +245,19 @@ class TreeNode(SkbioObject):
                 children=None,
             )
             res.id = node.id
-
-            # copy custom attributes, which may be compound objects therefore need to
-            # be copied
-            # this method of iteration is slightly faster than
-            # `for key in node.__dict__.keys() - exclude_attrs:`
-            for key in node.__dict__:
-                if key not in exclude_attrs:
-                    res.__dict__[key] = _copy(node.__dict__[key], *_args)
             return res
 
-        # start with a copy of self, which will become the root (no parent)
-        root = __copy_node(self)
-        stack = [[root, self, len(self.children)]]
+        # First pass: copy the tree structure (built-in attributes only) and record
+        # a mapping from each original node to its copy. Copying of custom attributes
+        # is deferred to a second pass so that every node already exists before any
+        # attribute that references another node is copied. This avoids producing
+        # detached duplicates (or recursing infinitely on cyclic references) when a
+        # custom attribute points at another node in the tree (see issue #2084).
+        new_root = __copy_structure(self)
+        node_pairs = [(self, new_root)]
+        stack = [[new_root, self, len(self.children)]]
         stack_append = stack.append
+        pairs_append = node_pairs.append
 
         while stack:
             # check the top node, any children left unvisited?
@@ -273,12 +267,38 @@ class TreeNode(SkbioObject):
             if unvisited_children:
                 top[2] -= 1
                 old_child = old_top_node.children[-unvisited_children]
-                new_child = __copy_node(old_child, new_top_node)
+                new_child = __copy_structure(old_child, new_top_node)
                 new_top_node.children.append(new_child)
+                pairs_append((old_child, new_child))
                 stack_append([new_child, old_child, len(old_child.children)])
             else:
                 del stack[-1]
-        return root
+
+        # Second pass: copy custom attributes, which may be compound objects and
+        # therefore need to be copied. References to nodes within the same tree are
+        # redirected to the corresponding nodes in the copy.
+        if deep:
+            # Seed the deepcopy memo with the old-to-new node mapping. ``deepcopy``
+            # then substitutes the copied node for any reference into the original
+            # tree, whether direct, nested within a container, or cyclic.
+            for old_node, new_node in node_pairs:
+                memo[id(old_node)] = new_node
+            for old_node, new_node in node_pairs:
+                for key in old_node.__dict__:
+                    if key not in exclude_attrs:
+                        new_node.__dict__[key] = deepcopy(old_node.__dict__[key], memo)
+        else:
+            node_map = {id(old_node): new_node for old_node, new_node in node_pairs}
+            for old_node, new_node in node_pairs:
+                for key in old_node.__dict__:
+                    if key not in exclude_attrs:
+                        value = old_node.__dict__[key]
+                        if id(value) in node_map:
+                            new_node.__dict__[key] = node_map[id(value)]
+                        else:
+                            new_node.__dict__[key] = copy(value)
+
+        return new_root
 
     def __copy__(self):
         """Return a shallow copy."""

--- a/skbio/tree/_tree.py
+++ b/skbio/tree/_tree.py
@@ -288,12 +288,18 @@ class TreeNode(SkbioObject):
                     if key not in exclude_attrs:
                         new_node.__dict__[key] = deepcopy(old_node.__dict__[key], memo)
         else:
-            node_map = {id(old_node): new_node for old_node, new_node in node_pairs}
+            node_map = None
             for old_node, new_node in node_pairs:
                 for key in old_node.__dict__:
                     if key not in exclude_attrs:
                         value = old_node.__dict__[key]
-                        if id(value) in node_map:
+                        if isinstance(value, TreeNode):
+                            if node_map is None:
+                                node_map = {
+                                    id(old_node): new_node
+                                    for old_node, new_node in node_pairs
+                                }
+                        if node_map is not None and id(value) in node_map:
                             new_node.__dict__[key] = node_map[id(value)]
                         else:
                             new_node.__dict__[key] = copy(value)
@@ -330,6 +336,9 @@ class TreeNode(SkbioObject):
         .. versionchanged:: 0.6.3
             Node attribute caches will not be copied.
 
+        .. versionchanged:: 0.7.4
+            Can redirect node references to the copied tree.
+
         See Also
         --------
         unrooted_copy
@@ -344,15 +353,66 @@ class TreeNode(SkbioObject):
         new objects rather than references to the original objects. The distinction
         between deep and shallow copies only applies to each node attribute.
 
+        If node attributes are references to other nodes in the tree, they will be
+        redirected to the new nodes in the copied tree, rather than the old nodes in
+        the original tree. However, node references nested inside compound attributes
+        will not be redirected in the shallow copy mode (they will when `deep=True` is
+        added to the function call).
+
         Examples
         --------
         >>> from skbio import TreeNode
-        >>> tree = TreeNode.read(["((a,b)c,(d,e)f)root;"])
-        >>> tree_copy = tree.copy()
-        >>> tree_nodes = set([id(n) for n in tree.traverse()])
-        >>> tree_copy_nodes = set([id(n) for n in tree_copy.traverse()])
-        >>> print(len(tree_nodes.intersection(tree_copy_nodes)))
-        0
+        >>> tree = TreeNode.read(["(a,b)c;"])
+        >>> a, b = tree.find("a"), tree.find("b")
+
+        The function's behavior will be demonstrated using these node attributes:
+
+        >>> a.length = 1.0       # built-in attribute
+        >>> a.label = "marker"   # custom simple attribute
+        >>> a.values = [[1, 2]]  # custom compound attribute
+        >>> a.partner = b        # direct node reference
+        >>> a.links = [b]        # nested node reference
+
+        By default, the function makes a shallow copy of the tree, in which only the
+        outer-most level of each node attribute is copied, whereas nested attributes
+        are shared as references.
+
+        >>> shallow = tree.copy()
+        >>> shallow_a = shallow.find("a")
+        >>> shallow_a is a
+        False
+        >>> shallow_a.length
+        1.0
+        >>> shallow_a.label
+        'marker'
+        >>> shallow_a.values
+        [[1, 2]]
+        >>> shallow_a.values is a.values
+        False
+        >>> shallow_a.values[0] is a.values[0]
+        True
+
+        Attributes that are references to other nodes in the tree are redirected to the
+        corresponding nodes in the copied tree. However, node references nested inside
+        compound attributes still point to the original tree.
+
+        >>> shallow_a.partner is shallow.find("b")
+        True
+        >>> shallow_a.links[0] is b
+        True
+
+        A deep copy also copies nested values and redirects nested node references:
+
+        >>> deep = tree.copy(deep=True)
+        >>> deep_a, deep_b = deep.find("a"), deep.find("b")
+        >>> deep_a.values is a.values
+        False
+        >>> deep_a.values[0] is a.values[0]
+        False
+        >>> deep_a.partner is deep_b
+        True
+        >>> deep_a.links[0] is deep_b
+        True
 
         """
         return self._copy(deep, {})
@@ -5957,8 +6017,9 @@ class TreeNode(SkbioObject):
 
     @classonlymethod
     def from_taxonomy(
-        cls, lineage_map: dict | Iterable[tuple] | pd.DataFrame,
-        extract_rank: bool = False
+        cls,
+        lineage_map: dict | Iterable[tuple] | pd.DataFrame,
+        extract_rank: bool = False,
     ) -> Self:
         r"""Construct a tree from a taxonomy.
 

--- a/skbio/tree/tests/test_tree.py
+++ b/skbio/tree/tests/test_tree.py
@@ -156,6 +156,58 @@ class TreeTests(TestCase):
         cp.dummy[1].append(0)
         self.assertListEqual(t.dummy[1], [2, 3])
 
+    def test_copy_remaps_node_reference_attribute(self):
+        """Deep copy redirects a node-referencing attribute to the new tree."""
+        t = self.simple_t
+        a, b = t.find("a"), t.find("b")
+        a.partner = b
+
+        cp = t.copy(deep=True)
+        cp_a, cp_b = cp.find("a"), cp.find("b")
+
+        # the attribute points to the corresponding node in the copy, not to
+        # a detached duplicate or the original node
+        self.assertIs(cp_a.partner, cp_b)
+        self.assertIsNot(cp_a.partner, b)
+
+    def test_copy_remaps_node_reference_attribute_shallow(self):
+        """Shallow copy redirects a node-referencing attribute to the new tree."""
+        t = self.simple_t
+        a, b = t.find("a"), t.find("b")
+        a.partner = b
+
+        cp = t.copy(deep=False)
+        cp_a, cp_b = cp.find("a"), cp.find("b")
+
+        self.assertIs(cp_a.partner, cp_b)
+        self.assertIsNot(cp_a.partner, b)
+
+    def test_copy_handles_cyclic_node_references(self):
+        """Copying a tree with cyclic node references does not infinitely recurse."""
+        t = self.simple_t
+        a, b = t.find("a"), t.find("b")
+        a.partner = b
+        b.partner = a
+
+        cp = t.copy(deep=True)
+        cp_a, cp_b = cp.find("a"), cp.find("b")
+
+        self.assertIs(cp_a.partner, cp_b)
+        self.assertIs(cp_b.partner, cp_a)
+
+    def test_copy_remaps_nested_node_references(self):
+        """Deep copy redirects node references nested inside containers."""
+        t = self.simple_t
+        a, b, c = t.find("a"), t.find("b"), t.find("c")
+        a.links = [b, c]
+
+        cp = t.copy(deep=True)
+        cp_a, cp_b, cp_c = cp.find("a"), cp.find("b"), cp.find("c")
+
+        self.assertIs(cp_a.links[0], cp_b)
+        self.assertIs(cp_a.links[1], cp_c)
+        self.assertIsNot(cp_a.links[0], b)
+
     # ------------------------------------------------
     # Tree navigation
     # ------------------------------------------------


### PR DESCRIPTION
### Fixes Issue

Fixes #2084

### Summary

When a `TreeNode` carried a custom attribute that referenced another node in the same tree (e.g. `node1.partner = node2`), `TreeNode.copy` — and the `copy.copy` / `copy.deepcopy` protocols it backs — handled the reference incorrectly:

- **Deep or shallow copy of a non-cyclic reference** produced a *detached duplicate* of the referenced node rather than pointing at the corresponding node in the copied tree. The copy's internal reference topology was silently wrong.
- **A cyclic reference** (e.g. `node1.partner = node2; node2.partner = node1`) caused `RecursionError` / infinite recursion.

The previous implementation only avoided this for a hard-coded set of cache attributes, so any user-defined node-referencing attribute (ecological links, horizontal-gene-transfer edges, pairing relationships, etc.) hit the bug.

### Fix

`_copy` is now performed in two passes:

1. **Structure pass** — build the new tree (built-in attributes only) and record an `{id(old_node): new_node}` mapping. Custom attributes are deferred so that *every* node exists before any reference between nodes is resolved.
2. **Attribute pass** — copy custom attributes, redirecting intra-tree node references to the corresponding nodes in the copy. For deep copies this is done by seeding the `deepcopy` memo with the node mapping, which also transparently handles references nested inside containers (lists, dicts, …) and cycles. For shallow copies, direct node references are substituted via the mapping.

References to nodes *outside* the tree being copied retain the prior behavior.

### Tests

Added four focused tests in `skbio/tree/tests/test_tree.py` covering: deep-copy remapping, shallow-copy remapping, cyclic references (no infinite recursion), and node references nested inside a container. All existing tree tests continue to pass.

### Checklist

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [ ] **This pull request includes code, documentation, or other content derived from external source(s).**
* [x] This pull request does not include code, documentation, or other content derived from external source(s).