### PR TITLE
fix: handle atol=None in pair_align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
-* Fixed `pair_align` raising `TypeError` when called with `atol=None`, a documented valid value equivalent to `atol=0` ([#2497](https://github.com/scikit-bio/scikit-bio/pull/2497)).
+* Fixed `pair_align` raising `TypeError` when called with `atol=None`, a documented valid value equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
 
 ## Version 0.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
 
+### Bug Fixes
+
+* Fixed `pair_align` raising `TypeError` when called with `atol=None`, a documented valid value equivalent to `atol=0` ([#2497](https://github.com/scikit-bio/scikit-bio/pull/2497)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/alignment/_pair.py
+++ b/skbio/alignment/_pair.py
@@ -395,8 +395,6 @@ def pair_align(
     # sequence alignment. While the most time-consuming step (matrix filling) is done
     # in Cython, this function retains as many steps as possible in Python, thereby
     # "outsourcing" computation and optimization to the upstream library (NumPy).
-    if atol is None:
-        atol = 0.0
 
     # Determine alignment mode (False - global, True - local)
     local = _prep_mode(mode)
@@ -421,6 +419,11 @@ def pair_align(
     # called here to be safe.
     query, target = np.ascontiguousarray(submat[seq1]), seq2
     dtype = query.dtype.type
+
+    # Cast tolerance to the same type.
+    if atol is None:
+        atol = 0.0
+    atol = dtype(atol)
 
     # Prepare affine or linear gap penalties.
     gap_open, gap_extend = prep_gapcost(gap_cost, dtype=dtype)

--- a/skbio/alignment/_pair.py
+++ b/skbio/alignment/_pair.py
@@ -396,6 +396,13 @@ def pair_align(
     # in Cython, this function retains as many steps as possible in Python, thereby
     # "outsourcing" computation and optimization to the upstream library (NumPy).
 
+    # Normalize `atol=None` to 0.0. Per the docstring, None is equivalent to 0 (exact
+    # score comparison), but downstream code (both the `<=` comparisons below and the
+    # Cython traceback routines, which take a typed `floating eps`) requires a real
+    # number and will raise a TypeError if `atol` is left as None.
+    if atol is None:
+        atol = 0.0
+
     # Determine alignment mode (False - global, True - local)
     local = _prep_mode(mode)
 

--- a/skbio/alignment/_pair.py
+++ b/skbio/alignment/_pair.py
@@ -395,11 +395,6 @@ def pair_align(
     # sequence alignment. While the most time-consuming step (matrix filling) is done
     # in Cython, this function retains as many steps as possible in Python, thereby
     # "outsourcing" computation and optimization to the upstream library (NumPy).
-
-    # Normalize `atol=None` to 0.0. Per the docstring, None is equivalent to 0 (exact
-    # score comparison), but downstream code (both the `<=` comparisons below and the
-    # Cython traceback routines, which take a typed `floating eps`) requires a real
-    # number and will raise a TypeError if `atol` is left as None.
     if atol is None:
         atol = 0.0
 

--- a/skbio/alignment/tests/test_pair.py
+++ b/skbio/alignment/tests/test_pair.py
@@ -610,6 +610,25 @@ class PairAlignTests(unittest.TestCase):
                          gap_cost=(np.nan, np.nan))
         self.assertTrue(np.isnan(obs.score))
 
+    def test_pair_align_atol_none(self):
+        """atol=None is equivalent to atol=0 and must not raise."""
+        for mode in ("global", "local"):
+            for max_paths in (1, 5):
+                obs_none = pair_align(
+                    "ACGT", "ACGA", mode=mode, atol=None, max_paths=max_paths
+                )
+                obs_zero = pair_align(
+                    "ACGT", "ACGA", mode=mode, atol=0, max_paths=max_paths
+                )
+                self.assertEqual(obs_none.score, obs_zero.score)
+                self.assertEqual(len(obs_none.paths), len(obs_zero.paths))
+                for p_none, p_zero in zip(obs_none.paths, obs_zero.paths):
+                    self.assertEqual(p_none.to_cigar(), p_zero.to_cigar())
+
+        # local alignment with no similarity: empty path list, no crash
+        obs = pair_align("AAAA", "TTTT", mode="local", atol=None)
+        self.assertEqual(obs.paths, [])
+
     def test_pair_align_error(self):
         """Errors."""
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
## Summary

`pair_align`'s docstring says setting `atol` to 0 or `None` is valid and "will slightly increase performance." In practice, `atol=None` raises `TypeError` as soon as the code path that uses it runs:

- For `mode="local"`, the check `abs(score) <= atol` raises `TypeError: '<=' not supported between instances of 'float' and 'NoneType'`.
- For `mode="global"` (and for local, once past that check), `atol` is forwarded as `eps` into the Cython traceback routines (`_trace_one_linear`, `_trace_one_affine`, `_all_stops`, etc.), which declare it as a typed `floating eps` and raise `TypeError: must be real number, not NoneType`.

So today `atol=None` fails for every mode and every `max_paths` value, not just local alignment.

## Fix

Normalize `atol=None` to `0.0` at the top of `pair_align`, before it reaches any of the downstream comparisons. This makes `atol=None` behave identically to `atol=0`, matching the documented contract.

## Testing

Added `test_pair_align_atol_none`, which checks `atol=None` against `atol=0` for both `global`/`local` modes and `max_paths=1`/`max_paths=5` (exercising both the single-path and multi-path traceback code), plus a no-similarity local case that should return an empty path list without raising.

```
$ pytest skbio/alignment/tests/test_pair.py -q
35 passed
```

Confirmed the new test fails with the pre-fix code (`TypeError: must be real number, not NoneType`) and passes after the one-line fix.

## Checklist

- [x] I have read the contribution guidelines.
- [x] I have documented this change in the changelog.
- [x] This pull request does not include code, documentation, or other content derived from external source(s).