### PR TITLE
ENH: add optional Numba engine for center_distance_matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Add optional support for the Numba backend [#2483](https://github.com/scikit-bio/scikit-bio/pull/2483), with Permanova and Mantel currently using it [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488)and [#2464](https://github.com/scikit-bio/scikit-bio/pull/2464).
+* `pcoa` and `center_distance_matrix` can now use the Numba backend for distance-matrix centering via `engine="numba"` [#2508](https://github.com/scikit-bio/scikit-bio/pull/2508).
 
 ### Performance enhancements
 

--- a/skbio/stats/ordination/_center_distance_matrix_numba.py
+++ b/skbio/stats/ordination/_center_distance_matrix_numba.py
@@ -1,0 +1,91 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+"""Optional CPU Numba implementation of distance-matrix double-centering.
+
+Mirrors the Cython implementation in ``_cutils.pyx`` (``e_matrix_means_cy``,
+``f_matrix_inplace_cy`` and ``center_distance_matrix_cy``) so the two engines
+are numerically interchangeable.
+"""
+
+import numpy as np
+
+try:
+    from numba import njit, prange
+
+    NUMBA_AVAILABLE = True
+except ImportError:
+    NUMBA_AVAILABLE = False
+
+
+if NUMBA_AVAILABLE:
+
+    @njit(parallel=True)
+    def e_matrix_means_nb(mat, centered, row_means):
+        """Apply the E-matrix transform and collect row/global means in one pass.
+
+        Writes ``-0.5 * d**2`` into ``centered`` and returns the global mean of
+        that transformed matrix. Values are promoted to float64 before squaring
+        to match the Cython ``double`` accumulator (matters for float32 input).
+        """
+        n = mat.shape[0]
+        global_sum = np.float64(0.0)
+
+        for row in prange(n):
+            row_sum = np.float64(0.0)
+
+            for col in range(n):
+                val = np.float64(mat[row, col])
+                el = np.float64(-0.5) * val * val
+                centered[row, col] = el
+                row_sum += el
+
+            row_means[row] = row_sum / np.float64(n)
+            global_sum += row_sum
+
+        return (global_sum / np.float64(n)) / np.float64(n)
+
+    @njit(parallel=True)
+    def f_matrix_inplace_nb(row_means, global_mean, centered):
+        """Double-center the E-matrix in-place.
+
+        Uses the same 24-wide block tiling as ``f_matrix_inplace_cy`` so the
+        two engines share a memory-access pattern.
+        """
+        n = centered.shape[0]
+
+        n_blocks = (n + 23) // 24
+        for brow in prange(n_blocks):
+            trow = brow * 24
+            trow_max = min(trow + 24, n)
+
+            for tcol in range(0, n, 24):
+                tcol_max = min(tcol + 24, n)
+
+                for row in range(trow, trow_max):
+                    gr_mean = global_mean - row_means[row]
+
+                    for col in range(tcol, tcol_max):
+                        centered[row, col] += gr_mean - row_means[col]
+
+    def center_distance_matrix_nb(mat, centered):
+        """Drop-in replacement for ``center_distance_matrix_cy``.
+
+        Parameters
+        ----------
+        mat : ndarray of shape (n, n)
+            Input distance matrix, C-contiguous, float32 or float64.
+        centered : ndarray of shape (n, n)
+            Pre-allocated output array of the same dtype as ``mat``. May alias
+            ``mat`` for in-place centering.
+
+        """
+        n = mat.shape[0]
+        row_means = np.zeros(n, dtype=mat.dtype)
+        global_mean = e_matrix_means_nb(mat, centered, row_means)
+        f_matrix_inplace_nb(row_means, np.float64(global_mean), centered)

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -45,17 +45,19 @@ def f_matrix(E_matrix):
     return E_matrix - row_means - col_means + matrix_mean
 
 
-def center_distance_matrix(distance_matrix, inplace=False):
+def center_distance_matrix(distance_matrix, inplace=False, engine=None):
     """Center a distance matrix.
 
     Note: For JAX arrays (immutable) and CuPy arrays (GPU), the ``inplace``
-    argument is accepted for API compatibility but ignored — the function
+    argument is accepted for API compatibility but ignored. The function
     always returns a centered array.
     """
-    # For true NumPy arrays, use the Cython-accelerated implementation,
-    # which also supports in-place modification.
+    # For true NumPy arrays, use the Cython- or Numba-accelerated
+    # implementation, which also supports in-place modification.
     if isinstance(distance_matrix, np.ndarray):
-        return center_distance_matrix_np(distance_matrix, inplace=inplace)
+        return center_distance_matrix_np(
+            distance_matrix, inplace=inplace, engine=engine
+        )
 
     # For JAX/CuPy and other array-API backends, use the generic
     # double-centering path; `inplace` is ignored for these backends.
@@ -99,6 +101,7 @@ def pcoa(
     seed=None,
     warn_neg_eigval=0.01,
     output_format=None,
+    engine=None,
 ):
     r"""Perform Principal Coordinate Analysis (PCoA).
 
@@ -141,6 +144,12 @@ def pcoa(
 
     output_format : optional
         Standard table parameters. See :ref:`table_params` for details.
+    engine : {"cython", "numba"}, optional
+        Compute engine to use for centering NumPy-backed distance matrices.
+        ``"cython"`` (default) uses the Cython implementation. ``"numba"``
+        uses the optional Numba implementation and requires Numba to be
+        installed. If not provided, the global default is used (see
+        :func:`skbio.set_config`).
 
     Returns
     -------
@@ -259,7 +268,9 @@ def pcoa(
     if method == "eigh":
         long_method_name = "Principal Coordinate Analysis"
         # Center distance matrix, a requirement for PCoA here
-        matrix_data = center_distance_matrix(distmat.data, inplace=inplace)
+        matrix_data = center_distance_matrix(
+            distmat.data, inplace=inplace, engine=engine
+        )
         if 0 < dimensions < 1:
             if matrix_data.shape[0] > 10:
                 warn(
@@ -326,7 +337,9 @@ def pcoa(
                 )
         # if we got here, we could not use skbb
         # Center distance matrix, a requirement for PCoA here
-        matrix_data = center_distance_matrix(distmat.data, inplace=inplace)
+        matrix_data = center_distance_matrix(
+            distmat.data, inplace=inplace, engine=engine
+        )
 
         eigvals, eigvecs = _fsvd(matrix_data, ndim, seed=seed)
     else:

--- a/skbio/stats/ordination/_utils.py
+++ b/skbio/stats/ordination/_utils.py
@@ -8,6 +8,8 @@
 
 import numpy as np
 
+from skbio._config import _resolve_engine
+
 from ._cutils import center_distance_matrix_cy
 
 
@@ -197,7 +199,7 @@ def f_matrix(E_matrix):
     return E_matrix - row_means - col_means + matrix_mean
 
 
-def center_distance_matrix(distance_matrix, inplace=False):
+def center_distance_matrix(distance_matrix, inplace=False, engine=None):
     """Centers a distance matrix.
 
     Note: If the used distance was euclidean, pairwise distances
@@ -214,18 +216,30 @@ def center_distance_matrix(distance_matrix, inplace=False):
     inplace : bool, optional
         Whether or not to center the given distance matrix in-place, which
         is more efficient in terms of memory and computation.
+    engine : {"cython", "numba"}, optional
+        Compute engine to use. ``"cython"`` (default) uses the Cython
+        implementation. ``"numba"`` uses the optional Numba implementation
+        and requires Numba to be installed. If not provided, the global
+        default is used (see :func:`skbio.set_config`).
 
     """
+    engine = _resolve_engine(engine, ("cython", "numba"))
+
+    if engine == "numba":
+        from ._center_distance_matrix_numba import center_distance_matrix_nb as center
+    else:
+        center = center_distance_matrix_cy
+
     if not distance_matrix.flags.c_contiguous:
-        # center_distance_matrix_cy requires c_contiguous, so make a copy
+        # the centering kernels require c_contiguous, so make a copy
         distance_matrix = np.asarray(distance_matrix, order="C")
 
     if inplace:
-        center_distance_matrix_cy(distance_matrix, distance_matrix)
+        center(distance_matrix, distance_matrix)
         return distance_matrix
     else:
         centered = np.empty(distance_matrix.shape, distance_matrix.dtype)
-        center_distance_matrix_cy(distance_matrix, centered)
+        center(distance_matrix, centered)
         return centered
 
 

--- a/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
@@ -18,7 +18,7 @@ from skbio.stats.distance import PairwiseMatrixError
 from skbio.stats.ordination import pcoa, pcoa_biplot
 from skbio.util import (get_data_path, assert_ordination_results_equal,
                         assert_data_frame_almost_equal, ArrayAPITestMixin,
-                        array_backends)
+                        array_backends, numba_code)
 from skbio.stats.ordination._principal_coordinate_analysis import (
     e_matrix,
     f_matrix,
@@ -60,6 +60,15 @@ class TestPCoA(TestCase):
 
         results = pcoa(self.dm3)
 
+        assert_ordination_results_equal(results, expected_results,
+                                        ignore_directionality=True)
+
+    @numba_code
+    def test_engine_numba_matches_cython(self):
+        # Selecting the numba centering engine must give the same PCoA as the
+        # default cython engine.
+        expected_results = pcoa(self.dm3, engine="cython")
+        results = pcoa(self.dm3, engine="numba")
         assert_ordination_results_equal(results, expected_results,
                                         ignore_directionality=True)
 

--- a/skbio/stats/ordination/tests/test_util.py
+++ b/skbio/stats/ordination/tests/test_util.py
@@ -16,6 +16,7 @@ from skbio.stats.ordination import corr, mean_and_std, e_matrix, f_matrix, \
     center_distance_matrix
 
 from skbio.stats.ordination._utils import _e_matrix_inplace, _f_matrix_inplace
+from skbio.util import numba_code
 
 
 class TestUtils(TestCase):
@@ -121,6 +122,34 @@ class TestUtils(TestCase):
 
         # and ensure that the result of inplace centering was correct
         npt.assert_almost_equal(dm_expected, dm_centered_inp)
+
+    @numba_code
+    def test_center_distance_matrix_numba_matches_cython(self):
+        # The numba and cython engines should produce the same centered matrix.
+        # `big` is larger than the 24-wide centering tile and not a multiple of
+        # 24, so it exercises the multi-block tiling and its partial final
+        # block; both float64 and float32, in-place or not.
+        rng = np.random.default_rng(0)
+        big = rng.random((50, 50))
+        big = (big + big.T) / 2.0
+        np.fill_diagonal(big, 0.0)
+
+        for base in (self.dist_mat, big):
+            for dtype in (np.float64, np.float32):
+                mat = base.astype(dtype)
+
+                cy = center_distance_matrix(mat.copy(), engine="cython")
+                nb = center_distance_matrix(mat.copy(), engine="numba")
+                npt.assert_allclose(nb, cy, rtol=0, atol=1e-6)
+
+                # in-place centering must match the out-of-place result
+                nb_inplace = center_distance_matrix(
+                    mat.copy(), inplace=True, engine="numba")
+                npt.assert_array_equal(nb_inplace, nb)
+
+    def test_center_distance_matrix_bad_engine(self):
+        with npt.assert_raises(ValueError):
+            center_distance_matrix(self.dist_mat.copy(), engine="nonsense")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds an optional Numba implementation of distance-matrix double-centering, selectable via `engine="numba"` on `center_distance_matrix` and `pcoa`, alongside the existing Cython path. This extends the `engine=` selector already used by `permanova` and `mantel` to the ordination centering step.

This carries forward the Numba centering work started in #2491 by @fyash1010, rebased on the current `development_numba_gpu`, with the engine dispatch refactored to share the in-place/out-of-place logic, docstrings aligned to the `permanova`/`mantel` convention, and tests added. It is opened as a fresh PR since #2491 has been inactive.

The Numba kernels mirror the Cython implementation in `_cutils.pyx` (`e_matrix_means_cy`, `f_matrix_inplace_cy`), including the 24-wide block tiling, so the two engines are numerically interchangeable (agreement below 1e-15 for float64). Numba stays an optional dependency and Cython remains the default. The array-API (GPU-resident) centering path is already present on this branch, so this PR only adds the CPU Numba engine.

## Tests

- Numba-vs-Cython agreement for float64 and float32, in-place and out-of-place, including a size that is larger than the 24-wide tile and not a multiple of it to exercise the partial final block.
- The public `pcoa(engine="numba")` path against the Cython result.
- Invalid-engine handling.

@sfiligoi
