### PR TITLE
BUG: Fix GFF3 reader for non-contiguous sequence IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
 
+### Bug Fixes
+
+* Fixed the GFF3 reader dropping or duplicating features when a sequence ID's records are not contiguous in the file. GFF3 does not require features to be grouped by sequence ID, but the reader previously only merged consecutive lines. As a result, reading a specific `seq_id` returned only its first block of features, and the generator reader yielded the same `seq_id` multiple times. All features for a sequence ID are now merged regardless of their order in the file ([#2501](https://github.com/scikit-bio/scikit-bio/pull/2501)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/io/format/gff3.py
+++ b/skbio/io/format/gff3.py
@@ -375,9 +375,12 @@ def _interval_metadata_to_gff3(obj, fh, seq_id, skip_subregion=True):
 
 def _construct_seq(fh, constructor=DNA, seq_num=1):
     lines = []
-    for i, (data_type, seq_id, L) in enumerate(_yield_record(fh), 1):
-        if data_type == "data" and seq_num == i:
-            lines = L
+    i = 0
+    for data_type, seq_id, L in _yield_record(fh):
+        if data_type == "data":
+            i += 1
+            if seq_num == i:
+                lines = L
     seq = _get_nth_sequence(
         _fasta_to_generator(fh, constructor=constructor), seq_num=seq_num
     )
@@ -386,36 +389,41 @@ def _construct_seq(fh, constructor=DNA, seq_num=1):
 
 
 def _yield_record(fh):
-    """Yield (seq_id, lines) that belong to the same sequence."""
-    lines = []
-    current = False
+    """Yield records grouped by sequence ID.
+
+    All feature lines that share a sequence ID are grouped into a single
+    ``("data", seq_id, lines)`` record, even when they are not contiguous in
+    the file. GFF3 does not require features to be sorted by sequence ID, so
+    interleaved records must still be merged (see issue #1842).
+
+    ``("length", seq_id, length)`` items (from ``##sequence-region`` pragmas)
+    are yielded first, followed by one ``data`` item per sequence ID, in the
+    order in which the sequence IDs first appear.
+    """
+    lengths = []
+    records = {}
+    order = []
     for line in _line_generator(fh, skip_blanks=True, strip=True):
         if line.startswith("##sequence-region"):
             _, seq_id, start, end = line.split()
             length = int(end) - int(start) + 1
-            yield "length", seq_id, length
-        if line.startswith("##FASTA"):
+            lengths.append(("length", seq_id, length))
+        elif line.startswith("##FASTA"):
             # stop once reaching to sequence section
             break
-        if not line.startswith("#"):
+        elif not line.startswith("#"):
             try:
                 seq_id, _ = line.split("\t", 1)
             except ValueError:
                 raise GFF3FormatError("Wrong GFF3 format at line: %s" % line)
-            if current == seq_id:
-                lines.append(line)
-            else:
-                if current is not False:
-                    yield "data", current, lines
-                lines = [line]
-                current = seq_id
-    if current is False:
-        # if the input file object is empty, it should return
-        # an empty generator
-        return
-        yield
-    else:
-        yield "data", current, lines
+            if seq_id not in records:
+                records[seq_id] = []
+                order.append(seq_id)
+            records[seq_id].append(line)
+
+    yield from lengths
+    for seq_id in order:
+        yield "data", seq_id, records[seq_id]
 
 
 def _parse_record(lines, length):

--- a/skbio/io/format/tests/test_gff3.py
+++ b/skbio/io/format/tests/test_gff3.py
@@ -190,6 +190,41 @@ class ReaderTests(GFF3IOTests):
             obs = list(_gff3_to_generator(empty_fp))
             self.assertEqual(obs, [])
 
+    def test_yield_record_noncontiguous(self):
+        # GFF3 does not require features to be grouped by seq id; features for
+        # the same seq id must be merged even when interleaved with others
+        s = ('seqid1\taaa\n'
+             'seqid2\tbbb\n'
+             'seqid1\tccc\n')
+        exp = [('data', 'seqid1', ['seqid1\taaa', 'seqid1\tccc']),
+               ('data', 'seqid2', ['seqid2\tbbb'])]
+        with io.StringIO(s) as fh:
+            self.assertEqual(list(_yield_record(fh)), exp)
+
+    def test_gff3_to_interval_metadata_noncontiguous(self):
+        # reading a specific seq id must return all of its features, even those
+        # that appear after features of other seq ids (see issue #1842)
+        s = ('##gff-version 3\n'
+             'ctg1\t.\tgene\t1\t10\t.\t+\t.\tID=g1\n'
+             'ctg2\t.\tgene\t1\t10\t.\t+\t.\tID=g2\n'
+             'ctg1\t.\tmRNA\t1\t10\t.\t+\t.\tID=m1\n')
+        with io.StringIO(s) as fh:
+            obs = _gff3_to_interval_metadata(fh, seq_id='ctg1')
+        self.assertEqual([i.metadata['ID'] for i in obs._intervals],
+                         ['g1', 'm1'])
+
+    def test_gff3_to_generator_noncontiguous(self):
+        # each seq id is yielded exactly once, with all of its features merged
+        s = ('##gff-version 3\n'
+             'ctg1\t.\tgene\t1\t10\t.\t+\t.\tID=g1\n'
+             'ctg2\t.\tgene\t1\t10\t.\t+\t.\tID=g2\n'
+             'ctg1\t.\tmRNA\t1\t10\t.\t+\t.\tID=m1\n')
+        with io.StringIO(s) as fh:
+            obs = [(sid, [i.metadata['ID'] for i in im._intervals])
+                   for sid, im in _gff3_to_generator(fh)]
+        exp = [('ctg1', ['g1', 'm1']), ('ctg2', ['g2'])]
+        self.assertEqual(obs, exp)
+
     def test_gff3_to_sequence(self):
         obs = _gff3_to_sequence(self.seq_fp)
         self.assertEqual(obs, self.seq)


### PR DESCRIPTION
### Fixes Issue

Fixes #1842

### Summary

GFF3 does not require features to be grouped or sorted by sequence ID (column 1). However, the reader's `_yield_record` grouped only *consecutive* lines that shared a sequence ID, so when a file interleaved records for different sequence IDs each contiguous block became a separate record. This caused two problems:

- **`IntervalMetadata` read for a specific `seq_id`** (`skbio.io.read(..., format="gff3", into=IntervalMetadata, seq_id=...)`) returned only the *first* contiguous block of that sequence's features and silently dropped the rest — the exact behavior reported in the issue.
- **The generator read** (`skbio.io.read(..., format="gff3")`) yielded the same `seq_id` more than once, each time carrying only part of its features.

### Reproduction (before the fix)

```python
from io import StringIO
from skbio.io import read
from skbio.metadata import IntervalMetadata

gff = (
    "##gff-version 3\n"
    "seq1\t.\tgene\t1\t100\t.\t+\t.\tID=g1\n"
    "seq2\t.\tgene\t1\t100\t.\t+\t.\tID=g2\n"
    "seq1\t.\tmRNA\t1\t100\t.\t+\t.\tID=m1\n"   # non-contiguous with seq1's gene
    "seq2\t.\tmRNA\t1\t100\t.\t+\t.\tID=m2\n"
)

# generator: seq1 and seq2 each yielded twice, 1 feature each (should be once, 2 each)
[(sid, len(im._intervals)) for sid, im in read(StringIO(gff), format="gff3")]

# seq_id read: returns only ['g1'] (should be ['g1', 'm1'])
read(StringIO(gff), format="gff3", into=IntervalMetadata, seq_id="seq1")
```

### Fix

`_yield_record` now accumulates the feature lines for every sequence ID across the whole annotation section and yields one merged `data` record per sequence ID, in first-seen order (`##sequence-region` length pragmas are yielded first). `_construct_seq` now counts only data records when selecting the nth sequence, so it is unaffected by the ordering of length pragmas.

### Tests

Added three tests in `skbio/io/format/tests/test_gff3.py` covering the root-cause function (`_yield_record`), the reported `seq_id` symptom, and the generator dedup/merge. All existing GFF3 tests (and the broader `skbio/io/format` + `skbio/metadata` suites) continue to pass.

### Checklist

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [ ] **This pull request includes code, documentation, or other content derived from external source(s).**
* [x] This pull request does not include code, documentation, or other content derived from external source(s).