### PR TITLE
BUG: Don't crash on fuzzy remote-entry feature locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
 
+### Bug Fixes
+
+* Fixed the GenBank/EMBL/GFF3 feature-location parser raising `FileFormatError` on remote entry references with fuzzy boundaries (e.g. `AB000684.1:<1..>275`). Such references are now dropped consistently with other remote entry references (whose coordinates refer to a different sequence), rather than raising ([#2502](https://github.com/scikit-bio/scikit-bio/pull/2502)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/io/format/_sequence_feature_vocabulary.py
+++ b/skbio/io/format/_sequence_feature_vocabulary.py
@@ -199,10 +199,12 @@ def _parse_loc_str(loc_str):
 
     Notes
     -----
-    This does not fully handle (e) case. It will discard the remote
-    entry part and only keep the local part. When it parses locations
-    across strand (e.g. "complement(123..145),200..209"), it will
-    record all the span parts but will record strand as negative.
+    This does not fully handle the (e) case. Remote entry references (e.g.
+    "J00194.1:1..9") are discarded entirely, because their coordinates refer
+    to a different sequence than the one being described; this includes
+    references with fuzzy boundaries (e.g. "AB000684.1:<1..>275"). When it
+    parses locations across strand (e.g. "complement(123..145),200..209"), it
+    will record all the span parts but will record strand as negative.
 
     References
     ----------
@@ -223,7 +225,12 @@ def _parse_loc_str(loc_str):
     b = r"(?P<B>\d+\^\d+)"
     c = r"(?P<C>\d+\.\d+)"
     d = r"(?P<D><?\d+\.\.>?\d+)"
-    e_left = r"(?P<EL><?[a-zA-Z_0-9\.]+:\d+\.\.>?\d+)"
+    # Remote entry references (INSDC case e), e.g. "J00194.1:1..9". The local
+    # range may carry the same `<`/`>` fuzzy markers as case (d); these belong
+    # to the base positions (after the colon), not to the accession (issue
+    # #1489). The whole reference is dropped below, since its coordinates refer
+    # to a different sequence.
+    e_left = r"(?P<EL>[a-zA-Z_0-9\.]+:<?\d+\.\.>?\d+)"
     e_right = r"(?P<ER><?\d+\.\.>?[a-zA-Z_0-9\.]+:\d+)"
     illegal = r"(?P<ILLEGAL>.+)"
     # The order of tokens in the master regular expression also

--- a/skbio/io/format/tests/test_sequence_feature_vocabulary.py
+++ b/skbio/io/format/tests/test_sequence_feature_vocabulary.py
@@ -74,6 +74,22 @@ class Tests(TestCase):
             parsed = _parse_loc_str(example)
             self.assertEqual(parsed, expect)
 
+    def test_parse_loc_str_remote_entry_fuzzy(self):
+        # Remote entry references (INSDC case e) are dropped because their
+        # coordinates refer to a different sequence. Fuzzy boundaries in such
+        # references must be dropped consistently rather than raising an error
+        # (issue #1489).
+        examples = [
+            'AB000684.1:<1..>275',
+            'J00194.1:1..>9',
+            'join(J00194.1:<1..>9,3..8)']
+        expects = [
+            ([], [], {'strand': '+'}),
+            ([], [], {'strand': '+'}),
+            ([(2, 8)], [(False, False)], {'strand': '+'})]
+        for example, expect in zip(examples, expects):
+            self.assertEqual(_parse_loc_str(example), expect)
+
     def test_parse_loc_str_invalid(self):
         examples = [
             'abc',


### PR DESCRIPTION
### Fixes Issue

Fixes #1489

### Summary

`_parse_loc_str` (the shared GenBank/EMBL/GFF3 feature-location parser) recognizes remote entry references — INSDC location case *(e)*, e.g. `J00194.1:1..9` — and **drops** them, since their coordinates refer to a *different* sequence than the one being described. This drop behavior is intentional and pinned by existing tests (`join(J00194.1:1..9,3..8)` → `[(2, 8)]`).

However, the `EL` token's pattern required plain digits immediately after the colon:

```
(?P<EL><?[a-zA-Z_0-9\.]+:\d+\.\.>?\d+)
```

so a remote reference carrying a **fuzzy boundary** (e.g. `AB000684.1:<1..>275`, valid INSDC) failed to match `EL`, fell through to the illegal-token branch, and raised `FileFormatError` — one of the cases reported in #1489.

### Reproduction (before the fix)

```python
from skbio.io.format._sequence_feature_vocabulary import _parse_loc_str
_parse_loc_str("AB000684.1:<1..>275")     # -> FileFormatError
_parse_loc_str("join(J00194.1:<1..>9,3..8)")  # -> FileFormatError
```

### Fix

The `EL` pattern now accepts the same `<`/`>` fuzzy markers on its local range as case *(d)* — the markers belong to the base positions after the colon, not to the accession (the old pattern also had a stray `<?` before the accession). Fuzzy remote references now match `EL` and are dropped consistently with every other remote reference instead of raising. The parser's docstring "Notes" is corrected: it previously claimed to "keep the local part," but remote references are (and were) discarded entirely.

After the fix:

```python
_parse_loc_str("AB000684.1:<1..>275")         # -> ([], [], {'strand': '+'})
_parse_loc_str("join(J00194.1:<1..>9,3..8)")  # -> ([(2, 8)], [(False, False)], {'strand': '+'})
```

### Scope

The issue also noted that plain remote references return empty bounds and that remote segments in a `join` are dropped. Those are the parser's **intended** behavior (pinned by existing tests, and consistent with scikit-bio's single-sequence coordinate model), so they're left unchanged. This PR fixes the one genuine defect — the crash on fuzzy remote references — and makes the docstring accurate.

### Tests

Added `test_parse_loc_str_remote_entry_fuzzy` covering a fuzzy remote-only reference, a partially-fuzzy remote reference, and a fuzzy remote segment inside a `join`. All existing location-parser tests and the GenBank/EMBL/GFF3 reader suites continue to pass.

### Checklist

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [ ] **This pull request includes code, documentation, or other content derived from external source(s).**
* [x] This pull request does not include code, documentation, or other content derived from external source(s).