### PR TITLE
ENH: support array-API (GPU-resident) buffers in DistanceMatrix

### DIFF
--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -26,7 +26,7 @@ from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow, is_symmetric
 from ._utils import distmat_reorder, distmat_reorder_condensed
-from skbio.util._array import ingest_array
+from skbio.util._array import ingest_array, copy_array
 
 import array_api_compat as _aac
 
@@ -537,16 +537,7 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
             self._validate_ids(filtered_data, ids)
             return self.__class__(filtered_data, ids, validate=False, condensed=True)
         else:
-            if _aac.is_numpy_array(self._data):
-                filtered_data = distmat_reorder(self.redundant_form(), idxs)
-            else:
-                # non-NumPy (e.g. GPU) buffer: reorder rows/cols via an xp gather
-                xp = _aac.array_namespace(self._data)
-                idx = xp.asarray(
-                    np.asarray(idxs, dtype=int),
-                    device=getattr(self._data, "device", None),
-                )
-                filtered_data = self._data[idx][:, idx]
+            filtered_data = distmat_reorder(self.redundant_form(), idxs)
             self._validate_ids(filtered_data, ids)
             return self.__class__(filtered_data, ids, validate=False)
 
@@ -1201,10 +1192,14 @@ class SymmetricMatrix(PairwiseMatrix):
         # array or (b) the data are not a single or double precision numpy
         # data type.
         if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer as-is so
-            # the DistanceMatrix can hold GPU data. NumPy / list / tuple inputs
-            # are still normalized to a NumPy array below.
+            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer so the
+            # DistanceMatrix can hold GPU data. NumPy / list / tuple inputs are
+            # still normalized to a NumPy array below. A non-floating buffer is
+            # cast to float64, mirroring the NumPy path (which keeps float32/64
+            # and casts everything else to float).
             _xp, data = ingest_array(data)
+            if not _xp.isdtype(data.dtype, (_xp.float32, _xp.float64)):
+                data = _xp.astype(data, _xp.float64)
         else:
             _issue_copy = True
             if isinstance(data, np.ndarray):
@@ -1299,6 +1294,18 @@ class SymmetricMatrix(PairwiseMatrix):
             1-D or 2-D array containing the values of the matrix.
 
         """
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # Array-API (e.g. GPU-resident) buffers are stored in redundant (2-D)
+            # form only. Condensed storage relies on scipy.squareform, which is
+            # NumPy-only, so a condensed or 1-D non-NumPy buffer could not be
+            # reordered/converted without a silent copy back to the host.
+            if condensed or data.ndim != 2:
+                raise SymmetricMatrixError(
+                    "Condensed form is not supported for non-NumPy (array-API) "
+                    "arrays. Provide a 2-D array to store the matrix on a "
+                    "non-NumPy device."
+                )
+            return data
         if condensed:
             # case where input is 1d and stays 1d
             if data.ndim == 1:
@@ -1327,15 +1334,6 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         if data.ndim == 1:
-            return
-        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # xp-aware symmetry check for a non-NumPy buffer (a NaN makes the
-            # inequality True, so this also rejects NaNs, matching is_symmetric).
-            xp = _aac.array_namespace(data)
-            if bool(xp.any(xp.matrix_transpose(data) != data)):
-                raise DistanceMatrixError(
-                    "Data must be symmetric and cannot contain NaNs."
-                )
             return
         if not is_symmetric(data):
             raise DistanceMatrixError("Data must be symmetric and cannot contain NaNs.")
@@ -1411,13 +1409,11 @@ class SymmetricMatrix(PairwiseMatrix):
                 f"Found {data.ndim} dimensions."
             )
 
-        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # array-API (e.g. GPU) buffer: check the float dtype via the namespace
-            if not _aac.array_namespace(data).isdtype(data.dtype, "real floating"):
-                raise PairwiseMatrixError(
-                    "Data must contain only floating point values."
-                )
-        elif data.dtype not in (np.float32, np.float64):
+        # isdtype works for NumPy and non-NumPy (e.g. GPU) buffers alike, via each
+        # array's own namespace. Restrict to single/double precision (as the legacy
+        # NumPy check did) so both paths accept exactly the same dtypes.
+        xp = _aac.array_namespace(data)
+        if not xp.isdtype(data.dtype, (xp.float32, xp.float64)):
             raise PairwiseMatrixError("Data must contain only floating point values.")
 
     @property
@@ -1786,20 +1782,6 @@ class SymmetricMatrix(PairwiseMatrix):
         rng = get_rng(seed)
         order = rng.permutation(self.shape[0])
 
-        if not _aac.is_numpy_array(self._data):
-            # Non-NumPy (e.g. GPU-resident) buffer: reorder rows and columns with
-            # an xp fancy-index gather instead of the Cython reorder helpers.
-            xp = _aac.array_namespace(self._data)
-            dev = getattr(self._data, "device", None)
-            order_xp = xp.asarray(order, device=dev)
-            permuted = self._data[order_xp][:, order_xp]
-            if condensed:
-                n = permuted.shape[0]
-                idx = xp.arange(n, device=dev)
-                # row-major upper triangle == condensed_form order
-                return permuted[idx[:, None] < idx[None, :]]
-            return self.__class__(permuted, self.ids, validate=False)
-
         if condensed:
             # if self.__class__ != DistanceMatrix:
             #     raise TypeError("Only distance matrices can return condensed.")
@@ -1851,11 +1833,7 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         # adding for backward compatibility
-        if _aac.is_numpy_array(self._data):
-            data = self._data.copy()
-        else:
-            # non-NumPy (e.g. GPU) buffer: copy via the array-API namespace
-            data = _aac.array_namespace(self._data).asarray(self._data, copy=True)
+        data = copy_array(self._data)
         # We deepcopy IDs in case the tuple contains mutable objects at some
         # point in the future.
         # Note: Skip validation, since we assume self was already validated
@@ -2080,10 +2058,14 @@ class DistanceMatrix(SymmetricMatrix):
         # array or (b) the data are not a single or double precision numpy
         # data type.
         if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer as-is so
-            # the DistanceMatrix can hold GPU data. NumPy / list / tuple inputs
-            # are still normalized to a NumPy array below.
+            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer so the
+            # DistanceMatrix can hold GPU data. NumPy / list / tuple inputs are
+            # still normalized to a NumPy array below. A non-floating buffer is
+            # cast to float64, mirroring the NumPy path (which keeps float32/64
+            # and casts everything else to float).
             _xp, data = ingest_array(data)
+            if not _xp.isdtype(data.dtype, (_xp.float32, _xp.float64)):
+                data = _xp.astype(data, _xp.float64)
         else:
             _issue_copy = True
             if isinstance(data, np.ndarray):
@@ -2109,18 +2091,9 @@ class DistanceMatrix(SymmetricMatrix):
         # if the input data is 1D, we don't need to check for hollowness or symmetry
         if data.ndim != 2:
             return
-        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # xp-aware symmetry + hollowness for a non-NumPy buffer (a NaN makes
-            # the inequality True, so this also rejects NaNs, like is_symmetric).
-            xp = _aac.array_namespace(data)
-            data_sym = not bool(xp.any(xp.matrix_transpose(data) != data))
-            data_hol = not bool(xp.any(xp.linalg.diagonal(data) != 0))
-        else:
-            data_sym, data_hol = is_symmetric_and_hollow(data)
+        data_sym, data_hol = is_symmetric_and_hollow(data)
         if not data_sym:
-            raise DistanceMatrixError(
-                "Data must be symmetric and cannot contain NaNs."
-            )
+            raise DistanceMatrixError("Data must be symmetric and cannot contain NaNs.")
         if not data_hol:
             raise DistanceMatrixError(
                 "Data must  be hollow (i.e., the diagonal can only contain zeros)."
@@ -2142,11 +2115,7 @@ class DistanceMatrix(SymmetricMatrix):
 
         """
         # adding for backward compatibility
-        if _aac.is_numpy_array(self._data):
-            data = self._data.copy()
-        else:
-            # non-NumPy (e.g. GPU) buffer: copy via the array-API namespace
-            data = _aac.array_namespace(self._data).asarray(self._data, copy=True)
+        data = copy_array(self._data)
         if transpose:
             data = data.T
         # We deepcopy IDs in case the tuple contains mutable objects at some

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -26,6 +26,9 @@ from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow, is_symmetric
 from ._utils import distmat_reorder, distmat_reorder_condensed
+from skbio.util._array import ingest_array
+
+import array_api_compat as _aac
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence, Iterable, Callable, Collection
@@ -534,7 +537,16 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
             self._validate_ids(filtered_data, ids)
             return self.__class__(filtered_data, ids, validate=False, condensed=True)
         else:
-            filtered_data = distmat_reorder(self.redundant_form(), idxs)
+            if _aac.is_numpy_array(self._data):
+                filtered_data = distmat_reorder(self.redundant_form(), idxs)
+            else:
+                # non-NumPy (e.g. GPU) buffer: reorder rows/cols via an xp gather
+                xp = _aac.array_namespace(self._data)
+                idx = xp.asarray(
+                    np.asarray(idxs, dtype=int),
+                    device=getattr(self._data, "device", None),
+                )
+                filtered_data = self._data[idx][:, idx]
             self._validate_ids(filtered_data, ids)
             return self.__class__(filtered_data, ids, validate=False)
 
@@ -1188,18 +1200,24 @@ class SymmetricMatrix(PairwiseMatrix):
         # np.asarray to situations where the data are (a) not already a numpy
         # array or (b) the data are not a single or double precision numpy
         # data type.
-        _issue_copy = True
-        if isinstance(data, np.ndarray):
-            if data.dtype in (np.float32, np.float64):
-                _issue_copy = False
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer as-is so
+            # the DistanceMatrix can hold GPU data. NumPy / list / tuple inputs
+            # are still normalized to a NumPy array below.
+            _xp, data = ingest_array(data)
+        else:
+            _issue_copy = True
+            if isinstance(data, np.ndarray):
+                if data.dtype in (np.float32, np.float64):
+                    _issue_copy = False
 
-        if _issue_copy:
-            data = np.asarray(data, dtype="float")
+            if _issue_copy:
+                data = np.asarray(data, dtype="float")
 
-        # Make data_ explicitly an ndarray to help with type checking.
-        # At this point in the code we can be certain that data is an
-        # ndarray.
-        assert isinstance(data, np.ndarray)
+            # Make data_ explicitly an ndarray to help with type checking.
+            # At this point in the code we can be certain that data is an
+            # ndarray.
+            assert isinstance(data, np.ndarray)
         data_: NDArray = data
         return (
             data_,
@@ -1308,7 +1326,18 @@ class SymmetricMatrix(PairwiseMatrix):
         be symmetric.
 
         """
-        if (data.ndim != 1) and (not is_symmetric(data)):
+        if data.ndim == 1:
+            return
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # xp-aware symmetry check for a non-NumPy buffer (a NaN makes the
+            # inequality True, so this also rejects NaNs, matching is_symmetric).
+            xp = _aac.array_namespace(data)
+            if bool(xp.any(xp.matrix_transpose(data) != data)):
+                raise DistanceMatrixError(
+                    "Data must be symmetric and cannot contain NaNs."
+                )
+            return
+        if not is_symmetric(data):
             raise DistanceMatrixError("Data must be symmetric and cannot contain NaNs.")
 
     def _validate_diagonal(
@@ -1382,7 +1411,13 @@ class SymmetricMatrix(PairwiseMatrix):
                 f"Found {data.ndim} dimensions."
             )
 
-        if data.dtype not in (np.float32, np.float64):
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # array-API (e.g. GPU) buffer: check the float dtype via the namespace
+            if not _aac.array_namespace(data).isdtype(data.dtype, "real floating"):
+                raise PairwiseMatrixError(
+                    "Data must contain only floating point values."
+                )
+        elif data.dtype not in (np.float32, np.float64):
             raise PairwiseMatrixError("Data must contain only floating point values.")
 
     @property
@@ -1751,6 +1786,20 @@ class SymmetricMatrix(PairwiseMatrix):
         rng = get_rng(seed)
         order = rng.permutation(self.shape[0])
 
+        if not _aac.is_numpy_array(self._data):
+            # Non-NumPy (e.g. GPU-resident) buffer: reorder rows and columns with
+            # an xp fancy-index gather instead of the Cython reorder helpers.
+            xp = _aac.array_namespace(self._data)
+            dev = getattr(self._data, "device", None)
+            order_xp = xp.asarray(order, device=dev)
+            permuted = self._data[order_xp][:, order_xp]
+            if condensed:
+                n = permuted.shape[0]
+                idx = xp.arange(n, device=dev)
+                # row-major upper triangle == condensed_form order
+                return permuted[idx[:, None] < idx[None, :]]
+            return self.__class__(permuted, self.ids, validate=False)
+
         if condensed:
             # if self.__class__ != DistanceMatrix:
             #     raise TypeError("Only distance matrices can return condensed.")
@@ -1802,7 +1851,11 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         # adding for backward compatibility
-        data = self._data.copy()
+        if _aac.is_numpy_array(self._data):
+            data = self._data.copy()
+        else:
+            # non-NumPy (e.g. GPU) buffer: copy via the array-API namespace
+            data = _aac.array_namespace(self._data).asarray(self._data, copy=True)
         # We deepcopy IDs in case the tuple contains mutable objects at some
         # point in the future.
         # Note: Skip validation, since we assume self was already validated
@@ -2026,18 +2079,24 @@ class DistanceMatrix(SymmetricMatrix):
         # np.asarray to situations where the data are (a) not already a numpy
         # array or (b) the data are not a single or double precision numpy
         # data type.
-        _issue_copy = True
-        if isinstance(data, np.ndarray):
-            if data.dtype in (np.float32, np.float64):
-                _issue_copy = False
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer as-is so
+            # the DistanceMatrix can hold GPU data. NumPy / list / tuple inputs
+            # are still normalized to a NumPy array below.
+            _xp, data = ingest_array(data)
+        else:
+            _issue_copy = True
+            if isinstance(data, np.ndarray):
+                if data.dtype in (np.float32, np.float64):
+                    _issue_copy = False
 
-        if _issue_copy:
-            data = np.asarray(data, dtype="float")
+            if _issue_copy:
+                data = np.asarray(data, dtype="float")
 
-        # Make data_ explicitly an ndarray to help with type checking.
-        # At this point in the code we can be certain that data is an
-        # ndarray.
-        assert isinstance(data, np.ndarray)
+            # Make data_ explicitly an ndarray to help with type checking.
+            # At this point in the code we can be certain that data is an
+            # ndarray.
+            assert isinstance(data, np.ndarray)
         data_: NDArray = data
         return data_, ids, validate_data, validate_ids, validate_shape
 
@@ -2048,16 +2107,24 @@ class DistanceMatrix(SymmetricMatrix):
 
         """
         # if the input data is 1D, we don't need to check for hollowness or symmetry
-        if data.ndim == 2:
+        if data.ndim != 2:
+            return
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # xp-aware symmetry + hollowness for a non-NumPy buffer (a NaN makes
+            # the inequality True, so this also rejects NaNs, like is_symmetric).
+            xp = _aac.array_namespace(data)
+            data_sym = not bool(xp.any(xp.matrix_transpose(data) != data))
+            data_hol = not bool(xp.any(xp.linalg.diagonal(data) != 0))
+        else:
             data_sym, data_hol = is_symmetric_and_hollow(data)
-            if not data_sym:
-                raise DistanceMatrixError(
-                    "Data must be symmetric and cannot contain NaNs."
-                )
-            if not data_hol:
-                raise DistanceMatrixError(
-                    "Data must  be hollow (i.e., the diagonal can only contain zeros)."
-                )
+        if not data_sym:
+            raise DistanceMatrixError(
+                "Data must be symmetric and cannot contain NaNs."
+            )
+        if not data_hol:
+            raise DistanceMatrixError(
+                "Data must  be hollow (i.e., the diagonal can only contain zeros)."
+            )
 
     def _copy(self, transpose: bool = False, condensed: bool = False) -> DistanceMatrix:
         """Copy support.
@@ -2075,7 +2142,11 @@ class DistanceMatrix(SymmetricMatrix):
 
         """
         # adding for backward compatibility
-        data = self._data.copy()
+        if _aac.is_numpy_array(self._data):
+            data = self._data.copy()
+        else:
+            # non-NumPy (e.g. GPU) buffer: copy via the array-API namespace
+            data = _aac.array_namespace(self._data).asarray(self._data, copy=True)
         if transpose:
             data = data.T
         # We deepcopy IDs in case the tuple contains mutable objects at some

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -1333,9 +1333,7 @@ class SymmetricMatrix(PairwiseMatrix):
         be symmetric.
 
         """
-        if data.ndim == 1:
-            return
-        if not is_symmetric(data):
+        if (data.ndim != 1) and (not is_symmetric(data)):
             raise DistanceMatrixError("Data must be symmetric and cannot contain NaNs.")
 
     def _validate_diagonal(
@@ -2089,15 +2087,16 @@ class DistanceMatrix(SymmetricMatrix):
 
         """
         # if the input data is 1D, we don't need to check for hollowness or symmetry
-        if data.ndim != 2:
-            return
-        data_sym, data_hol = is_symmetric_and_hollow(data)
-        if not data_sym:
-            raise DistanceMatrixError("Data must be symmetric and cannot contain NaNs.")
-        if not data_hol:
-            raise DistanceMatrixError(
-                "Data must  be hollow (i.e., the diagonal can only contain zeros)."
-            )
+        if data.ndim == 2:
+            data_sym, data_hol = is_symmetric_and_hollow(data)
+            if not data_sym:
+                raise DistanceMatrixError(
+                    "Data must be symmetric and cannot contain NaNs."
+                )
+            if not data_hol:
+                raise DistanceMatrixError(
+                    "Data must  be hollow (i.e., the diagonal can only contain zeros)."
+                )
 
     def _copy(self, transpose: bool = False, condensed: bool = False) -> DistanceMatrix:
         """Copy support.

--- a/skbio/stats/distance/_utils.py
+++ b/skbio/stats/distance/_utils.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import numpy as np
+import array_api_compat as _aac
 
 from ._cutils import is_symmetric_and_hollow_cy
 from ._cutils import distmat_reorder_cy, distmat_reorder_condensed_cy
@@ -31,11 +32,23 @@ def is_symmetric_and_hollow(mat):
 
     Notes
     -----
+    A non-NumPy array-API buffer (e.g. GPU-resident) is checked via its own array
+    namespace; a NumPy array uses the parallel Cython kernel.
+
     This function uses parallel computation for improved performance.
     See the :install:`parallelization guide <#parallelization>` for information on
     controlling the number of threads used.
 
     """
+    if _aac.is_array_api_obj(mat) and not _aac.is_numpy_array(mat):
+        # Non-NumPy (e.g. GPU-resident) buffer: check symmetry and hollowness via
+        # the array-API namespace. A NaN makes the inequality True, so this also
+        # rejects NaNs, matching the Cython path.
+        xp = _aac.array_namespace(mat)
+        is_symmetric = not bool(xp.any(xp.matrix_transpose(mat) != mat))
+        is_hollow = not bool(xp.any(xp.linalg.diagonal(mat) != 0))
+        return is_symmetric, is_hollow
+
     # is_symmetric_and_hollow_cy is optimized
     # for the common cas of c_contiguous.
     # For all other cases, make a copy.
@@ -132,11 +145,26 @@ def distmat_reorder(in_mat, reorder_vec, validate=False):
 
     Notes
     -----
+    A non-NumPy array-API buffer (e.g. GPU-resident) is reordered on its own device
+    via the array namespace; a NumPy array uses the parallel Cython kernel.
+
     This function uses parallel computation for improved performance.
     See the :install:`parallelization guide <#parallelization>` for information on
     controlling the number of threads used.
 
     """
+    if _aac.is_array_api_obj(in_mat) and not _aac.is_numpy_array(in_mat):
+        # Non-NumPy (e.g. GPU-resident) buffer: reorder rows and columns with an
+        # xp fancy-index gather, keeping the result on the input's device.
+        if validate:
+            _validate_order(np.asarray(reorder_vec, dtype=np.intp), in_mat)
+        xp = _aac.array_namespace(in_mat)
+        order = xp.asarray(
+            np.asarray(reorder_vec, dtype=int),
+            device=getattr(in_mat, "device", None),
+        )
+        return in_mat[order][:, order]
+
     np_reorder = np.asarray(reorder_vec, dtype=np.intp)
     if validate:
         _validate_order(np_reorder, in_mat)
@@ -180,11 +208,29 @@ def distmat_reorder_condensed(in_mat, reorder_vec, validate=False):
 
     Notes
     -----
+    A non-NumPy array-API buffer (e.g. GPU-resident) is reordered on its own device
+    via the array namespace; a NumPy array uses the parallel Cython kernel.
+
     This function uses parallel computation for improved performance.
     See the :install:`parallelization guide <#parallelization>` for information on
     controlling the number of threads used.
 
     """
+    if _aac.is_array_api_obj(in_mat) and not _aac.is_numpy_array(in_mat):
+        # Non-NumPy (e.g. GPU-resident) buffer: reorder then take the row-major
+        # upper triangle (the condensed_form order), on the input's device.
+        # Note: the boolean-mask gather relies on library-specific boolean
+        # indexing (supported by numpy/torch/jax/cupy), not the strict array API.
+        if validate:
+            _validate_order(np.asarray(reorder_vec, dtype=np.intp), in_mat)
+        xp = _aac.array_namespace(in_mat)
+        dev = getattr(in_mat, "device", None)
+        order = xp.asarray(np.asarray(reorder_vec, dtype=int), device=dev)
+        reordered = in_mat[order][:, order]
+        n = reordered.shape[0]
+        idx = xp.arange(n, device=dev)
+        return reordered[idx[:, None] < idx[None, :]]
+
     np_reorder = np.asarray(reorder_vec, dtype=np.intp)
     if validate:
         _validate_order(np_reorder, in_mat)

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -37,6 +37,7 @@ from skbio.stats.distance._base import _preprocess_input, _run_monte_carlo_stats
 from skbio.stats.distance._utils import is_symmetric_and_hollow
 from skbio.util import assert_data_frame_almost_equal
 from skbio.util._testing import assert_series_almost_equal
+from skbio.util._testing import ArrayAPITestMixin, array_backends
 
 
 class PairwiseMatrixTestData:
@@ -2232,6 +2233,70 @@ class DistanceMatrixTests(DistanceMatrixTestBase, TestCase):
 
     def setUp(self):
         super(DistanceMatrixTests, self).setUp()
+
+
+class DistanceMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
+    """A DistanceMatrix can hold a non-NumPy (e.g. GPU-resident) array-API buffer."""
+
+    def setUp(self):
+        rng = np.random.default_rng(0)
+        a = rng.random((5, 5))
+        a = (a + a.T) / 2.0
+        np.fill_diagonal(a, 0.0)
+        self.data = a
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_constructor_preserves_buffer(self, xp, device):
+        dm = DistanceMatrix(self.make_array(xp, device, self.data))
+        self.assert_type_preserved(dm.data, xp, device)
+        self.assertEqual(tuple(dm.shape), (5, 5))
+        self.assert_close(dm.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_replace_data_buffer(self, xp, device):
+        dm = DistanceMatrix(self.data)
+        dm._data = self.make_array(xp, device, self.data)
+        self.assert_type_preserved(dm.data, xp, device)
+        self.assert_close(dm.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_nonsymmetric_rejected(self, xp, device):
+        bad = self.data.copy()
+        bad[0, 1] = bad[0, 1] + 5.0
+        with self.assertRaises(DistanceMatrixError):
+            DistanceMatrix(self.make_array(xp, device, bad))
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_nonhollow_rejected(self, xp, device):
+        bad = self.data.copy()
+        bad[2, 2] = 1.0
+        with self.assertRaises(DistanceMatrixError):
+            DistanceMatrix(self.make_array(xp, device, bad))
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_permute_backend(self, xp, device):
+        ref = DistanceMatrix(self.data).permute(condensed=True, seed=0)
+        got = DistanceMatrix(
+            self.make_array(xp, device, self.data)
+        ).permute(condensed=True, seed=0)
+        self.assert_close(got, ref)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_copy_backend(self, xp, device):
+        dm = DistanceMatrix(self.make_array(xp, device, self.data))
+        cp = dm.copy()
+        self.assert_type_preserved(cp.data, xp, device)
+        self.assert_close(cp.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_filter_backend(self, xp, device):
+        ids = list("abcde")
+        dm = DistanceMatrix(self.make_array(xp, device, self.data), ids=ids)
+        sub = dm.filter(["a", "c", "e"])
+        self.assert_type_preserved(sub.data, xp, device)
+        self.assertEqual(tuple(sub.ids), ("a", "c", "e"))
+        ref = DistanceMatrix(self.data, ids=ids).filter(["a", "c", "e"])
+        self.assert_close(sub.data, ref.data)
 
 
 if __name__ == "__main__":

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -11,6 +11,7 @@ from unittest import TestCase, main, skipUnless
 
 import numpy as np
 import numpy.testing as npt
+import array_api_compat as aac
 import pandas as pd
 import pandas.testing as pdt
 import scipy.spatial.distance
@@ -2297,6 +2298,53 @@ class DistanceMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
         self.assertEqual(tuple(sub.ids), ("a", "c", "e"))
         ref = DistanceMatrix(self.data, ids=ids).filter(["a", "c", "e"])
         self.assert_close(sub.data, ref.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_integer_buffer_cast_to_float(self, xp, device):
+        # A non-floating buffer must be cast to float64 (matching the NumPy path,
+        # which casts non-float input to float), while keeping the backend/device.
+        idata = [
+            [0, 1, 2, 3, 4],
+            [1, 0, 5, 6, 7],
+            [2, 5, 0, 8, 9],
+            [3, 6, 8, 0, 1],
+            [4, 7, 9, 1, 0],
+        ]
+        dm = DistanceMatrix(self.make_array(xp, device, idata, dtype=xp.int64))
+        self.assert_type_preserved(dm.data, xp, device)
+        ns = aac.array_namespace(dm.data)
+        self.assertTrue(
+            ns.isdtype(dm.data.dtype, (ns.float32, ns.float64)),
+            f"integer buffer not cast to float64, got {dm.data.dtype}",
+        )
+        self.assert_close(dm.data, np.asarray(idata, dtype=float))
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_float16_cast_to_supported_precision(self, xp, device):
+        # float16 must be cast to single/double precision (matching the NumPy path,
+        # which upcasts float16 to float64), not preserved as float16.
+        buf = self.make_array(xp, device, self.data, dtype=xp.float16)
+        dm = DistanceMatrix(buf)
+        self.assert_type_preserved(dm.data, xp, device)
+        ns = aac.array_namespace(dm.data)
+        self.assertTrue(ns.isdtype(dm.data.dtype, (ns.float32, ns.float64)))
+        self.assertFalse(ns.isdtype(dm.data.dtype, xp.float16))
+
+    @array_backends("jax", "torch", "cupy")
+    def test_condensed_rejected_for_non_numpy(self, xp, device):
+        # Condensed storage is NumPy-only (scipy.squareform); a non-NumPy 2-D
+        # buffer with condensed=True must raise rather than silently host-copy.
+        buf = self.make_array(xp, device, self.data)
+        with self.assertRaises(SymmetricMatrixError):
+            DistanceMatrix(buf, condensed=True)
+
+    @array_backends("jax", "torch", "cupy")
+    def test_1d_buffer_rejected_for_non_numpy(self, xp, device):
+        # A 1-D (condensed-form) non-NumPy buffer must be rejected: expanding it
+        # to redundant form would require scipy.squareform (NumPy-only).
+        cond = self.make_array(xp, device, np.array([1.0, 2.0, 3.0]))
+        with self.assertRaises(SymmetricMatrixError):
+            DistanceMatrix(cond)
 
 
 if __name__ == "__main__":

--- a/skbio/util/_array.py
+++ b/skbio/util/_array.py
@@ -268,3 +268,33 @@ def ingest_array(
     """
     arrays = tuple(_get_array(x, to_numpy=to_numpy) for x in arrays)
     return aac.array_namespace(*arrays), *arrays
+
+
+def copy_array(arr: StdArray) -> StdArray:
+    r"""Return an independent copy of an array on its original device.
+
+    Parameters
+    ----------
+    arr : array
+        A NumPy array or an array object compliant with the Python array API
+        standard.
+
+    Returns
+    -------
+    array
+        A copy of `arr`, of the same type and on the same device.
+
+    See Also
+    --------
+    ingest_array
+
+    Notes
+    -----
+    For a NumPy array this is equivalent to ``arr.copy()``. For a non-NumPy
+    (e.g. GPU-resident) array it copies via the array's own namespace, keeping
+    the data on its original device rather than forcing a host copy.
+
+    """
+    if aac.is_numpy_array(arr):
+        return arr.copy()
+    return aac.array_namespace(arr).asarray(arr, copy=True)


### PR DESCRIPTION
This is a first step toward letting the distance functions operate on GPU-resident distance matrices. It allows `DistanceMatrix` to hold a non-NumPy, array-API-compatible buffer (e.g. a cupy/torch/jax array) instead of coercing everything to NumPy at construction.

### What changed
- `DistanceMatrix` (and the `SymmetricMatrix` machinery it inherits) now preserves a non-NumPy array-API buffer at construction instead of forcing `np.asarray`.
- Validation (symmetry, hollowness, dtype), `permute`, `copy` and `filter` dispatch to an array-API (`xp`) path when the buffer is non-NumPy.
- The NumPy path (Cython kernels and existing validation) is untouched, so behavior for NumPy inputs is unchanged.
- Adds array-API tests for `DistanceMatrix`.

### Approach and scope
Dispatch keys off whether `.data` is a NumPy array, following the existing `ingest_array`/`xp` pattern. This is deliberately a focused first step on the class itself:
- IO and plotting on a non-NumPy buffer are left for a follow-up.
- `PairwiseMatrix` is kept NumPy-only; `DistanceMatrix` and `SymmetricMatrix` are the array-API-capable ones.
- The duplicated `_normalize_input` across the classes is kept as-is rather than refactored.

### Testing
- The array-API tests are parametrized over numpy/jax/torch/cupy (picked up by the array-api CI). I verified them locally on NumPy and PyTorch (CPU).
- The `DistanceMatrix` array-API tests were also run on a real AMD Instinct MI210 via torch-ROCm and pass: construction, validation, `permute`, `copy` and `filter` all behave correctly with a GPU-resident buffer.
- Existing distance / ordination / diversity suites remain green.

### Follow-ups
- `permanova`/`mantel` array-API support, consuming a GPU-backed `DistanceMatrix`.
- Docstring and changelog updates.

cc @sfiligoi
