### PR TITLE
ENH: array-API (GPU-resident) support for permanova and mantel

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -2,7 +2,7 @@ name: Array API Compatibility
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, development_numba_gpu]
     paths-ignore: ["web/**", "**.md", "README.rst"]
     types: [labeled, synchronize]
   workflow_dispatch:

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -1998,6 +1998,16 @@ class DistanceMatrix(SymmetricMatrix):
             data, ids
         )
 
+        # The Cython kernels (validation, permutation, reordering) read through a
+        # C-contiguous, writable typed memoryview. A read-only buffer (e.g. one
+        # materialized from an immutable JAX array via __dlpack__) or a
+        # non-contiguous one gets a single writable copy here; non-NumPy
+        # (array-API) buffers stay on their own device untouched.
+        if _aac.is_numpy_array(data) and not (
+            data.flags.c_contiguous and data.flags.writeable
+        ):
+            data = np.array(data, order="C")
+
         if ids is None:
             ids = self._generate_ids(data)
         else:

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -20,7 +20,7 @@ from scipy.stats import kendalltau, ConstantInputWarning, NearConstantInputWarni
 from ._cutils import mantel_perm_pearsonr_cy, mantel_perm_pearsonr_condensed_cy
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
-from skbio.util._array import ingest_array, _to_numpy
+from skbio.util._array import ingest_array, _get_array
 from skbio._config import _resolve_engine
 
 import array_api_compat as _aac
@@ -467,9 +467,9 @@ def mantel(
     # (the fallback above). A non-NumPy DistanceMatrix is materialized on the host
     # here (SciPy's kendalltau is host-only, and _order_dms runs on host).
     if x_is_xp:
-        x = DistanceMatrix(_to_numpy(x.data), x.ids)
+        x = DistanceMatrix(_get_array(x.data, to_numpy=True), x.ids)
     if y_is_xp:
-        y = DistanceMatrix(_to_numpy(y.data), y.ids)
+        y = DistanceMatrix(_get_array(y.data, to_numpy=True), y.ids)
 
     x, y = _order_dms(x, y, strict=strict, lookup=lookup)
 
@@ -581,8 +581,8 @@ def _mantel_stats_pearson_xp(x, y, permutations, rng, alternative, spearman=Fals
         y_flat = _xp_rank_average(xp, y_flat)
         # rebuild the ranked symmetric matrix so permuted pairs can be gathered
         # (one-time host assembly; on-device gather is a possible follow-up).
-        xr = _to_numpy(x_flat)
-        i0, j0 = _to_numpy(iu0), _to_numpy(iu1)
+        xr = _get_array(x_flat, to_numpy=True)
+        i0, j0 = _get_array(iu0, to_numpy=True), _get_array(iu1, to_numpy=True)
         full = np.zeros((n, n), dtype=np.float64)
         full[i0, j0] = xr
         full[j0, i0] = xr

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -20,7 +20,10 @@ from scipy.stats import kendalltau, ConstantInputWarning, NearConstantInputWarni
 from ._cutils import mantel_perm_pearsonr_cy, mantel_perm_pearsonr_condensed_cy
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
+from skbio.util._array import ingest_array, _to_numpy
 from skbio._config import _resolve_engine
+
+import array_api_compat as _aac
 
 try:
     from numba import njit, prange
@@ -431,6 +434,37 @@ def mantel(
     if alternative not in ("two-sided", "greater", "less"):
         raise ValueError("Invalid alternative hypothesis '%s'." % alternative)
 
+    # A DistanceMatrix backed by a non-NumPy (e.g. GPU-resident) buffer is
+    # dispatched to the backend-agnostic xp path for pearson/spearman so the
+    # matrices stay on their device. kendalltau has no xp path and falls through
+    # to the host/scipy route below, where _order_dms materializes on host.
+    x_is_xp = isinstance(x, DistanceMatrix) and not _aac.is_numpy_array(x.data)
+    y_is_xp = isinstance(y, DistanceMatrix) and not _aac.is_numpy_array(y.data)
+
+    if special and (x_is_xp or y_is_xp):
+        # both inputs must be non-NumPy DistanceMatrix objects on the same backend
+        if not (x_is_xp and y_is_xp) or (
+            _aac.array_namespace(x.data) is not _aac.array_namespace(y.data)
+        ):
+            raise ValueError(
+                "x and y must both be DistanceMatrix objects backed by the same "
+                "array backend for the array-API path."
+            )
+        # align ids exactly like the NumPy path; the reorder/filter stays on
+        # the input's device (distmat_reorder is array-API aware).
+        x, y = _order_dms(x, y, strict=strict, lookup=lookup)
+        return _mantel_stats_pearson_xp(
+            x.data, y.data, permutations, rng, alternative,
+            spearman=(method == "spearman"),
+        )
+
+    # kendalltau has no xp path; materialize a non-NumPy DistanceMatrix on the
+    # host (SciPy's kendalltau is host-only).
+    if x_is_xp:
+        x = DistanceMatrix(_to_numpy(x.data), x.ids)
+    if y_is_xp:
+        y = DistanceMatrix(_to_numpy(y.data), y.ids)
+
     x, y = _order_dms(x, y, strict=strict, lookup=lookup)
 
     n = x.shape[0]
@@ -480,6 +514,128 @@ def mantel(
         p_value = (count_better + 1) / (permutations + 1)
 
     return orig_stat, p_value, n
+
+
+def _upper_tri_xp(xp, n, device=None):
+    """Row-major upper-triangle (i < j) index vectors, matching condensed order."""
+    idx = xp.arange(n, device=device)
+    ones = xp.ones(n, dtype=idx.dtype, device=device)
+    ii = idx[:, None] * ones[None, :]
+    jj = ones[:, None] * idx[None, :]
+    mask = idx[:, None] < idx[None, :]
+    return xp.astype(ii[mask], idx.dtype), xp.astype(jj[mask], idx.dtype)
+
+
+def _xp_rank_average(xp, a):
+    """Average-tie ranks, matching ``scipy.stats.rankdata`` (method='average')."""
+    n = a.shape[0]
+    dev = _device(a)
+    sorter = xp.argsort(a, stable=True)
+    inv = xp.argsort(sorter)  # inverse permutation without item assignment
+    a_sorted = a[sorter]
+    obs = xp.concat([xp.asarray([True], device=dev), a_sorted[1:] != a_sorted[:-1]])
+    dense = xp.cumulative_sum(xp.astype(obs, xp.int64), axis=0)[inv]
+    count_nz = xp.nonzero(obs)[0]
+    count = xp.concat([count_nz, xp.asarray([n], dtype=count_nz.dtype, device=dev)])
+    return 0.5 * (
+        xp.astype(count[dense], xp.float64)
+        + xp.astype(count[dense - 1], xp.float64)
+        + 1.0
+    )
+
+
+def _mantel_stats_pearson_xp(x, y, permutations, rng, alternative, spearman=False):
+    """Mantel pearson/spearman result in the ``xp`` namespace.
+
+    Backend-agnostic equivalent of ``_mantel_stats_pearson``/``_spearman`` for
+    full (non-condensed) array-API matrices. Matches the RNG usage of the NumPy
+    path (identity permutation first, then ``permutations`` calls to
+    ``rng.permutation(n)``) so p-values are reproducible and identical.
+
+    Returns ``(orig_stat, p_value, n)``, matching ``mantel``'s return.
+    """
+    xp, X, Y = ingest_array(x, y)
+    if X.shape != Y.shape:
+        raise ValueError("Distance matrices must have the same shape.")
+    if X.ndim != 2 or X.shape[0] != X.shape[1]:
+        raise ValueError("Distance matrix must be a square 2-D array.")
+    n = X.shape[0]
+    if n < 3:
+        raise ValueError(
+            "Distance matrices must have at least 3 matching IDs "
+            "between them (i.e., minimum 3x3 in size)."
+        )
+
+    iu0, iu1 = _upper_tri_xp(xp, n, device=_device(X))
+    x_flat = X[iu0, iu1]
+    y_flat = Y[iu0, iu1]
+
+    if spearman:
+        x_flat = _xp_rank_average(xp, x_flat)
+        y_flat = _xp_rank_average(xp, y_flat)
+        # rebuild the ranked symmetric matrix so permuted pairs can be gathered
+        # (one-time host assembly; on-device gather is a possible follow-up).
+        xr = _to_numpy(x_flat)
+        i0, j0 = _to_numpy(iu0), _to_numpy(iu1)
+        full = np.zeros((n, n), dtype=np.float64)
+        full[i0, j0] = xr
+        full[j0, i0] = xr
+        Xsrc = xp.asarray(full, device=_device(X))
+    else:
+        Xsrc = X
+
+    # constant input -> correlation undefined (matches scipy/skbio behavior)
+    if bool(xp.all(x_flat == x_flat[0])) or bool(xp.all(y_flat == y_flat[0])):
+        warn(ConstantInputWarning())
+        return np.nan, np.nan, n
+
+    xmean = xp.mean(x_flat)
+    normxm = xp.sqrt(xp.sum((x_flat - xmean) ** 2))
+    ymean = xp.mean(y_flat)
+    normym = xp.sqrt(xp.sum((y_flat - ymean) ** 2))
+    ym_norm = (y_flat - ymean) / normym
+
+    # near-constant input -> loss of precision in r (matches the NumPy path)
+    threshold = 1e-13
+    if (float(normxm) < threshold * abs(float(xmean))) or (
+        float(normym) < threshold * abs(float(ymean))
+    ):
+        warn(NearConstantInputWarning())
+
+    def _corr(cond):
+        s = float(xp.sum(((cond - xmean) / normxm) * ym_norm))
+        return max(min(s, 1.0), -1.0)
+
+    orig_stat = _corr(x_flat)
+    comp_stat = orig_stat
+    permuted_stats = []
+    if not (permutations == 0 or np.isnan(orig_stat)):
+        # identity permutation gives comp_stat (matches perm_order[0] in the
+        # NumPy path); the RNG is then consumed exactly `permutations` times.
+        idx = xp.arange(n, device=_device(X))
+        comp_stat = _corr(Xsrc[idx[iu0], idx[iu1]])
+        permuted_stats = np.empty(permutations, dtype=np.float64)
+        for k in range(permutations):
+            pp = xp.asarray(rng.permutation(n), device=_device(X))
+            permuted_stats[k] = _corr(Xsrc[pp[iu0], pp[iu1]])
+
+    # p-value from the permutation distribution (matches the NumPy path exactly)
+    if permutations == 0 or np.isnan(orig_stat):
+        p_value = np.nan
+    else:
+        if alternative == "two-sided":
+            count_better = (np.absolute(permuted_stats) >= np.absolute(comp_stat)).sum()
+        elif alternative == "greater":
+            count_better = (permuted_stats >= comp_stat).sum()
+        else:
+            count_better = (permuted_stats <= comp_stat).sum()
+        p_value = (count_better + 1) / (permutations + 1)
+    return orig_stat, p_value, n
+
+
+def _device(arr):
+    """Best-effort device of an array-API array (None if not exposed)."""
+    return getattr(arr, "device", None)
 
 
 def _mantel_stats_pearson_flat(x, y_flat, permutations, seed=None, engine=None):

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -442,24 +442,30 @@ def mantel(
     y_is_xp = isinstance(y, DistanceMatrix) and not _aac.is_numpy_array(y.data)
 
     if special and (x_is_xp or y_is_xp):
-        # both inputs must be non-NumPy DistanceMatrix objects on the same backend
         if not (x_is_xp and y_is_xp) or (
             _aac.array_namespace(x.data) is not _aac.array_namespace(y.data)
         ):
-            raise ValueError(
-                "x and y must both be DistanceMatrix objects backed by the same "
-                "array backend for the array-API path."
+            # mixed or mismatched backends: fall back to the NumPy path below with
+            # a warning rather than a hard failure.
+            warn(
+                "x and y are not both DistanceMatrix objects on the same array "
+                "backend; falling back to the NumPy path.",
+                UserWarning,
             )
-        # align ids exactly like the NumPy path; the reorder/filter stays on
-        # the input's device (distmat_reorder is array-API aware).
-        x, y = _order_dms(x, y, strict=strict, lookup=lookup)
-        return _mantel_stats_pearson_xp(
-            x.data, y.data, permutations, rng, alternative,
-            spearman=(method == "spearman"),
-        )
+        else:
+            # both are non-NumPy DistanceMatrix objects on the same backend: align
+            # ids exactly like the NumPy path; the reorder/filter stays on the
+            # input's device (distmat_reorder is array-API aware).
+            x, y = _order_dms(x, y, strict=strict, lookup=lookup)
+            return _mantel_stats_pearson_xp(
+                x.data, y.data, permutations, rng, alternative,
+                spearman=(method == "spearman"),
+            )
 
-    # kendalltau has no xp path; materialize a non-NumPy DistanceMatrix on the
-    # host (SciPy's kendalltau is host-only).
+    # Default NumPy path: reached for kendalltau (no xp path), when neither input
+    # is a non-NumPy array, or when the inputs were not all on the same backend
+    # (the fallback above). A non-NumPy DistanceMatrix is materialized on the host
+    # here (SciPy's kendalltau is host-only, and _order_dms runs on host).
     if x_is_xp:
         x = DistanceMatrix(_to_numpy(x.data), x.ids)
     if y_is_xp:
@@ -557,7 +563,7 @@ def _mantel_stats_pearson_xp(x, y, permutations, rng, alternative, spearman=Fals
     xp, X, Y = ingest_array(x, y)
     if X.shape != Y.shape:
         raise ValueError("Distance matrices must have the same shape.")
-    if X.ndim != 2 or X.shape[0] != X.shape[1]:
+    if (X.ndim != 2) or (X.shape[0] != X.shape[1]):
         raise ValueError("Distance matrix must be a square 2-D array.")
     n = X.shape[0]
     if n < 3:

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -28,7 +28,10 @@ from skbio.binaries import (
 )
 from skbio.util import get_rng
 from skbio.util._decorator import params_aliased
+from skbio.util._array import ingest_array
 from skbio._config import _resolve_engine
+
+import array_api_compat as _aac
 
 try:
     from numba import njit, prange
@@ -518,6 +521,14 @@ def permanova(
     if not isinstance(distmat, DistanceMatrix):
         raise TypeError("Input must be a DistanceMatrix.")
 
+    # A DistanceMatrix backed by a non-NumPy (e.g. GPU-resident) buffer is
+    # dispatched to the backend-agnostic xp path; a NumPy-backed DM keeps the
+    # existing Cython/Numba engine path below.
+    if not _aac.is_numpy_array(distmat.data):
+        return _permanova_array_api(
+            distmat.data, grouping, column, permutations, seed, ids=distmat.ids
+        )
+
     sample_size = distmat.shape[0]
 
     num_groups, grouping = _preprocess_input_sng(
@@ -600,3 +611,52 @@ def _compute_f_stat(
 
     s_A = s_T - s_W
     return (s_A / (num_groups - 1)) / (s_W / (sample_size - num_groups))
+
+
+def _permanova_sW_xp(xp, dm, grouping, inv_group_sizes):
+    """Within-group sum of squares s_W for a full distance matrix, in ``xp``.
+
+    Backend-agnostic equivalent of ``permanova_f_stat_sW_cy`` for the
+    non-condensed (full 2-D) case: sum over upper-triangle pairs ``i < j`` in
+    the same group of ``d[i, j] ** 2`` divided by the group size of row ``i``.
+    """
+    n = dm.shape[0]
+    idx = xp.arange(n, device=dm.device)
+    upper = idx[:, None] < idx[None, :]
+    same = grouping[:, None] == grouping[None, :]
+    mask = xp.astype(upper & same, dm.dtype)
+    row_w = xp.take(inv_group_sizes, grouping)
+    return xp.sum(dm * dm * mask * row_w[:, None])
+
+
+def _permanova_array_api(distmat, grouping, column, permutations, seed, ids=None):
+    """PERMANOVA on an array-API (e.g. GPU-resident) full distance matrix.
+
+    Mirrors the DistanceMatrix path but computes the pseudo-F statistic with
+    the ``xp`` namespace so the distance matrix stays on its device. ``ids``
+    align a DataFrame/Series grouping to the matrix rows. Permutations reuse the
+    shared Monte-Carlo driver so the p-value matches the NumPy path exactly.
+    """
+    xp, dm = ingest_array(distmat)
+    sample_size = dm.shape[0]
+
+    num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
+
+    group_sizes = np.bincount(grouping)
+    inv_group_sizes = xp.asarray(
+        1.0 / group_sizes, dtype=dm.dtype, device=dm.device
+    )
+    # full 2-D matrix (array-API input is never condensed); halve to count each
+    # unordered pair once, matching the DistanceMatrix full-matrix path.
+    s_T = xp.sum(dm * dm) / sample_size / 2.0
+
+    def _test_stat(grp):
+        grp = xp.asarray(grp, device=dm.device)
+        s_W = _permanova_sW_xp(xp, dm, grp, inv_group_sizes)
+        s_A = s_T - s_W
+        return float((s_A / (num_groups - 1)) / (s_W / (sample_size - num_groups)))
+
+    stat, p_value = _run_monte_carlo_stats(_test_stat, grouping, permutations, seed)
+    return _build_results(
+        "PERMANOVA", "pseudo-F", sample_size, num_groups, stat, p_value, permutations
+    )

--- a/skbio/stats/distance/_utils.py
+++ b/skbio/stats/distance/_utils.py
@@ -49,11 +49,13 @@ def is_symmetric_and_hollow(mat):
         is_hollow = not bool(xp.any(xp.linalg.diagonal(mat) != 0))
         return is_symmetric, is_hollow
 
-    # is_symmetric_and_hollow_cy is optimized
-    # for the common cas of c_contiguous.
-    # For all other cases, make a copy.
-    if not mat.flags.c_contiguous:
-        mat = np.asarray(mat, order="C")
+    # is_symmetric_and_hollow_cy reads through a C-contiguous, writable typed
+    # memoryview. For any other case (non-contiguous, or a read-only buffer such
+    # as a NumPy array shared from an immutable JAX array) make a single
+    # C-contiguous, writable copy; the kernel only reads it, but the memoryview
+    # still requires a writable buffer.
+    if not (mat.flags.c_contiguous and mat.flags.writeable):
+        mat = np.array(mat, order="C")
 
     return is_symmetric_and_hollow_cy(mat)
 

--- a/skbio/stats/distance/_utils.py
+++ b/skbio/stats/distance/_utils.py
@@ -49,13 +49,11 @@ def is_symmetric_and_hollow(mat):
         is_hollow = not bool(xp.any(xp.linalg.diagonal(mat) != 0))
         return is_symmetric, is_hollow
 
-    # is_symmetric_and_hollow_cy reads through a C-contiguous, writable typed
-    # memoryview. For any other case (non-contiguous, or a read-only buffer such
-    # as a NumPy array shared from an immutable JAX array) make a single
-    # C-contiguous, writable copy; the kernel only reads it, but the memoryview
-    # still requires a writable buffer.
-    if not (mat.flags.c_contiguous and mat.flags.writeable):
-        mat = np.array(mat, order="C")
+    # is_symmetric_and_hollow_cy is optimized
+    # for the common cas of c_contiguous.
+    # For all other cases, make a copy.
+    if not mat.flags.c_contiguous:
+        mat = np.asarray(mat, order="C")
 
     return is_symmetric_and_hollow_cy(mat)
 

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -1328,13 +1328,16 @@ class DistanceMatrixTestBase(PairwiseMatrixTestData):
         ] * 2
 
     def test_init_from_readonly_array(self):
-        # A read-only NumPy array (e.g. one shared from an immutable JAX array)
-        # must still construct: is_symmetric_and_hollow makes a writable copy for
-        # the Cython validator rather than failing on the read-only buffer.
+        # A read-only NumPy array (e.g. one materialized from an immutable JAX
+        # array) is stored as a writable copy, so the Cython kernels work: the
+        # matrix constructs, and can be validated and permuted/reordered, which
+        # would otherwise fail with "buffer source array is read-only".
         data = np.array(self.dm_3x3_data, dtype=float)
         data.flags.writeable = False
         obs = self.matobj(data, ["a", "b", "c"])
         self.assertEqual(obs, self.dm_3x3)
+        self.assertTrue(obs.data.flags.writeable)
+        obs.permute(condensed=True, seed=0)  # exercises distmat_reorder_condensed
 
     def test_matrix_from_matrix(self):
         # distance from distance

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -1327,6 +1327,15 @@ class DistanceMatrixTestBase(PairwiseMatrixTestData):
             np.array([0.01, 4.2, 12.0]),
         ] * 2
 
+    def test_init_from_readonly_array(self):
+        # A read-only NumPy array (e.g. one shared from an immutable JAX array)
+        # must still construct: is_symmetric_and_hollow makes a writable copy for
+        # the Cython validator rather than failing on the read-only buffer.
+        data = np.array(self.dm_3x3_data, dtype=float)
+        data.flags.writeable = False
+        obs = self.matobj(data, ["a", "b", "c"])
+        self.assertEqual(obs, self.dm_3x3)
+
     def test_matrix_from_matrix(self):
         # distance from distance
         sm = DistanceMatrix(self.dm_3x3)

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -26,7 +26,8 @@ from skbio.stats.distance._mantel import _mantel_stats_spearman
 from skbio.stats.distance._cutils import (mantel_perm_pearsonr_cy,
                                           mantel_perm_pearsonr_condensed_cy)
 from skbio.stats.distance._utils import distmat_reorder_condensed
-from skbio.util import get_data_path, assert_data_frame_almost_equal, numba_code
+from skbio.util import (get_data_path, assert_data_frame_almost_equal, numba_code,
+                        get_rng)
 from skbio.util._testing import _data_frame_to_default_int_type
 from skbio.util._testing import ArrayAPITestMixin, array_backends
 
@@ -1258,11 +1259,19 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
         self.assertAlmostEqual(p, p_ref, places=10)
 
     @array_backends("jax", "torch", "cupy")  # non-NumPy only, to force a mix
-    def test_mixed_backend_raises(self, xp, device):
-        with self.assertRaises(ValueError):
-            mantel(DistanceMatrix(self.x),
-                   DistanceMatrix(self.make_array(xp, device, self.y)),
-                   method="pearson", permutations=0)
+    def test_mixed_backend_warns_and_falls_back(self, xp, device):
+        # a NumPy x with a non-NumPy y is a mixed backend: warn and fall back to
+        # the NumPy path (matching the all-NumPy result) rather than hard-failing.
+        mx = DistanceMatrix(self.x)
+        my = DistanceMatrix(self.make_array(xp, device, self.y))
+        with self.assertWarns(UserWarning):
+            r, p, _ = mantel(mx, my, method="pearson", permutations=99, seed=0)
+        r_ref, p_ref, _ = mantel(
+            DistanceMatrix(self.x), DistanceMatrix(self.y),
+            method="pearson", permutations=99, seed=0,
+        )
+        self.assertAlmostEqual(r, r_ref, places=10)
+        self.assertAlmostEqual(p, p_ref, places=10)
 
     @array_backends("numpy", "jax", "torch", "cupy")
     def test_id_reorder_backends(self, xp, device):
@@ -1291,6 +1300,43 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
                             ids=['z' + str(i) for i in range(10)])
         with self.assertRaises(ValueError):
             mantel(mx, my, method="pearson", permutations=0)
+
+    def test_mantel_stats_pearson_xp_numpy_backend(self):
+        # NumPy is array-API compatible; call the array-API compute helper
+        # directly with NumPy arrays (a normal mantel() with NumPy DMs takes the
+        # host path, not the xp one) so the array-API path is exercised under
+        # ordinary (NumPy-only) CI, matching the reference result.
+        for spearman in (False, True):
+            method = "spearman" if spearman else "pearson"
+            r_ref, p_ref, _ = mantel(
+                DistanceMatrix(self.x), DistanceMatrix(self.y),
+                method=method, permutations=99, seed=0,
+            )
+            r, p, n = mantel_mod._mantel_stats_pearson_xp(
+                self.x, self.y, 99, get_rng(0), "two-sided", spearman=spearman,
+            )
+            self.assertEqual(n, self.x.shape[0])
+            self.assertAlmostEqual(r, r_ref, places=10)
+            self.assertAlmostEqual(p, p_ref, places=10)
+
+    def test_mantel_stats_pearson_xp_validation_numpy(self):
+        # exercise the array-API validation/warning branches on NumPy input.
+        with self.assertRaises(ValueError):  # shape mismatch
+            mantel_mod._mantel_stats_pearson_xp(
+                self.x, self.y[:9, :9], 0, get_rng(0), "two-sided")
+        with self.assertRaises(ValueError):  # not square
+            mantel_mod._mantel_stats_pearson_xp(
+                np.zeros((3, 4)), np.zeros((3, 4)), 0, get_rng(0), "two-sided")
+        with self.assertRaises(ValueError):  # fewer than 3 objects
+            mantel_mod._mantel_stats_pearson_xp(
+                np.zeros((2, 2)), np.zeros((2, 2)), 0, get_rng(0), "two-sided")
+        # constant input -> ConstantInputWarning and a NaN statistic
+        const = np.ones((5, 5))
+        np.fill_diagonal(const, 0.0)
+        with self.assertWarns(ConstantInputWarning):
+            r, p, _ = mantel_mod._mantel_stats_pearson_xp(
+                const, self.x[:5, :5], 0, get_rng(0), "two-sided")
+        self.assertTrue(np.isnan(r))
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -28,6 +28,7 @@ from skbio.stats.distance._cutils import (mantel_perm_pearsonr_cy,
 from skbio.stats.distance._utils import distmat_reorder_condensed
 from skbio.util import get_data_path, assert_data_frame_almost_equal, numba_code
 from skbio.util._testing import _data_frame_to_default_int_type
+from skbio.util._testing import ArrayAPITestMixin, array_backends
 
 
 class MantelTestData(TestCase):
@@ -1197,6 +1198,99 @@ class MantelCondensedTests(TestCase):
         full_size = dm_full._data.nbytes
         cond_size = dm_cond._data.nbytes
         self.assertLess(cond_size, full_size / 2 + 1)  # +1 for rounding
+
+
+class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
+    """mantel on DistanceMatrices backed by non-NumPy array-API buffers."""
+
+    def setUp(self):
+        def sym(seed):
+            g = np.random.default_rng(seed)
+            a = g.random((10, 10))
+            a = (a + a.T) / 2.0
+            np.fill_diagonal(a, 0.0)
+            return a
+        self.x = sym(2)
+        self.y = sym(3)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_mantel_backends(self, xp, device):
+        for method in ("pearson", "spearman"):
+            r_ref, p_ref, _ = mantel(
+                DistanceMatrix(self.x), DistanceMatrix(self.y),
+                method=method, permutations=99, seed=0,
+            )
+            mx = DistanceMatrix(self.make_array(xp, device, self.x))
+            my = DistanceMatrix(self.make_array(xp, device, self.y))
+            r, p, _ = mantel(mx, my, method=method, permutations=99, seed=0)
+            self.assertAlmostEqual(r, r_ref, places=10)
+            self.assertAlmostEqual(p, p_ref, places=10)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_spearman_ties_backends(self, xp, device):
+        # integer distances with repeats -> tied ranks, exercising the
+        # average-tie ranking on the xp path (matches scipy rankdata 'average').
+        def sym_int(seed):
+            r = np.random.default_rng(seed)
+            a = r.integers(1, 4, size=(8, 8)).astype(float)
+            a = np.triu(a, 1)
+            return a + a.T
+        dx, dy = sym_int(11), sym_int(12)
+        r_ref, p_ref, _ = mantel(
+            DistanceMatrix(dx), DistanceMatrix(dy),
+            method="spearman", permutations=99, seed=0,
+        )
+        mx = DistanceMatrix(self.make_array(xp, device, dx))
+        my = DistanceMatrix(self.make_array(xp, device, dy))
+        r, p, _ = mantel(mx, my, method="spearman", permutations=99, seed=0)
+        self.assertAlmostEqual(r, r_ref, places=10)
+        self.assertAlmostEqual(p, p_ref, places=10)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_kendalltau_backends(self, xp, device):
+        # kendalltau has no xp path; a non-NumPy buffer is host-converted.
+        r_ref, p_ref, _ = mantel(DistanceMatrix(self.x), DistanceMatrix(self.y),
+                                 method="kendalltau", permutations=99, seed=0)
+        mx = DistanceMatrix(self.make_array(xp, device, self.x))
+        my = DistanceMatrix(self.make_array(xp, device, self.y))
+        r, p, _ = mantel(mx, my, method="kendalltau", permutations=99, seed=0)
+        self.assertAlmostEqual(r, r_ref, places=10)
+        self.assertAlmostEqual(p, p_ref, places=10)
+
+    @array_backends("jax", "torch", "cupy")  # non-NumPy only, to force a mix
+    def test_mixed_backend_raises(self, xp, device):
+        with self.assertRaises(ValueError):
+            mantel(DistanceMatrix(self.x),
+                   DistanceMatrix(self.make_array(xp, device, self.y)),
+                   method="pearson", permutations=0)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_id_reorder_backends(self, xp, device):
+        # ids in a different order are reordered on-device (via _order_dms),
+        # matching the numpy path exactly.
+        ids = [str(i) for i in range(10)]
+        perm = [7, 2, 9, 0, 4, 1, 8, 3, 6, 5]
+        ids_p = [ids[i] for i in perm]
+        y_p = self.y[np.ix_(perm, perm)]
+        r_ref, p_ref, _ = mantel(
+            DistanceMatrix(self.x, ids), DistanceMatrix(y_p, ids_p),
+            method="pearson", permutations=99, seed=0,
+        )
+        mx = DistanceMatrix(self.make_array(xp, device, self.x), ids=ids)
+        my = DistanceMatrix(self.make_array(xp, device, y_p), ids=ids_p)
+        r, p, _ = mantel(mx, my, method="pearson", permutations=99, seed=0)
+        self.assertAlmostEqual(r, r_ref, places=10)
+        self.assertAlmostEqual(p, p_ref, places=10)
+
+    @array_backends("jax", "torch", "cupy")  # non-NumPy only
+    def test_disjoint_ids_raise(self, xp, device):
+        # fully disjoint ids raise (via _order_dms, same as the numpy path)
+        mx = DistanceMatrix(self.make_array(xp, device, self.x),
+                            ids=[str(i) for i in range(10)])
+        my = DistanceMatrix(self.make_array(xp, device, self.y),
+                            ids=['z' + str(i) for i in range(10)])
+        with self.assertRaises(ValueError):
+            mantel(mx, my, method="pearson", permutations=0)
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -21,6 +21,7 @@ from skbio.stats.distance import _permanova as permanova_mod
 from skbio.stats.distance._cutils import (permanova_f_stat_sW_cy,
                                           permanova_f_stat_sW_condensed_cy)
 from skbio.util import get_data_path, numba_code
+from skbio.util._testing import ArrayAPITestMixin, array_backends
 from skbio.stats.distance._base import _preprocess_input_sng
 
 
@@ -507,6 +508,31 @@ class InternalPERMANOVATests(PERMANOVATestData):
                         engine="cython")
         self.assertAlmostEqual(obs['test statistic'], exp['test statistic'])
         self.assertAlmostEqual(obs['p-value'], exp['p-value'])
+
+
+class PermanovaArrayAPITests(TestCase, ArrayAPITestMixin):
+    """permanova on a DistanceMatrix backed by a non-NumPy array-API buffer."""
+
+    def setUp(self):
+        rng = np.random.default_rng(1)
+        a = rng.random((12, 12))
+        a = (a + a.T) / 2.0
+        np.fill_diagonal(a, 0.0)
+        self.data = a
+        self.grouping = ['a', 'a', 'a', 'b', 'b', 'b',
+                         'c', 'c', 'c', 'd', 'd', 'd']
+        self.ref = permanova(
+            DistanceMatrix(a), self.grouping, permutations=99, seed=0
+        )
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_permanova_backends(self, xp, device):
+        dm = DistanceMatrix(self.make_array(xp, device, self.data))
+        res = permanova(dm, self.grouping, permutations=99, seed=0)
+        self.assertAlmostEqual(
+            res['test statistic'], self.ref['test statistic'], places=10
+        )
+        self.assertAlmostEqual(res['p-value'], self.ref['p-value'], places=10)
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -534,6 +534,21 @@ class PermanovaArrayAPITests(TestCase, ArrayAPITestMixin):
         )
         self.assertAlmostEqual(res['p-value'], self.ref['p-value'], places=10)
 
+    def test_permanova_array_api_numpy_backend(self):
+        # NumPy is array-API compatible, so the array-API compute path runs on a
+        # NumPy array. The dispatch routes a NumPy DistanceMatrix to the
+        # cython/numba path, so a normal permanova() call never reaches these
+        # helpers; call them directly here so the array-API path is exercised
+        # under ordinary (NumPy-only) CI, matching the reference result.
+        ids = [str(i) for i in range(self.data.shape[0])]
+        res = permanova_mod._permanova_array_api(
+            self.data, self.grouping, None, 99, 0, ids=ids
+        )
+        self.assertAlmostEqual(
+            res['test statistic'], self.ref['test statistic'], places=10
+        )
+        self.assertAlmostEqual(res['p-value'], self.ref['p-value'], places=10)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
### Description
Follow-up to #2499. Adds first-pass array-API / GPU support to `permanova` and `mantel`, dispatching on where the `DistanceMatrix` data lives: a NumPy-backed `DistanceMatrix` keeps the existing cython/numba `engine=` path unchanged, while a non-NumPy (GPU-resident cupy/torch/jax) buffer is computed through the array-API (`xp`) namespace so the matrix stays on its device.

`mantel` covers pearson and spearman on the xp path; kendalltau has no xp path and is materialized on the host (SciPy's kendalltau is host-only). IDs are aligned exactly like the NumPy path (reorder / `strict` / `lookup`) via `_order_dms`, which became array-API aware in #2499. Both functions keep DistanceMatrix-only semantics (no raw-array input). The permutation p-values match the NumPy path to floating-point precision, using the same RNG order.

### Scope / follow-ups
- First-pass GPU support (roadmap step 2). The performant numba-GPU (`@cuda.jit` / `@hip.jit`) kernel backend and explicit `engine=` GPU selection are planned as later performance work (step 4).
- Permutations rebuild the index array on the host each iteration, and mantel spearman does a one-time host assembly of the ranked matrix; keeping these fully on-device is a performance follow-up.

### Testing
- array-API tests added for both functions, run on numpy and PyTorch (including id-reordering and spearman tie handling).
- Verified on a real AMD Instinct MI210 (torch-ROCm): the xp path runs on-device and matches the numpy result to floating-point precision (permanova pseudo-F, mantel pearson/spearman r and p-values), including id-reordering happening on the GPU buffer.
- Existing permanova/mantel test suites pass unchanged.

cc @sfiligoi @qiyunzhu
