### PR TITLE
BUG: accumulate permanova s_T in float64 for float32 distance matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
 
+### Bug fixes
+
+* Fixed `permanova` returning an inaccurate pseudo-F for float32 distance matrices, caused by accumulating the total sum of squares in float32 rather than float64 [#2509](https://github.com/scikit-bio/scikit-bio/pull/2509).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -561,7 +561,9 @@ def permanova(
     # if we got here, we could not use skbb
     # Calculate number of objects in each group.
     group_sizes = np.bincount(grouping)
-    s_T = (distmat.data**2).sum() / sample_size
+    # accumulate in float64: for a float32 matrix s_T and s_W nearly cancel in
+    # the pseudo-F, so a float32 sum here loses accuracy in the s_A = s_T - s_W step
+    s_T = (distmat.data**2).sum(dtype=np.float64) / sample_size
     if not distmat._flags["CONDENSED"]:
         # we are going over the whole matrix, instead of just upper triangle
         # so cut in half
@@ -648,7 +650,7 @@ def _permanova_array_api(distmat, grouping, column, permutations, seed, ids=None
     )
     # full 2-D matrix (array-API input is never condensed); halve to count each
     # unordered pair once, matching the DistanceMatrix full-matrix path.
-    s_T = xp.sum(dm * dm) / sample_size / 2.0
+    s_T = xp.sum(dm * dm, dtype=xp.float64) / sample_size / 2.0
 
     def _test_stat(grp):
         grp = xp.asarray(grp, device=dm.device)

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -202,6 +202,25 @@ class PERMANOVATests(PERMANOVATestData):
         with self.assertRaises(TypeError):
             permanova(self.dm_ties.data, self.grouping_equal, seed=42)
 
+    def test_float32_matches_float64(self):
+        # A float32 distance matrix must give the same pseudo-F as its float64
+        # equivalent. s_T is accumulated in float64; a float32 sum there loses
+        # accuracy because s_T and s_W nearly cancel in the ratio, which showed
+        # up as a several-percent error on real (float32) UniFrac matrices. Weak
+        # grouping (F ~ 1) makes the cancellation strongest.
+        rng = np.random.default_rng(1)
+        n = 2000
+        a = rng.random((n, n)).astype(np.float32)
+        a = ((a + a.T) / 2).astype(np.float32)
+        np.fill_diagonal(a, 0.0)
+        grouping = rng.integers(0, 3, n).astype(str).tolist()
+        f32 = permanova(
+            DistanceMatrix(a), grouping, permutations=0)['test statistic']
+        f64 = permanova(
+            DistanceMatrix(a.astype(np.float64)), grouping,
+            permutations=0)['test statistic']
+        self.assertAlmostEqual(float(f32), float(f64), places=5)
+
 
 class PERMANOVACondensedTests(PERMANOVATestData):
     """Tests for PERMANOVA with condensed distance matrices.


### PR DESCRIPTION
## Summary

PERMANOVA's total sum of squares `s_T` was accumulated in the distance matrix's dtype. For a **float32** matrix this gives an inaccurate pseudo-F, because `s_T` and the within-group sum of squares `s_W` nearly cancel in `s_A = s_T - s_W`, so a small float32 rounding error in `s_T` is amplified in the F ratio.

On real float32 UniFrac matrices the error grows with size — about 0.2% at n=5k and **~5% at n=25k** (the EMP matrices are float32). `s_W` is already accumulated in float64; this accumulates `s_T` in float64 too, in both the `DistanceMatrix` (Cython/Numba) path and the array-API path. Float64 matrices are unaffected. Found while benchmarking on the EMP UniFrac matrices.

## Change

`s_T` is computed with a float64 accumulator (`.sum(dtype=np.float64)` / `xp.sum(..., dtype=xp.float64)`). The per-element float32 square is negligible; it was the accumulation that mattered.

## Test

`test_float32_matches_float64`: a float32 matrix with weak grouping (where the cancellation is strongest) must give the same pseudo-F as its float64 equivalent. Fails on the old code (about 5e-5 at n=2000), passes with the fix.

@sfiligoi
