### PR TITLE
ENH: support condensed form for GPU-resident distance matrices

### DIFF
--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -26,7 +26,7 @@ from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow, is_symmetric
 from ._utils import distmat_reorder, distmat_reorder_condensed
-from skbio.util._array import ingest_array, copy_array
+from skbio.util._array import ingest_array, copy_array, _to_numpy
 
 import array_api_compat as _aac
 
@@ -776,7 +776,9 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         fig, ax = self.plt.subplots()
 
         # use pcolormesh instead of pcolor for performance
-        heatmap = ax.pcolormesh(self.redundant_form(), cmap=cmap)
+        # matplotlib needs a host array; a non-NumPy (e.g. GPU-resident)
+        # buffer is materialized here since a heatmap is inherently host-side.
+        heatmap = ax.pcolormesh(_to_numpy(self.redundant_form()), cmap=cmap)
         fig.colorbar(heatmap)
 
         # center labels within each cell
@@ -822,8 +824,10 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         c  2.0  3.0  0.0
 
         """
+        # pandas needs a host array; a non-NumPy (e.g. GPU-resident) buffer is
+        # materialized here since a DataFrame is inherently host-side.
         return pd.DataFrame(
-            data=self.redundant_form(), index=self.ids, columns=self.ids
+            data=_to_numpy(self.redundant_form()), index=self.ids, columns=self.ids
         )
 
     def __str__(self) -> str:
@@ -1256,6 +1260,9 @@ class SymmetricMatrix(PairwiseMatrix):
             if data.ndim == 1:
                 return 0.0
             elif data.ndim == 2:
+                if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+                    xp = _aac.array_namespace(data)
+                    return xp.linalg.diagonal(data)
                 return np.diagonal(data)
         return None
 
@@ -1295,16 +1302,18 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-            # Array-API (e.g. GPU-resident) buffers are stored in redundant (2-D)
-            # form only. Condensed storage relies on scipy.squareform, which is
-            # NumPy-only, so a condensed or 1-D non-NumPy buffer could not be
-            # reordered/converted without a silent copy back to the host.
-            if condensed or data.ndim != 2:
-                raise SymmetricMatrixError(
-                    "Condensed form is not supported for non-NumPy (array-API) "
-                    "arrays. Provide a 2-D array to store the matrix on a "
-                    "non-NumPy device."
-                )
+            if condensed:
+                if data.ndim == 1:
+                    # Already condensed; store as-is, no conversion needed.
+                    return data
+                # 2-D non-NumPy input requested in condensed form: extract the
+                # row-major upper triangle on-device (identity-reordered), the
+                # same operation condensed_form() uses.
+                n = data.shape[0]
+                return distmat_reorder_condensed(data, np.arange(n))
+            if data.ndim == 1:
+                # Redundant form requested from a condensed non-NumPy vector.
+                return self._condensed_to_redundant(data)
             return data
         if condensed:
             # case where input is 1d and stays 1d
@@ -1325,6 +1334,22 @@ class SymmetricMatrix(PairwiseMatrix):
             # case where input is 2d and stays 2d
             else:
                 return data
+
+    def _condensed_to_redundant(self, condensed: NDArray) -> NDArray:
+        """Expand a non-NumPy condensed vector to a redundant 2-D buffer on its device.
+
+        Uses a single host round-trip because scattering values into a matrix needs
+        item-assignment, which some backends (e.g. JAX) do not support.
+
+        """
+        xp = _aac.array_namespace(condensed)
+        dev = getattr(condensed, "device", None)
+        mat_np = squareform(_to_numpy(condensed), force="tomatrix", checks=False)
+        diag = self._diagonal if self._diagonal is not None else 0.0
+        if _aac.is_array_api_obj(diag) and not _aac.is_numpy_array(diag):
+            diag = _to_numpy(diag)
+        np.fill_diagonal(mat_np, diag)
+        return xp.asarray(mat_np, device=dev)
 
     def _validate_data(self, data: NDArray) -> None:
         """Validate the data array.
@@ -1651,6 +1676,10 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         if self._flags["CONDENSED"]:
+            if _aac.is_array_api_obj(self._data) and not _aac.is_numpy_array(
+                self._data
+            ):
+                return self._condensed_to_redundant(self._data)
             mat = squareform(self._data, force="tomatrix", checks=False)
             np.fill_diagonal(mat, self._diagonal)
             return mat
@@ -1728,6 +1757,9 @@ class SymmetricMatrix(PairwiseMatrix):
         """
         if self._flags["CONDENSED"]:
             return self._data
+        elif _aac.is_array_api_obj(self._data) and not _aac.is_numpy_array(self._data):
+            n = self._data.shape[0]
+            return distmat_reorder_condensed(self._data, np.arange(n))
         else:
             return squareform(self._data, force="tovector", checks=False)
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -26,7 +26,7 @@ from skbio.io.descriptors import Read, Write
 
 from ._utils import is_symmetric_and_hollow, is_symmetric
 from ._utils import distmat_reorder, distmat_reorder_condensed
-from skbio.util._array import ingest_array, copy_array, _to_numpy
+from skbio.util._array import ingest_array, copy_array, _to_numpy, _get_backend_name
 
 import array_api_compat as _aac
 
@@ -1338,12 +1338,32 @@ class SymmetricMatrix(PairwiseMatrix):
     def _condensed_to_redundant(self, condensed: NDArray) -> NDArray:
         """Expand a non-NumPy condensed vector to a redundant 2-D buffer on its device.
 
-        Uses a single host round-trip because scattering values into a matrix needs
-        item-assignment, which some backends (e.g. JAX) do not support.
+        Mutable backends (e.g. PyTorch, CuPy) scatter the values into the matrix
+        on-device via item-assignment. Immutable backends (e.g. JAX), which do not
+        support item-assignment, go through a single host round-trip instead.
 
         """
         xp = _aac.array_namespace(condensed)
         dev = getattr(condensed, "device", None)
+
+        if _get_backend_name(xp) in ("torch", "cupy"):
+            # scatter on-device (no host round-trip): place the values in the
+            # row-major upper triangle (matching the condensed order), mirror to
+            # the lower triangle, then set the diagonal.
+            k = condensed.shape[0]
+            n = int((1.0 + (1.0 + 8.0 * k) ** 0.5) / 2.0)
+            idx = xp.arange(n, device=dev)
+            upper = idx[:, None] < idx[None, :]
+            mat = xp.zeros((n, n), dtype=condensed.dtype, device=dev)
+            mat[upper] = condensed
+            mat = mat + xp.matrix_transpose(mat)  # symmetric; diagonal stays zero
+            if self._diagonal is not None:
+                mat[idx, idx] = xp.asarray(
+                    self._diagonal, dtype=condensed.dtype, device=dev
+                )
+            return mat
+
+        # immutable backends (e.g. JAX): build the matrix via one host round-trip.
         mat_np = squareform(_to_numpy(condensed), force="tomatrix", checks=False)
         diag = self._diagonal if self._diagonal is not None else 0.0
         if _aac.is_array_api_obj(diag) and not _aac.is_numpy_array(diag):

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -2330,21 +2330,93 @@ class DistanceMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
         self.assertTrue(ns.isdtype(dm.data.dtype, (ns.float32, ns.float64)))
         self.assertFalse(ns.isdtype(dm.data.dtype, xp.float16))
 
-    @array_backends("jax", "torch", "cupy")
-    def test_condensed_rejected_for_non_numpy(self, xp, device):
-        # Condensed storage is NumPy-only (scipy.squareform); a non-NumPy 2-D
-        # buffer with condensed=True must raise rather than silently host-copy.
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_condensed_2d_buffer_backend(self, xp, device):
+        # A non-NumPy 2-D buffer with condensed=True is stored as a 1-D
+        # condensed buffer on-device (extracted via distmat_reorder_condensed),
+        # matching the NumPy path's condensed_form() output.
         buf = self.make_array(xp, device, self.data)
-        with self.assertRaises(SymmetricMatrixError):
-            DistanceMatrix(buf, condensed=True)
+        dm = DistanceMatrix(buf, condensed=True)
+        self.assertEqual(dm.data.ndim, 1)
+        self.assert_type_preserved(dm.data, xp, device)
+        ref = DistanceMatrix(self.data).condensed_form()
+        self.assert_close(dm.data, ref)
 
-    @array_backends("jax", "torch", "cupy")
-    def test_1d_buffer_rejected_for_non_numpy(self, xp, device):
-        # A 1-D (condensed-form) non-NumPy buffer must be rejected: expanding it
-        # to redundant form would require scipy.squareform (NumPy-only).
-        cond = self.make_array(xp, device, np.array([1.0, 2.0, 3.0]))
-        with self.assertRaises(SymmetricMatrixError):
-            DistanceMatrix(cond)
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_condensed_1d_buffer_backend(self, xp, device):
+        # A 1-D non-NumPy (condensed-form) buffer is stored as-is, no
+        # conversion needed.
+        ref_dm = DistanceMatrix(self.data)
+        cond = self.make_array(xp, device, ref_dm.condensed_form())
+        dm = DistanceMatrix(cond, condensed=True)
+        self.assertEqual(dm.data.ndim, 1)
+        self.assert_type_preserved(dm.data, xp, device)
+        self.assert_close(dm.data, ref_dm.condensed_form())
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_1d_buffer_redundant_form_backend(self, xp, device):
+        # A 1-D non-NumPy buffer requesting redundant storage (condensed=False,
+        # the default) is expanded to a 2-D matrix on-device.
+        ref_dm = DistanceMatrix(self.data)
+        cond = self.make_array(xp, device, ref_dm.condensed_form())
+        dm = DistanceMatrix(cond)
+        self.assertEqual(dm.data.ndim, 2)
+        self.assert_type_preserved(dm.data, xp, device)
+        self.assert_close(dm.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_condensed_redundant_round_trip_backend(self, xp, device):
+        # condensed_form() and redundant_form() round-trip correctly for a
+        # non-NumPy DistanceMatrix, on both storage forms.
+        buf_2d = self.make_array(xp, device, self.data)
+        dm_2d = DistanceMatrix(buf_2d)
+        self.assert_type_preserved(dm_2d.condensed_form(), xp, device)
+        self.assert_close(dm_2d.condensed_form(), dm_2d.condensed_form())
+
+        ref_dm = DistanceMatrix(self.data)
+        cond = self.make_array(xp, device, ref_dm.condensed_form())
+        dm_1d = DistanceMatrix(cond, condensed=True)
+        self.assert_type_preserved(dm_1d.redundant_form(), xp, device)
+        self.assert_close(dm_1d.redundant_form(), self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_plot_and_to_data_frame_backend(self, xp, device):
+        # plot() and to_data_frame() hand off to matplotlib/pandas, which are
+        # host-only; a non-NumPy buffer must be materialized rather than
+        # erroring or silently misbehaving.
+        dm = DistanceMatrix(self.make_array(xp, device, self.data), ids=list("abcde"))
+        df = dm.to_data_frame()
+        self.assertEqual(df.shape, (5, 5))
+        self.assert_close(df.to_numpy(), self.data)
+        fig = dm.plot()
+        self.assertEqual(len(fig.axes), 2)  # heatmap axis + colorbar axis
+
+
+class SymmetricMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
+    """A SymmetricMatrix supports condensed form on a non-NumPy buffer.
+
+    A SymmetricMatrix (unlike a DistanceMatrix) can carry a non-zero diagonal,
+    which is stored separately from the condensed off-diagonal values.
+    """
+
+    def setUp(self):
+        rng = np.random.default_rng(0)
+        a = rng.random((5, 5))
+        a = (a + a.T) / 2.0
+        # non-zero diagonal, which a SymmetricMatrix keeps
+        np.fill_diagonal(a, rng.random(5))
+        self.data = a
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_condensed_2d_preserves_diagonal(self, xp, device):
+        # Building condensed from a 2-D buffer stores the diagonal separately;
+        # redundant_form must reconstruct it (the diagonal is materialized to
+        # the host for the scatter, then moved back to the buffer's device).
+        sm = SymmetricMatrix(self.make_array(xp, device, self.data), condensed=True)
+        self.assertEqual(sm.data.ndim, 1)
+        red = sm.redundant_form()
+        self.assert_type_preserved(red, xp, device)
+        self.assert_close(red, self.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Follow-up to #2499, continuing the GPU-resident support for the distance-matrix classes. This makes the condensed-form conversions and the host-side export helpers work when the matrix data is a non-NumPy (GPU-resident cupy/torch/jax) buffer, so a distance matrix that lives on a device behaves the same as a NumPy-backed one for these operations.

`condensed_form()` on a non-NumPy 2-D buffer now extracts the row-major upper triangle on-device through the existing `distmat_reorder_condensed` helper (array-aware since #2499) rather than calling `scipy.spatial.distance.squareform`, which is NumPy-only. A non-NumPy buffer can also be constructed directly in condensed form, and a condensed non-NumPy buffer can be expanded back to redundant form. Expanding a condensed vector into a symmetric matrix goes through one host round-trip, because scattering values into a matrix needs item-assignment, which some backends (e.g. JAX) do not support. `plot()` and `to_data_frame()` materialize the matrix to the host before handing it to matplotlib and pandas, which are host-only.

NumPy inputs are unaffected: the form-conversion changes are guarded on a non-NumPy buffer, and the `plot`/`to_data_frame` exports route through a helper that returns a NumPy array unchanged. This is independent of #2503 (permanova/mantel) and touches only the matrix classes in `_base.py`.

### Scope / follow-ups
- File IO for a non-NumPy matrix (`lsmat` write) is not covered here and is left as a follow-up, as noted on #2499. Reading a matrix from a file always produces a NumPy array, so only writing is affected.
- The array-API symmetry check in `is_symmetric_and_hollow` compares the full transpose; a faster upper-triangle version is a possible performance follow-up (it needs to be measured, since an index-gather version I tried was slower on the backends I benchmarked).

### Testing
- array-API tests added for `DistanceMatrix` and `SymmetricMatrix`, run on numpy and PyTorch: condensed round-trip in both directions, `condensed_form`/`redundant_form` agreement with the NumPy path, `plot`/`to_data_frame` on a non-NumPy buffer, and a non-zero diagonal preserved through a condensed round-trip.
- Verified on a real AMD Instinct MI210 (torch-ROCm): the condensed conversions and exports run on-device and match the NumPy result exactly, including the non-zero-diagonal round-trip.
- The two tests that asserted condensed form was rejected for a non-NumPy buffer are replaced, since that restriction is now lifted.
- Existing distance test suites pass unchanged.

cc @sfiligoi @qiyunzhu
