### PR TITLE
ENH: add a Numba GPU backend for permanova and mantel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 * Add optional support for the Numba backend [#2483](https://github.com/scikit-bio/scikit-bio/pull/2483), with Permanova and Mantel currently using it [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488)and [#2464](https://github.com/scikit-bio/scikit-bio/pull/2464).
 * `pcoa` and `center_distance_matrix` can now use the Numba backend for distance-matrix centering via `engine="numba"` [#2508](https://github.com/scikit-bio/scikit-bio/pull/2508).
+* Added a Numba GPU backend for `permanova` and `mantel`. With `engine="numba"` and a GPU-resident `DistanceMatrix`, a fused single-source kernel runs on the device (`numba.cuda` on NVIDIA, `numba.hip` on AMD), falling back to the array-API path when the kernel is unavailable [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Performance enhancements
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
+* On a GPU-resident matrix, the fused Numba kernel runs `permanova` and `mantel` much faster than the CPU engines (for example, `permanova` at 25000 samples and 9999 permutations in about 7 s versus about 426 s for OpenMP Cython on an MI300X) [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Performance enhancements
 
 * When using the Numba backend, Permanova is up to 8x faster [#2488](https://github.com/scikit-bio/scikit-bio/pull/2488).
-* On a GPU-resident matrix, the fused Numba kernel runs `permanova` and `mantel` much faster than the CPU engines (for example, `permanova` at 25000 samples and 9999 permutations in about 7 s versus about 426 s for OpenMP Cython on an MI300X) [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
+* On a GPU-resident matrix, the fused Numba kernel accelerates `permanova` and `mantel` on the device; on a datacenter GPU it is much faster than the CPU engines (for example, `permanova` at 25000 samples and 9999 permutations in about 7 s versus about 426 s for OpenMP Cython on an MI300X) [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Bug fixes
 

--- a/skbio/stats/distance/_gpu.py
+++ b/skbio/stats/distance/_gpu.py
@@ -40,8 +40,8 @@ def _numba_gpu_module_for(arr):
     unavailable backend, when Numba GPU support is not installed, or when this
     backend's fused kernel has already failed once in this process (see
     :func:`_mark_gpu_unavailable`); the caller then takes the array-API path. A
-    CuPy (CUDA) array is never routed to ``numba.hip`` (mixing the two crashes on
-    the array handoff).
+    CuPy array is routed to ``numba.cuda``, never ``numba.hip`` (the two target
+    different GPU vendors).
 
     Parameters
     ----------

--- a/skbio/stats/distance/_gpu.py
+++ b/skbio/stats/distance/_gpu.py
@@ -11,9 +11,9 @@
 The permutation-test statistics (PERMANOVA, Mantel) each ship a fused kernel that
 compiles through ``numba.cuda`` on NVIDIA and ``numba.hip`` on AMD. This module
 holds the piece they share: choosing the Numba GPU module for a given
-device-resident array (``numba.cuda`` for CuPy / CUDA-PyTorch, ``numba.hip`` for
-ROCm-PyTorch), and a correctness-first fallback to the array-API path whenever the
-fused kernel is unavailable or fails to build on the running stack.
+device-resident array (``numba.cuda`` for CUDA CuPy / PyTorch, ``numba.hip`` for
+ROCm CuPy / PyTorch), and a correctness-first fallback to the array-API path
+whenever the fused kernel is unavailable or fails to build on the running stack.
 """
 
 from warnings import warn
@@ -35,13 +35,12 @@ _unavailable = set()
 def _numba_gpu_module_for(arr):
     """Return the Numba GPU module for ``arr``'s device, or None.
 
-    CuPy and CUDA-built PyTorch map to ``numba.cuda``; ROCm-built PyTorch maps to
-    ``numba.hip``. Returns None for any other namespace (e.g. JAX, Dask), an
-    unavailable backend, when Numba GPU support is not installed, or when this
-    backend's fused kernel has already failed once in this process (see
-    :func:`_mark_gpu_unavailable`); the caller then takes the array-API path. A
-    CuPy array is routed to ``numba.cuda``, never ``numba.hip`` (the two target
-    different GPU vendors).
+    CUDA-built CuPy and PyTorch map to ``numba.cuda``; ROCm-built CuPy and PyTorch
+    map to ``numba.hip`` (both report the same array-API namespace, so the build's
+    own flag disambiguates them). Returns None for any other namespace (e.g. JAX,
+    Dask), an unavailable backend, when Numba GPU support is not installed, or when
+    this backend's fused kernel has already failed once in this process (see
+    :func:`_mark_gpu_unavailable`); the caller then takes the array-API path.
 
     Parameters
     ----------
@@ -57,7 +56,11 @@ def _numba_gpu_module_for(arr):
     if name in _unavailable:
         return None
     if name == "cupy":
-        want = "cuda"
+        import cupy
+
+        # cuPy reports the same namespace for CUDA and ROCm builds; the build's
+        # own is_hip flag disambiguates them (ROCm -> numba.hip).
+        want = "hip" if getattr(cupy.cuda.runtime, "is_hip", False) else "cuda"
     elif name == "torch":
         import torch
 

--- a/skbio/stats/distance/_gpu.py
+++ b/skbio/stats/distance/_gpu.py
@@ -1,0 +1,105 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+"""Shared helpers for the single-source Numba CUDA/HIP GPU backends.
+
+The permutation-test statistics (PERMANOVA, Mantel) each ship a fused kernel that
+compiles through ``numba.cuda`` on NVIDIA and ``numba.hip`` on AMD. This module
+holds the piece they share: choosing the Numba GPU module for a given
+device-resident array (``numba.cuda`` for CuPy / CUDA-PyTorch, ``numba.hip`` for
+ROCm-PyTorch), and a correctness-first fallback to the array-API path whenever the
+fused kernel is unavailable or fails to build on the running stack.
+"""
+
+from warnings import warn
+
+import array_api_compat as _aac
+
+from skbio.util._array import _get_backend_name
+
+# One thread block per permutation; _TPB threads walk the columns (the tile width
+# used by scikit-bio-binaries).
+_TPB = 128
+
+# Backend names whose fused Numba GPU kernel failed to build or run in this
+# process. Populated by ``_mark_gpu_unavailable`` so that later calls skip the
+# kernel and take the array-API path instead of retrying a failing compilation.
+_unavailable = set()
+
+
+def _numba_gpu_module_for(arr):
+    """Return the Numba GPU module for ``arr``'s device, or None.
+
+    CuPy and CUDA-built PyTorch map to ``numba.cuda``; ROCm-built PyTorch maps to
+    ``numba.hip``. Returns None for any other namespace (e.g. JAX, Dask), an
+    unavailable backend, when Numba GPU support is not installed, or when this
+    backend's fused kernel has already failed once in this process (see
+    :func:`_mark_gpu_unavailable`); the caller then takes the array-API path. A
+    CuPy (CUDA) array is never routed to ``numba.hip`` (mixing the two crashes on
+    the array handoff).
+
+    Parameters
+    ----------
+    arr : array
+        A non-NumPy, array-API-compatible buffer (the DistanceMatrix data).
+
+    Returns
+    -------
+    module or None
+        The Numba GPU module usable on this array's device, else None.
+    """
+    name = _get_backend_name(_aac.array_namespace(arr))
+    if name in _unavailable:
+        return None
+    if name == "cupy":
+        want = "cuda"
+    elif name == "torch":
+        import torch
+
+        # torch reports the same namespace for CUDA and ROCm builds; the build's
+        # own hip version tag disambiguates them (ROCm -> numba.hip).
+        want = "hip" if torch.version.hip is not None else "cuda"
+    else:
+        return None
+
+    try:
+        mod = getattr(__import__("numba", fromlist=[want]), want)
+    except Exception:
+        return None
+    try:
+        return mod if mod.is_available() else None
+    except Exception:
+        return None
+
+
+def _mark_gpu_unavailable(arr):
+    """Record that ``arr``'s backend cannot run the fused kernel this process.
+
+    Called by the statistic dispatchers when the fused kernel raises (for example
+    a numba-hip build that fails to compile on the running ROCm stack). Warns once
+    per backend, then routes that backend to the array-API path from then on.
+    """
+    name = _get_backend_name(_aac.array_namespace(arr))
+    if name not in _unavailable:
+        _unavailable.add(name)
+        warn(
+            f"The Numba GPU kernel could not be used for the '{name}' backend on "
+            "this system; using the array-API fallback instead.",
+            UserWarning,
+        )
+
+
+def _get_kernel(cache, builder, gpu, backend_name):
+    """Return the compiled kernel for a Numba GPU module, building it once.
+
+    ``cache`` is a per-statistic dict (backend name -> compiled kernel); ``builder``
+    compiles the kernel for a given Numba GPU module.
+    """
+    if backend_name not in cache:
+        cache[backend_name] = builder(gpu)
+    return cache[backend_name]

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -459,9 +459,9 @@ def mantel(
             # ids exactly like the NumPy path; the reorder/filter stays on the
             # input's device (distmat_reorder is array-API aware).
             x, y = _order_dms(x, y, strict=strict, lookup=lookup)
-            # With engine="numba" and a matching CUDA backend, run the fused GPU
-            # kernel on the device-resident matrices; otherwise take the
-            # backend-agnostic array-API path (also the ROCm-PyTorch fallback).
+            # With engine="numba" and a matching Numba GPU backend, run the fused
+            # GPU kernel on the device-resident matrices; otherwise take the
+            # backend-agnostic array-API path.
             gpu = _numba_gpu_module_for(x.data) if engine == "numba" else None
             if gpu is not None:
                 try:

--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -18,6 +18,8 @@ import scipy.special
 from scipy.stats import kendalltau, ConstantInputWarning, NearConstantInputWarning
 
 from ._cutils import mantel_perm_pearsonr_cy, mantel_perm_pearsonr_condensed_cy
+from ._gpu import _numba_gpu_module_for, _mark_gpu_unavailable
+from ._mantel_gpu import _run_mantel_gpu
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
 from skbio.util._array import ingest_array, _get_array
@@ -457,6 +459,20 @@ def mantel(
             # ids exactly like the NumPy path; the reorder/filter stays on the
             # input's device (distmat_reorder is array-API aware).
             x, y = _order_dms(x, y, strict=strict, lookup=lookup)
+            # With engine="numba" and a matching CUDA backend, run the fused GPU
+            # kernel on the device-resident matrices; otherwise take the
+            # backend-agnostic array-API path (also the ROCm-PyTorch fallback).
+            gpu = _numba_gpu_module_for(x.data) if engine == "numba" else None
+            if gpu is not None:
+                try:
+                    return _run_mantel_gpu(
+                        gpu, x.data, y.data, permutations, rng, alternative,
+                        spearman=(method == "spearman"),
+                    )
+                except Exception:
+                    # The fused kernel could not build/run on this stack; record
+                    # it and fall back to the array-API path (correct anywhere).
+                    _mark_gpu_unavailable(x.data)
             return _mantel_stats_pearson_xp(
                 x.data, y.data, permutations, rng, alternative,
                 spearman=(method == "spearman"),

--- a/skbio/stats/distance/_mantel_gpu.py
+++ b/skbio/stats/distance/_mantel_gpu.py
@@ -48,7 +48,9 @@ def _build_kernel(gpu):
         # Each thread sums the contribution of a strided subset of rows; the row's
         # upper-triangle entries pair the (permuted) x value with the fixed y value
         # at the matching condensed index, normalized on the fly via mul/add.
-        acc = 0.0
+        # Only the accumulator is float64; the per-element products stay in the
+        # matrix dtype (float32 on consumer GPUs, whose fp64 throughput is poor).
+        acc = nb_f64(0.0)
         row = t
         while row < n_dims - 1:
             vrow = perm_order[p, row]
@@ -58,7 +60,7 @@ def _build_kernel(gpu):
             while col < n_dims:
                 vcol = perm_order[p, col]
                 y = ym_norm[row_start + icol]
-                x = nb_f64(mat[vrow, vcol]) * mul + add
+                x = mat[vrow, vcol] * mul + add
                 acc += y * x
                 col += 1
                 icol += 1
@@ -177,6 +179,11 @@ def _run_mantel_gpu(gpu, x, y, permutations, rng, alternative, spearman=False):
 
     mul = 1.0 / normxm
     add = -xmean / normxm
+    # Keep the kernel's per-element math in the matrix dtype (float32 on consumer
+    # GPUs); only its accumulator is float64. Match the scalars and y to Xsrc.
+    if Xsrc.dtype == xp.float32:
+        mul, add = np.float32(mul), np.float32(add)
+        ym_norm = xp.astype(ym_norm, xp.float32)
     perm_order = _perm_order(n, permutations, rng)
 
     kernel = _get_kernel(_kernels, _build_kernel, gpu, _get_backend_name(xp))

--- a/skbio/stats/distance/_mantel_gpu.py
+++ b/skbio/stats/distance/_mantel_gpu.py
@@ -1,0 +1,202 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+"""Mantel GPU backend: a fused single-source Numba CUDA/HIP kernel.
+
+Analogous to the PERMANOVA GPU backend: it is taken when both distance matrices
+are resident on a matching GPU device and ``engine="numba"`` is requested (CuPy /
+CUDA-PyTorch compile through ``numba.cuda``, ROCm-PyTorch through ``numba.hip``).
+One thread block per permutation walks the upper triangle and accumulates the
+permuted Pearson correlation, reducing across the block in shared memory. The
+statistic and p-value are assembled on the host in the same RNG order as the
+NumPy and array-API paths, so the result is identical to the cython, numba and
+xp engines. Spearman uses the same kernel on rank-transformed matrices.
+
+If the fused kernel cannot build or run on the current stack (see :mod:`._gpu`,
+notably the AMD/ROCm init-order case), the caller catches it and falls back to
+the array-API GPU path. NVIDIA is unaffected.
+"""
+
+import numpy as np
+
+from warnings import warn
+
+from scipy.stats import ConstantInputWarning, NearConstantInputWarning
+
+from skbio.util._array import _get_backend_name
+from ._gpu import _TPB, _get_kernel
+
+_kernels = {}  # backend name -> compiled kernel (built on first use)
+
+
+def _build_kernel(gpu):
+    """Compile the permuted-Pearson kernel for ``gpu`` (a Numba GPU module)."""
+    from numba import float64 as nb_f64
+
+    @gpu.jit
+    def _mantel_r(n_dims, mat, perm_order, ym_norm, mul, add, out):
+        p = gpu.blockIdx.x              # one block per permutation
+        t = gpu.threadIdx.x
+        tile = gpu.blockDim.x           # == _TPB
+        acc_arr = gpu.shared.array(_TPB, nb_f64)
+
+        # Each thread sums the contribution of a strided subset of rows; the row's
+        # upper-triangle entries pair the (permuted) x value with the fixed y value
+        # at the matching condensed index, normalized on the fly via mul/add.
+        acc = 0.0
+        row = t
+        while row < n_dims - 1:
+            vrow = perm_order[p, row]
+            row_start = row * (n_dims - 1) - ((row - 1) * row) // 2
+            icol = 0
+            col = row + 1
+            while col < n_dims:
+                vcol = perm_order[p, col]
+                y = ym_norm[row_start + icol]
+                x = nb_f64(mat[vrow, vcol]) * mul + add
+                acc += y * x
+                col += 1
+                icol += 1
+            row += tile
+
+        # shared-memory tree reduction of acc across the block (128 -> 32 -> 8 -> 1)
+        acc_arr[t] = acc
+        gpu.syncthreads()
+        if t < 32:
+            s = 0.0
+            k = t
+            while k < tile:
+                s += acc_arr[k]
+                k += 32
+            acc_arr[t] = s
+        gpu.syncthreads()
+        if t < 8:
+            s = 0.0
+            k = t
+            while k < 32:
+                s += acc_arr[k]
+                k += 8
+            acc_arr[t] = s
+        gpu.syncthreads()
+        if t == 0:
+            s = 0.0
+            for k in range(8):
+                s += acc_arr[k]
+            if s > 1.0:
+                s = 1.0
+            elif s < -1.0:
+                s = -1.0
+            out[p] = s
+
+    return _mantel_r
+
+
+def _perm_order(n, permutations, rng):
+    """Identity permutation followed by ``permutations`` permutations of range(n).
+
+    Consumes ``rng`` in the same order as ``_mantel_stats_pearson_flat`` and
+    ``_mantel_stats_pearson_xp`` (identity first, then ``permutations`` calls to
+    ``rng.permutation(n)``), so the p-value matches the other engines exactly.
+    """
+    out = np.empty((permutations + 1, n), dtype=np.int64)
+    out[0] = np.arange(n)
+    for r in range(1, permutations + 1):
+        out[r] = rng.permutation(n)
+    return out
+
+
+def _run_mantel_gpu(gpu, x, y, permutations, rng, alternative, spearman=False):
+    """Run the Mantel pearson/spearman test with the fused GPU kernel.
+
+    Mirrors :func:`._mantel._mantel_stats_pearson_xp`'s preprocessing (upper
+    triangle, normalization, optional rank transform) but replaces the
+    per-permutation array-API loop with the fused kernel on the device-resident
+    matrices. ``gpu`` is the Numba module from :func:`._gpu._numba_gpu_module_for`.
+    Returns ``(orig_stat, p_value, n)`` to match :func:`._mantel.mantel`.
+    """
+    # Lazy import avoids a circular import (``_mantel`` imports this module).
+    from ._mantel import _upper_tri_xp, _xp_rank_average, _device
+    from skbio.util._array import ingest_array, _get_array
+
+    xp, X, Y = ingest_array(x, y)
+    if X.shape != Y.shape:
+        raise ValueError("Distance matrices must have the same shape.")
+    if (X.ndim != 2) or (X.shape[0] != X.shape[1]):
+        raise ValueError("Distance matrix must be a square 2-D array.")
+    n = X.shape[0]
+    if n < 3:
+        raise ValueError(
+            "Distance matrices must have at least 3 matching IDs "
+            "between them (i.e., minimum 3x3 in size)."
+        )
+
+    iu0, iu1 = _upper_tri_xp(xp, n, device=_device(X))
+    x_flat = X[iu0, iu1]
+    y_flat = Y[iu0, iu1]
+
+    if spearman:
+        x_flat = _xp_rank_average(xp, x_flat)
+        y_flat = _xp_rank_average(xp, y_flat)
+        # rebuild the ranked symmetric matrix so the kernel can gather permuted
+        # pairs from it (one-time host assembly, as in the array-API path).
+        xr = _get_array(x_flat, to_numpy=True)
+        i0, j0 = _get_array(iu0, to_numpy=True), _get_array(iu1, to_numpy=True)
+        full = np.zeros((n, n), dtype=np.float64)
+        full[i0, j0] = xr
+        full[j0, i0] = xr
+        Xsrc = xp.asarray(full, device=_device(X))
+    else:
+        Xsrc = X
+
+    # constant input -> correlation undefined (matches scipy/skbio behavior)
+    if bool(xp.all(x_flat == x_flat[0])) or bool(xp.all(y_flat == y_flat[0])):
+        warn(ConstantInputWarning())
+        return np.nan, np.nan, n
+
+    xmean = float(xp.mean(x_flat))
+    normxm = float(xp.sqrt(xp.sum((x_flat - xmean) ** 2)))
+    ymean = float(xp.mean(y_flat))
+    normym = float(xp.sqrt(xp.sum((y_flat - ymean) ** 2)))
+    ym_norm = (y_flat - ymean) / normym
+
+    # near-constant input -> loss of precision in r (matches the NumPy path)
+    threshold = 1e-13
+    if (normxm < threshold * abs(xmean)) or (normym < threshold * abs(ymean)):
+        warn(NearConstantInputWarning())
+
+    orig_stat = float(xp.sum(((x_flat - xmean) / normxm) * ym_norm))
+    orig_stat = max(min(orig_stat, 1.0), -1.0)
+
+    if permutations == 0 or np.isnan(orig_stat):
+        return orig_stat, np.nan, n
+
+    mul = 1.0 / normxm
+    add = -xmean / normxm
+    perm_order = _perm_order(n, permutations, rng)
+
+    kernel = _get_kernel(_kernels, _build_kernel, gpu, _get_backend_name(xp))
+    d_perm = gpu.to_device(perm_order)
+    d_out = gpu.device_array(permutations + 1, dtype=np.float64)
+    # Xsrc and ym_norm are already on the device; the kernel reads them in place
+    # via their __cuda_array_interface__ (no host round-trip).
+    kernel[permutations + 1, _TPB](n, Xsrc, d_perm, ym_norm, mul, add, d_out)
+    gpu.synchronize()
+
+    stats = d_out.copy_to_host()
+    comp_stat = stats[0]        # identity permutation, matches perm_order[0]
+    permuted_stats = stats[1:]
+
+    if alternative == "two-sided":
+        count_better = (np.absolute(permuted_stats) >= np.absolute(comp_stat)).sum()
+    elif alternative == "greater":
+        count_better = (permuted_stats >= comp_stat).sum()
+    else:
+        count_better = (permuted_stats <= comp_stat).sum()
+    p_value = (count_better + 1) / (permutations + 1)
+
+    return orig_stat, p_value, n

--- a/skbio/stats/distance/_mantel_gpu.py
+++ b/skbio/stats/distance/_mantel_gpu.py
@@ -9,8 +9,9 @@
 """Mantel GPU backend: a fused single-source Numba CUDA/HIP kernel.
 
 Analogous to the PERMANOVA GPU backend: it is taken when both distance matrices
-are resident on a matching GPU device and ``engine="numba"`` is requested (CuPy /
-CUDA-PyTorch compile through ``numba.cuda``, ROCm-PyTorch through ``numba.hip``).
+are resident on a matching GPU device and ``engine="numba"`` is requested (CUDA
+CuPy / PyTorch compile through ``numba.cuda``, ROCm CuPy / PyTorch through
+``numba.hip``).
 One thread block per permutation walks the upper triangle and accumulates the
 permuted Pearson correlation, reducing across the block in shared memory. The
 statistic and p-value are assembled on the host in the same RNG order as the

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -457,10 +457,10 @@ def permanova(
         and requires Numba to be installed. If not provided, the global
         default is used (see :func:`skbio.set_config`). When ``"numba"`` is
         selected, the optional scikit-bio-binaries acceleration is not used.
-        When the distance matrix is resident on a CUDA device (e.g. a CuPy- or
-        CUDA-PyTorch-backed matrix) and ``engine="numba"``, a fused GPU kernel
-        is used. Matrices on other backends, and ROCm-PyTorch matrices (see
-        Notes), use the array-API path instead.
+        When the distance matrix is resident on a CuPy- or PyTorch-backed GPU
+        (CUDA or ROCm) and ``engine="numba"``, a fused GPU kernel is used;
+        matrices on other backends use the array-API path instead (see Notes for
+        the ROCm-PyTorch case).
 
     Returns
     -------
@@ -484,10 +484,11 @@ def permanova(
     :install:`scikit-bio-binaries <#acceleration>` for more information.
 
     On a GPU-resident distance matrix with ``engine="numba"``, a fused GPU kernel
-    is used on CUDA devices. It is not used for ROCm-PyTorch matrices: a Numba HIP
-    kernel cannot be compiled once ROCm-PyTorch has been imported in the same
-    process, so such matrices fall back to the array-API path, which runs on the
-    device regardless. The result is identical across all paths.
+    runs on CuPy or PyTorch matrices, on both CUDA and ROCm devices. The exception
+    is ROCm PyTorch on stacks where a Numba HIP kernel cannot be compiled after
+    ROCm PyTorch has been imported in the same process; those matrices fall back
+    to the array-API path, which runs on the device regardless. The result is
+    identical across all paths.
 
     See [1]_ for the original method reference, as well as ``vegan::adonis``,
     available in R's vegan package [2]_.

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -22,6 +22,8 @@ from ._base import (
     DistanceMatrix,
 )
 from ._cutils import permanova_f_stat_sW_cy, permanova_f_stat_sW_condensed_cy
+from ._gpu import _mark_gpu_unavailable
+from ._permanova_gpu import _numba_gpu_module_for, _run_permanova_gpu
 from skbio.binaries import (
     permanova_available as _skbb_permanova_available,
     permanova as _skbb_permanova,
@@ -453,7 +455,11 @@ def permanova(
         Compute engine to use. ``"cython"`` (default) uses the Cython
         implementation. ``"numba"`` uses the optional Numba implementation
         and requires Numba to be installed. If not provided, the global
-        default is used (see :func:`skbio.set_config`).
+        default is used (see :func:`skbio.set_config`). When the distance
+        matrix is resident on a CUDA device (e.g. a CuPy- or CUDA-PyTorch-backed
+        matrix) and ``engine="numba"``, a fused GPU kernel is used. Matrices on
+        other backends, and ROCm-PyTorch matrices (see Notes), use the
+        array-API path instead.
 
     Returns
     -------
@@ -475,6 +481,12 @@ def permanova(
 
     Low-level acceleration is available for this function. See
     :install:`scikit-bio-binaries <#acceleration>` for more information.
+
+    On a GPU-resident distance matrix with ``engine="numba"``, a fused GPU kernel
+    is used on CUDA devices. It is not used for ROCm-PyTorch matrices: a Numba HIP
+    kernel cannot be compiled once ROCm-PyTorch has been imported in the same
+    process, so such matrices fall back to the array-API path, which runs on the
+    device regardless. The result is identical across all paths.
 
     See [1]_ for the original method reference, as well as ``vegan::adonis``,
     available in R's vegan package [2]_.
@@ -521,10 +533,25 @@ def permanova(
     if not isinstance(distmat, DistanceMatrix):
         raise TypeError("Input must be a DistanceMatrix.")
 
-    # A DistanceMatrix backed by a non-NumPy (e.g. GPU-resident) buffer is
-    # dispatched to the backend-agnostic xp path; a NumPy-backed DM keeps the
-    # existing Cython/Numba engine path below.
+    engine = _resolve_engine(engine, ("cython", "numba"))
+
+    # A DistanceMatrix backed by a non-NumPy (e.g. GPU-resident) buffer: with
+    # engine="numba" and a matching Numba GPU backend it runs the fused GPU
+    # kernel on the device-resident matrix; otherwise it takes the backend-
+    # agnostic xp path. A NumPy-backed DM keeps the Cython/Numba engine path.
     if not _aac.is_numpy_array(distmat.data):
+        gpu = _numba_gpu_module_for(distmat.data) if engine == "numba" else None
+        if gpu is not None:
+            try:
+                return _run_permanova_gpu(
+                    gpu, distmat.data, grouping, column, permutations, seed,
+                    ids=distmat.ids,
+                )
+            except Exception:
+                # The fused kernel could not build/run on this stack (e.g. a
+                # numba-hip build that fails to compile); record it and fall
+                # back to the array-API path, which is correct on any backend.
+                _mark_gpu_unavailable(distmat.data)
         return _permanova_array_api(
             distmat.data, grouping, column, permutations, seed, ids=distmat.ids
         )
@@ -534,8 +561,6 @@ def permanova(
     num_groups, grouping = _preprocess_input_sng(
         distmat.ids, sample_size, grouping, column
     )
-
-    engine = _resolve_engine(engine, ("cython", "numba"))
 
     if _skbb_permanova_available(
         distmat, grouping, permutations, seed

--- a/skbio/stats/distance/_permanova_gpu.py
+++ b/skbio/stats/distance/_permanova_gpu.py
@@ -1,0 +1,177 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2013--, scikit-bio development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+"""PERMANOVA GPU backend: a fused single-source Numba CUDA/HIP kernel.
+
+This is the fast path taken when a DistanceMatrix is already on a GPU device and
+``engine="numba"`` is requested: the same source compiles through ``numba.cuda``
+on NVIDIA and ``numba.hip`` on AMD, and the kernel reads the device-resident
+matrix in place (no host round-trip). It follows the coalesced design of
+scikit-bio-binaries (``pmn_f_stat_sW_cuda_one``): one block per permutation,
+threads walk the columns so global reads are coalesced, group labels cached in
+shared memory, s_W reduced in shared memory.
+
+Correctness-first stays the rule: this backend runs only when the device maps to
+an available Numba GPU module (CuPy / CUDA-PyTorch -> ``numba.cuda``, ROCm-PyTorch
+-> ``numba.hip``). If the fused kernel cannot build or run on the current stack,
+the caller catches it, marks the backend, and keeps the vendor-neutral xp path.
+Permutations are drawn on the host in the same RNG order as the CPU Monte-Carlo
+path, so the p-value is identical to the cython, numba and xp engines.
+
+On AMD/ROCm the numba-hip kernel and torch-ROCm can conflict at kernel-compile
+time on some stacks (an AMD init-order issue). Where they do, the kernel launch
+raises and the matrix falls back to the array-API path; where the stack supports
+both, the kernel runs in place. NVIDIA is unaffected.
+"""
+
+import numpy as np
+
+from skbio.util import get_rng
+from skbio.util._array import _get_backend_name
+from ._gpu import _TPB, _numba_gpu_module_for, _get_kernel
+
+_kernels = {}  # backend name -> compiled kernel (built on first use)
+
+
+def _build_kernel(gpu):
+    """Compile the within-group sum-of-squares kernel for ``gpu`` (cuda or hip)."""
+    from numba import float64 as nb_f64, int64 as nb_i64
+
+    @gpu.jit
+    def _pmn_sW(n_dims, mat, groupings, inv_gs, out_sW):
+        gel = gpu.blockIdx.x            # one block per permutation
+        icol = gpu.threadIdx.x
+        tile = gpu.blockDim.x           # == _TPB
+        s_W_arr = gpu.shared.array(_TPB, nb_f64)
+        row_grouping = gpu.shared.array(_TPB, nb_i64)
+
+        s_W = 0.0
+        trow = 0
+        while trow < n_dims - 1:
+            tcol = trow + 1
+            while tcol < n_dims:
+                max_row = min(trow + tile, n_dims - 1)
+                max_col = min(tcol + tile, n_dims)
+                gpu.syncthreads()
+                rc = trow + icol
+                if rc < max_row:
+                    row_grouping[icol] = groupings[gel, rc]
+                gpu.syncthreads()
+
+                local = 0.0
+                row = trow
+                while row < max_row:
+                    min_col = max(tcol, row + 1)
+                    gidx = row_grouping[row - trow]
+                    col = min_col + icol      # thread -> column: coalesced read
+                    if col < max_col:
+                        if groupings[gel, col] == gidx:
+                            v = nb_f64(mat[row, col])
+                            local += v * v * inv_gs[gidx]
+                    row += 1
+                s_W += local
+                tcol += tile
+            trow += tile
+
+        # shared-memory tree reduction of s_W across the block (128 -> 32 -> 8 -> 1)
+        s_W_arr[icol] = s_W
+        gpu.syncthreads()
+        if icol < 32:
+            acc = 0.0
+            t = icol
+            while t < tile:
+                acc += s_W_arr[t]
+                t += 32
+            s_W_arr[icol] = acc
+        gpu.syncthreads()
+        if icol < 8:
+            acc = 0.0
+            t = icol
+            while t < 32:
+                acc += s_W_arr[t]
+                t += 8
+            s_W_arr[icol] = acc
+        gpu.syncthreads()
+        if icol == 0:
+            acc = 0.0
+            for t in range(8):
+                acc += s_W_arr[t]
+            out_sW[gel] = acc
+
+    return _pmn_sW
+
+
+def _permutation_batch(grouping, permutations, seed):
+    """The observed grouping followed by ``permutations`` permutations of it.
+
+    Uses ``get_rng(seed)`` and ``rng.permutation`` in the same order as the CPU
+    Monte-Carlo driver (``_run_monte_carlo_stats``), so p-values match exactly.
+    """
+    rng = get_rng(seed)
+    out = np.empty((permutations + 1, grouping.shape[0]), dtype=np.int64)
+    out[0] = grouping
+    for i in range(permutations):
+        out[i + 1] = rng.permutation(grouping)
+    return out
+
+
+def _assemble_fp(s_W, s_T, sample_size, num_groups, permutations):
+    """Pseudo-F and Monte Carlo p-value from the per-permutation ``s_W``.
+
+    ``s_W[0]`` is the observed grouping; ``s_W[1:]`` the permutations. Pure NumPy
+    (no GPU), so the assembly and p-value formula are covered by ordinary CI and
+    match the cython/numba/xp result.
+    """
+    n, ng = sample_size, num_groups
+    f = ((s_T - s_W) / (ng - 1)) / (s_W / (n - ng))
+    obs = float(f[0])
+    if permutations > 0:
+        p_value = ((f[1:] >= f[0]).sum() + 1) / (permutations + 1)
+    else:
+        p_value = np.nan
+    return obs, float(p_value)
+
+
+def _run_permanova_gpu(gpu, distmat, grouping, column, permutations, seed, ids=None):
+    """Run PERMANOVA with the fused GPU kernel on a device-resident matrix.
+
+    Mirrors :func:`_permanova_array_api`'s preprocessing (same ``ids`` alignment
+    and ``s_T``), then runs the fused kernel on the on-device matrix instead of
+    the per-permutation array-API loop. ``gpu`` is the Numba module returned by
+    :func:`_numba_gpu_module_for`.
+    """
+    from ._base import _preprocess_input_sng, _build_results
+    from skbio.util._array import ingest_array
+
+    xp, dm = ingest_array(distmat)
+    sample_size = dm.shape[0]
+    num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
+
+    group_sizes = np.bincount(grouping)
+    inv_gs = (1.0 / group_sizes).astype(np.float64)
+    # full 2-D matrix (array-API input is never condensed); halve to count each
+    # unordered pair once, matching the DistanceMatrix full-matrix path.
+    s_T = float(xp.sum(dm * dm, dtype=xp.float64) / sample_size / 2.0)
+
+    groupings = _permutation_batch(grouping, permutations, seed)
+
+    kernel = _get_kernel(_kernels, _build_kernel, gpu, _get_backend_name(xp))
+    d_grp = gpu.to_device(groupings)
+    d_inv = gpu.to_device(inv_gs)
+    d_out = gpu.device_array(permutations + 1, dtype=np.float64)
+    # dm is already on the device; the kernel reads it in place via the array's
+    # __cuda_array_interface__ (no host round-trip).
+    kernel[permutations + 1, _TPB](sample_size, dm, d_grp, d_inv, d_out)
+    gpu.synchronize()
+
+    stat, p_value = _assemble_fp(
+        d_out.copy_to_host(), s_T, sample_size, num_groups, permutations
+    )
+    return _build_results(
+        "PERMANOVA", "pseudo-F", sample_size, num_groups, stat, p_value, permutations
+    )

--- a/skbio/stats/distance/_permanova_gpu.py
+++ b/skbio/stats/distance/_permanova_gpu.py
@@ -17,8 +17,8 @@ threads walk the columns so global reads are coalesced, group labels cached in
 shared memory, s_W reduced in shared memory.
 
 Correctness-first stays the rule: this backend runs only when the device maps to
-an available Numba GPU module (CuPy / CUDA-PyTorch -> ``numba.cuda``, ROCm-PyTorch
--> ``numba.hip``). If the fused kernel cannot build or run on the current stack,
+an available Numba GPU module (CUDA CuPy / PyTorch -> ``numba.cuda``, ROCm CuPy /
+PyTorch -> ``numba.hip``). If the fused kernel cannot build or run on the current stack,
 the caller catches it, marks the backend, and keeps the vendor-neutral xp path.
 Permutations are drawn on the host in the same RNG order as the CPU Monte-Carlo
 path, so the p-value is identical to the cython, numba and xp engines.

--- a/skbio/stats/distance/_permanova_gpu.py
+++ b/skbio/stats/distance/_permanova_gpu.py
@@ -50,7 +50,9 @@ def _build_kernel(gpu):
         s_W_arr = gpu.shared.array(_TPB, nb_f64)
         row_grouping = gpu.shared.array(_TPB, nb_i64)
 
-        s_W = 0.0
+        # Only the accumulators are float64; the per-element products stay in the
+        # matrix dtype (float32 on consumer GPUs, whose fp64 throughput is poor).
+        s_W = nb_f64(0.0)
         trow = 0
         while trow < n_dims - 1:
             tcol = trow + 1
@@ -63,7 +65,7 @@ def _build_kernel(gpu):
                     row_grouping[icol] = groupings[gel, rc]
                 gpu.syncthreads()
 
-                local = 0.0
+                local = nb_f64(0.0)
                 row = trow
                 while row < max_row:
                     min_col = max(tcol, row + 1)
@@ -71,7 +73,7 @@ def _build_kernel(gpu):
                     col = min_col + icol      # thread -> column: coalesced read
                     if col < max_col:
                         if groupings[gel, col] == gidx:
-                            v = nb_f64(mat[row, col])
+                            v = mat[row, col]
                             local += v * v * inv_gs[gidx]
                     row += 1
                 s_W += local
@@ -153,7 +155,10 @@ def _run_permanova_gpu(gpu, distmat, grouping, column, permutations, seed, ids=N
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 
     group_sizes = np.bincount(grouping)
-    inv_gs = (1.0 / group_sizes).astype(np.float64)
+    # Match the matrix dtype so the kernel's per-element math stays in that
+    # precision (float32 on consumer GPUs); the kernel accumulates in float64.
+    elem_dtype = np.float32 if dm.dtype == xp.float32 else np.float64
+    inv_gs = (1.0 / group_sizes).astype(elem_dtype)
     # full 2-D matrix (array-API input is never condensed); halve to count each
     # unordered pair once, matching the DistanceMatrix full-matrix path.
     s_T = float(xp.sum(dm * dm, dtype=xp.float64) / sample_size / 2.0)

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from unittest import TestCase, main, mock
+from unittest import TestCase, main
 
 import numpy as np
 import numpy.testing as npt
@@ -1406,33 +1406,6 @@ class MantelGpuHostTests(TestCase):
                                  permutations=perms, seed=0, engine="cython")
         self.assertAlmostEqual(comp_stat, r_ref, places=10)
         self.assertEqual(p_value, p_ref)
-
-    @numba_code
-    def test_gpu_dispatch_falls_back_when_kernel_raises(self):
-        # Two non-NumPy DMs on the same backend whose fused kernel raises must
-        # record the backend and fall back to the array-API path, matching cython.
-        from skbio.stats.distance import _gpu as gpu_mod
-
-        gpu_mod._unavailable.discard("torch")
-        try:
-            with mock.patch.object(mantel_mod._aac, "is_numpy_array",
-                                   return_value=False), \
-                    mock.patch.object(mantel_mod, "_numba_gpu_module_for",
-                                      return_value=object()), \
-                    mock.patch.object(
-                        mantel_mod, "_run_mantel_gpu",
-                        side_effect=RuntimeError("kernel build failed")), \
-                    mock.patch.object(mantel_mod,
-                                      "_mark_gpu_unavailable") as mark:
-                r_obs, p_obs, _ = mantel(self.x, self.y, method="pearson",
-                                         permutations=99, seed=0, engine="numba")
-            r_ref, p_ref, _ = mantel(self.x, self.y, method="pearson",
-                                     permutations=99, seed=0, engine="cython")
-            self.assertAlmostEqual(r_obs, r_ref, places=6)
-            self.assertEqual(p_obs, p_ref)
-            mark.assert_called_once()
-        finally:
-            gpu_mod._unavailable.discard("torch")
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from unittest import TestCase, main
+from unittest import TestCase, main, mock
 
 import numpy as np
 import numpy.testing as npt
@@ -23,6 +23,7 @@ from skbio.stats.distance import _mantel as mantel_mod
 from skbio.stats.distance._mantel import _order_dms
 from skbio.stats.distance._mantel import _mantel_stats_pearson
 from skbio.stats.distance._mantel import _mantel_stats_spearman
+from skbio.stats.distance._mantel_gpu import _perm_order
 from skbio.stats.distance._cutils import (mantel_perm_pearsonr_cy,
                                           mantel_perm_pearsonr_condensed_cy)
 from skbio.stats.distance._utils import distmat_reorder_condensed
@@ -1337,6 +1338,101 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
             r, p, _ = mantel_mod._mantel_stats_pearson_xp(
                 const, self.x[:5, :5], 0, get_rng(0), "two-sided")
         self.assertTrue(np.isnan(r))
+
+
+class MantelGpuHostTests(TestCase):
+    """Host-side logic of the GPU Mantel path, exercised without a GPU.
+
+    The GPU kernel is validated on hardware separately; these cover the pieces
+    that are the same regardless of where the matrix lives: the permutation order
+    follows the CPU/array-API RNG order, and the fused per-permutation Pearson
+    formulation reproduces the cython engine's statistic and p-value.
+    """
+
+    def setUp(self):
+        rng = np.random.default_rng(11)
+        a = rng.random((25, 25))
+        a = (a + a.T) / 2.0
+        np.fill_diagonal(a, 0.0)
+        b = rng.random((25, 25))
+        b = (b + b.T) / 2.0
+        np.fill_diagonal(b, 0.0)
+        self.x = DistanceMatrix(a)
+        self.y = DistanceMatrix(b)
+
+    def test_perm_order_matches_rng(self):
+        # identity first, then permutations drawn with the same rng calls the
+        # cython/xp paths make, so the p-value agrees.
+        n, k = 25, 40
+        order = _perm_order(n, k, get_rng(0))
+        self.assertEqual(order.shape, (k + 1, n))
+        np.testing.assert_array_equal(order[0], np.arange(n))
+        rng = get_rng(0)
+        for r in range(1, k + 1):
+            np.testing.assert_array_equal(order[r], rng.permutation(n))
+
+    def test_kernel_math_matches_cython(self):
+        # Replicate on the host exactly what the GPU kernel computes (permuted,
+        # on-the-fly-normalized Pearson over the upper triangle) and confirm the
+        # assembled statistic and p-value match the cython engine.
+        a, b = self.x.data, self.y.data
+        n = a.shape[0]
+        perms = 99
+        iu0, iu1 = np.triu_indices(n, 1)
+        x_flat, y_flat = a[iu0, iu1], b[iu0, iu1]
+        xmean, ymean = x_flat.mean(), y_flat.mean()
+        normxm = np.linalg.norm(x_flat - xmean)
+        normym = np.linalg.norm(y_flat - ymean)
+        ym_norm = (y_flat - ymean) / normym
+        mul, add = 1.0 / normxm, -xmean / normxm
+
+        order = _perm_order(n, perms, get_rng(0))
+        stats = np.empty(perms + 1)
+        for pi, perm in enumerate(order):
+            s = 0.0
+            for row in range(n - 1):
+                vrow = perm[row]
+                row_start = row * (n - 1) - ((row - 1) * row) // 2
+                for icol in range(n - row - 1):
+                    vcol = perm[icol + row + 1]
+                    s += ym_norm[row_start + icol] * (a[vrow, vcol] * mul + add)
+            stats[pi] = max(min(s, 1.0), -1.0)
+
+        comp_stat, permuted = stats[0], stats[1:]
+        count = (np.absolute(permuted) >= np.absolute(comp_stat)).sum()
+        p_value = (count + 1) / (perms + 1)
+
+        r_ref, p_ref, _ = mantel(self.x, self.y, method="pearson",
+                                 permutations=perms, seed=0, engine="cython")
+        self.assertAlmostEqual(comp_stat, r_ref, places=10)
+        self.assertEqual(p_value, p_ref)
+
+    @numba_code
+    def test_gpu_dispatch_falls_back_when_kernel_raises(self):
+        # Two non-NumPy DMs on the same backend whose fused kernel raises must
+        # record the backend and fall back to the array-API path, matching cython.
+        from skbio.stats.distance import _gpu as gpu_mod
+
+        gpu_mod._unavailable.discard("torch")
+        try:
+            with mock.patch.object(mantel_mod._aac, "is_numpy_array",
+                                   return_value=False), \
+                    mock.patch.object(mantel_mod, "_numba_gpu_module_for",
+                                      return_value=object()), \
+                    mock.patch.object(
+                        mantel_mod, "_run_mantel_gpu",
+                        side_effect=RuntimeError("kernel build failed")), \
+                    mock.patch.object(mantel_mod,
+                                      "_mark_gpu_unavailable") as mark:
+                r_obs, p_obs, _ = mantel(self.x, self.y, method="pearson",
+                                         permutations=99, seed=0, engine="numba")
+            r_ref, p_ref, _ = mantel(self.x, self.y, method="pearson",
+                                     permutations=99, seed=0, engine="cython")
+            self.assertAlmostEqual(r_obs, r_ref, places=6)
+            self.assertEqual(p_obs, p_ref)
+            mark.assert_called_once()
+        finally:
+            gpu_mod._unavailable.discard("torch")
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -619,35 +619,6 @@ class PermanovaGpuHostTests(TestCase):
         self.assertAlmostEqual(f, ref['test statistic'], places=10)
         self.assertEqual(p, ref['p-value'])
 
-    def test_numba_gpu_module_routing(self):
-        # cupy and CUDA-built torch route to numba.cuda; ROCm-built torch routes
-        # to numba.hip (the kernel is offered on AMD, with a runtime fallback if
-        # it cannot build); other namespaces route to None.
-        import sys
-        import types
-
-        fake_cuda = types.SimpleNamespace(is_available=lambda: True)
-        fake_hip = types.SimpleNamespace(is_available=lambda: True)
-        fake_numba = types.SimpleNamespace(cuda=fake_cuda, hip=fake_hip)
-        cases = [
-            ("cupy", None, fake_cuda),
-            ("torch", None, fake_cuda),      # CUDA build (version.hip is None)
-            ("torch", "6.4.1", fake_hip),    # ROCm build -> numba.hip
-            ("jax", None, None),
-        ]
-        for backend, hip_version, expected in cases:
-            gpu_mod._unavailable.discard(backend)
-            torch_stub = types.SimpleNamespace(
-                version=types.SimpleNamespace(hip=hip_version)
-            )
-            with mock.patch.object(gpu_mod, "_get_backend_name",
-                                   return_value=backend), \
-                    mock.patch.object(gpu_mod._aac, "array_namespace",
-                                      return_value=object()), \
-                    mock.patch.dict(sys.modules,
-                                    {"torch": torch_stub, "numba": fake_numba}):
-                self.assertIs(gpu_mod._numba_gpu_module_for(object()), expected)
-
     def test_mark_gpu_unavailable_warns_once_then_routes_none(self):
         # The first failure for a backend warns and records it; later calls are
         # silent and _numba_gpu_module_for returns None for that backend.

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -8,7 +8,7 @@
 
 import io
 from functools import partial
-from unittest import TestCase, main
+from unittest import TestCase, main, mock
 
 import numpy as np
 import pandas as pd
@@ -20,9 +20,11 @@ from skbio.stats.distance import permanova
 from skbio.stats.distance import _permanova as permanova_mod
 from skbio.stats.distance._cutils import (permanova_f_stat_sW_cy,
                                           permanova_f_stat_sW_condensed_cy)
-from skbio.util import get_data_path, numba_code
+from skbio.util import get_data_path, numba_code, get_rng
 from skbio.util._testing import ArrayAPITestMixin, array_backends
 from skbio.stats.distance._base import _preprocess_input_sng
+from skbio.stats.distance import _gpu as gpu_mod
+from skbio.stats.distance._permanova_gpu import _assemble_fp, _permutation_batch
 
 
 class PERMANOVATestData(TestCase):
@@ -567,6 +569,130 @@ class PermanovaArrayAPITests(TestCase, ArrayAPITestMixin):
             res['test statistic'], self.ref['test statistic'], places=10
         )
         self.assertAlmostEqual(res['p-value'], self.ref['p-value'], places=10)
+
+
+class PermanovaGpuHostTests(TestCase):
+    """Host-side helpers of the GPU permanova path, exercised without a GPU.
+
+    These cover the pieces that are the same regardless of how the GPU buffer is
+    obtained: the permutation batch follows the CPU Monte-Carlo RNG order, and the
+    pseudo-F / p-value assembly reproduces the cython engine.
+    """
+
+    def setUp(self):
+        rng = np.random.default_rng(3)
+        a = rng.random((40, 40))
+        a = (a + a.T) / 2.0
+        np.fill_diagonal(a, 0.0)
+        self.dm = DistanceMatrix(a)
+        self.grouping = np.repeat(np.arange(4), 10).astype(str).tolist()
+
+    def test_permutation_batch_matches_cpu_rng_order(self):
+        # observed grouping first, then permutations drawn with get_rng(seed) in
+        # the same order as _run_monte_carlo_stats, so the p-value agrees.
+        n = self.dm.shape[0]
+        _, grouping = _preprocess_input_sng(self.dm.ids, n, self.grouping, None)
+        batch = _permutation_batch(grouping, 50, 0)
+        self.assertEqual(batch.shape, (51, n))
+        np.testing.assert_array_equal(batch[0], grouping)
+        rng = get_rng(0)
+        for i in range(50):
+            np.testing.assert_array_equal(batch[i + 1], rng.permutation(grouping))
+
+    def test_assemble_fp_matches_cython(self):
+        # build s_W on the host exactly as the kernel does (upper triangle,
+        # inverse group-size weight) for the observed grouping and the permutation
+        # batch, then check _assemble_fp reproduces the cython pseudo-F and p-value.
+        dm = self.dm
+        n = dm.shape[0]
+        num_groups, grouping = _preprocess_input_sng(dm.ids, n, self.grouping, None)
+        inv_gs = 1.0 / np.bincount(grouping)
+        s_T = (dm.data ** 2).sum() / n / 2.0
+        i0, j0 = np.triu_indices(n, 1)
+        d2 = dm.data[i0, j0] ** 2
+        batch = _permutation_batch(grouping, 99, 0)
+        s_W = np.array(
+            [(d2 * (g[i0] == g[j0]) * inv_gs[g[i0]]).sum() for g in batch]
+        )
+        f, p = _assemble_fp(s_W, s_T, n, num_groups, 99)
+        ref = permanova(dm, self.grouping, permutations=99, seed=0, engine="cython")
+        self.assertAlmostEqual(f, ref['test statistic'], places=10)
+        self.assertEqual(p, ref['p-value'])
+
+    def test_numba_gpu_module_routing(self):
+        # cupy and CUDA-built torch route to numba.cuda; ROCm-built torch routes
+        # to numba.hip (the kernel is offered on AMD, with a runtime fallback if
+        # it cannot build); other namespaces route to None.
+        import sys
+        import types
+
+        fake_cuda = types.SimpleNamespace(is_available=lambda: True)
+        fake_hip = types.SimpleNamespace(is_available=lambda: True)
+        fake_numba = types.SimpleNamespace(cuda=fake_cuda, hip=fake_hip)
+        cases = [
+            ("cupy", None, fake_cuda),
+            ("torch", None, fake_cuda),      # CUDA build (version.hip is None)
+            ("torch", "6.4.1", fake_hip),    # ROCm build -> numba.hip
+            ("jax", None, None),
+        ]
+        for backend, hip_version, expected in cases:
+            gpu_mod._unavailable.discard(backend)
+            torch_stub = types.SimpleNamespace(
+                version=types.SimpleNamespace(hip=hip_version)
+            )
+            with mock.patch.object(gpu_mod, "_get_backend_name",
+                                   return_value=backend), \
+                    mock.patch.object(gpu_mod._aac, "array_namespace",
+                                      return_value=object()), \
+                    mock.patch.dict(sys.modules,
+                                    {"torch": torch_stub, "numba": fake_numba}):
+                self.assertIs(gpu_mod._numba_gpu_module_for(object()), expected)
+
+    def test_mark_gpu_unavailable_warns_once_then_routes_none(self):
+        # The first failure for a backend warns and records it; later calls are
+        # silent and _numba_gpu_module_for returns None for that backend.
+        import warnings
+
+        gpu_mod._unavailable.discard("torch")
+        try:
+            with mock.patch.object(gpu_mod, "_get_backend_name",
+                                   return_value="torch"), \
+                    mock.patch.object(gpu_mod._aac, "array_namespace",
+                                      return_value=object()):
+                with self.assertWarns(UserWarning):
+                    gpu_mod._mark_gpu_unavailable(object())
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error")
+                    gpu_mod._mark_gpu_unavailable(object())  # must not warn again
+                self.assertIsNone(gpu_mod._numba_gpu_module_for(object()))
+        finally:
+            gpu_mod._unavailable.discard("torch")
+
+    @numba_code
+    def test_gpu_dispatch_falls_back_when_kernel_raises(self):
+        # A non-NumPy DM whose fused kernel raises must record the backend and
+        # return the array-API result, which matches the cython engine.
+        gpu_mod._unavailable.discard("torch")
+        try:
+            with mock.patch.object(permanova_mod._aac, "is_numpy_array",
+                                   return_value=False), \
+                    mock.patch.object(permanova_mod, "_numba_gpu_module_for",
+                                      return_value=object()), \
+                    mock.patch.object(
+                        permanova_mod, "_run_permanova_gpu",
+                        side_effect=RuntimeError("kernel build failed")), \
+                    mock.patch.object(permanova_mod,
+                                      "_mark_gpu_unavailable") as mark:
+                obs = permanova(self.dm, self.grouping, permutations=99,
+                                seed=0, engine="numba")
+            ref = permanova(self.dm, self.grouping, permutations=99,
+                            seed=0, engine="cython")
+            self.assertAlmostEqual(obs['test statistic'],
+                                   ref['test statistic'], places=6)
+            self.assertEqual(obs['p-value'], ref['p-value'])
+            mark.assert_called_once()
+        finally:
+            gpu_mod._unavailable.discard("torch")
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -8,7 +8,7 @@
 
 import io
 from functools import partial
-from unittest import TestCase, main, mock
+from unittest import TestCase, main
 
 import numpy as np
 import pandas as pd
@@ -619,51 +619,22 @@ class PermanovaGpuHostTests(TestCase):
         self.assertAlmostEqual(f, ref['test statistic'], places=10)
         self.assertEqual(p, ref['p-value'])
 
-    def test_mark_gpu_unavailable_warns_once_then_routes_none(self):
+    def test_mark_gpu_unavailable_warns_once(self):
         # The first failure for a backend warns and records it; later calls are
-        # silent and _numba_gpu_module_for returns None for that backend.
+        # silent. Uses a real NumPy array (backend name "numpy"), no patching.
         import warnings
 
-        gpu_mod._unavailable.discard("torch")
+        arr = np.zeros((3, 3))
+        gpu_mod._unavailable.discard("numpy")
         try:
-            with mock.patch.object(gpu_mod, "_get_backend_name",
-                                   return_value="torch"), \
-                    mock.patch.object(gpu_mod._aac, "array_namespace",
-                                      return_value=object()):
-                with self.assertWarns(UserWarning):
-                    gpu_mod._mark_gpu_unavailable(object())
-                with warnings.catch_warnings():
-                    warnings.simplefilter("error")
-                    gpu_mod._mark_gpu_unavailable(object())  # must not warn again
-                self.assertIsNone(gpu_mod._numba_gpu_module_for(object()))
+            with self.assertWarns(UserWarning):
+                gpu_mod._mark_gpu_unavailable(arr)
+            self.assertIn("numpy", gpu_mod._unavailable)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                gpu_mod._mark_gpu_unavailable(arr)  # must not warn again
         finally:
-            gpu_mod._unavailable.discard("torch")
-
-    @numba_code
-    def test_gpu_dispatch_falls_back_when_kernel_raises(self):
-        # A non-NumPy DM whose fused kernel raises must record the backend and
-        # return the array-API result, which matches the cython engine.
-        gpu_mod._unavailable.discard("torch")
-        try:
-            with mock.patch.object(permanova_mod._aac, "is_numpy_array",
-                                   return_value=False), \
-                    mock.patch.object(permanova_mod, "_numba_gpu_module_for",
-                                      return_value=object()), \
-                    mock.patch.object(
-                        permanova_mod, "_run_permanova_gpu",
-                        side_effect=RuntimeError("kernel build failed")), \
-                    mock.patch.object(permanova_mod,
-                                      "_mark_gpu_unavailable") as mark:
-                obs = permanova(self.dm, self.grouping, permutations=99,
-                                seed=0, engine="numba")
-            ref = permanova(self.dm, self.grouping, permutations=99,
-                            seed=0, engine="cython")
-            self.assertAlmostEqual(obs['test statistic'],
-                                   ref['test statistic'], places=6)
-            self.assertEqual(obs['p-value'], ref['p-value'])
-            mark.assert_called_once()
-        finally:
-            gpu_mod._unavailable.discard("torch")
+            gpu_mod._unavailable.discard("numpy")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

I added a fused, single-source Numba GPU backend for `permanova` and `mantel`. The same kernel source compiles through `numba.cuda` on NVIDIA and `numba.hip` on AMD. It runs when `engine="numba"` and the `DistanceMatrix` is already resident on the GPU: the kernel reads the device matrix in place with no host round-trip, and I dispatch on where the matrix lives instead of adding a new engine value. If the kernel cannot build or run on the current stack (for example the ROCm init-order case on some torch-ROCm builds), the call warns once and falls back to the array-API GPU path, which is correct on any array-API backend. I draw the permutations on the host in the same RNG order as the cython, numba, and xp engines, so the p-values match.

This builds on the array-API GPU support (#2503) and the float64 `s_T` fix (#2509), and it sits on top of the binaries engine gate (#2510).

## Correctness

I validated the kernels against the cython and double-precision reference:

- **permanova**: exact p-value parity on the AMD MI210 and MI300X at 1k, 5k, and 25k, including 25k with 9999 permutations, with the pseudo-F matching to about 1e-13. On an NVIDIA RTX 4060 the pseudo-F is within 8.6e-8 of the cython float64 reference at 25k. The kernel reads a float32 matrix but accumulates in float64, so its single-precision result stays close to double precision.
- **mantel**: matches the cython engine and the double-precision reference at 5k, to about 4e-7. I have not run a 25k mantel correctness check yet, so the 25k mantel rows below are timing only.

## Benchmarks

I ran two benchmarks, each on a single machine. The first, on an AMD MI300X, compares the fused kernel to the CPU engines; its cython baseline is built with OpenMP. The second, on an NVIDIA RTX 4060, is the direct same-card comparison against scikit-bio-binaries, the existing GPU accelerator. The two are on different GPUs, so compare within a table, not across.

### AMD Instinct MI300X: the fused kernel vs the CPU engines (seconds)

`permanova`

| n | perms | cython | numba (CPU) | numba-hip (kernel) | xp (array-API) |
|---|---|---|---|---|---|
| 5000 | 999 | 1.28 | 2.05 | **0.045** | 1.58 |
| 5000 | 9999 | 9.81 | 3.16 | **0.22** | 2.24 |
| 25000 | 999 | 43.8 | 5.77 | **1.84** | 3.61 |
| 25000 | 9999 | 426 | 30.0 | **7.29** | 12.5 |

`mantel`

| n | perms | cython | numba (CPU) | numba-hip (kernel) | xp (array-API) |
|---|---|---|---|---|---|
| 5000 | 999 | 3.91 | 5.60 | **0.37** | 1.96 |
| 5000 | 9999 | 36.6 | 44.5 | **5.96** | 8.13 |
| 25000 | 999 | 120 | 138 | **11.2** | 12.98 |
| 25000 | 9999 | 1407 | 1547 | **157** | 161.6 |

The kernel is a large win over the CPU engines. Against the array-API GPU fallback its advantage is largest at small and medium sizes; for mantel it narrows at the largest `n`, where the kernel and the xp path run about even (157 vs 162 s at 25k / 9999).

### NVIDIA RTX 4060: every engine on one card (`permanova`, 999 permutations, seconds)

Here I put all the engines on the same card so they line up directly, including scikit-bio-binaries, the existing GPU accelerator. SKBB accelerates `permanova` and `pcoa_fsvd`, not `mantel`, so there is no SKBB mantel row. I confirmed SKBB's GPU build auto-detects and uses the card, and that its result is correct: the pseudo-F is within 5e-12 of the cython float64 reference at 25k in double precision. cython here is an OpenMP build; both it and numba (CPU) run in float64, while xp, SKBB (fp32), and the kernel run in float32 (the kernel accumulates in float64).

| n | cython | numba (CPU) | xp (array-API) | SKBB GPU (fp32) | SKBB GPU (fp64) | numba-cuda kernel |
|---|---|---|---|---|---|---|
| 1000 | 0.20 | 0.026 | 0.73 | **0.01** | 0.17 | 0.027 |
| 5000 | 3.86 | 0.41 | 4.74 | **0.14** | 0.43 | 0.43 |
| 25000 | 116.8 | 10.37 | OOM (8 GB) | **3.19** | 6.23 | 8.57 |

On this 8 GB consumer card the array-API path runs out of memory at 25k: its `xp` statistic (`_permanova_sW_xp`) materializes several full n-by-n intermediates, two of them (`mask` and `dm*dm`) about 2.5 GB each in float32 at 25k, which together exceed the card. The fused kernel walks the matrix in place with no n-by-n temporary, so it (and SKBB) fit. For permanova here SKBB's C++ is the fastest GPU option (3.2 s fp32, 6.2 s fp64 at 25k), ahead of my kernel (8.6 s), and on this entry-level GPU the kernel leads the CPU engines only modestly. The kernel earns its place elsewhere: it also does `mantel`, which SKBB does not; it is much faster than the CPU engines on the datacenter MI300X above; it is one Python source across NVIDIA and AMD inside the `engine=` dispatch with no separate compiled dependency; and its float64 accumulation keeps the single-precision result within 8.6e-8 of the reference at 25k, where the SKBB fp32 path is at 4.9e-4.

## Tests

Host logic (permutation order, statistic assembly), the dispatch (backend routing, warn-once fallback), and the kernel math against the cython engine. The kernel bodies run on hardware and are gated to the GPU CI.

@sfiligoi
