### PR TITLE
Improved pairwise alignment arithmetic tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
-* Fixed a subtle issue in `pair_align` floating-point arithmetic path. Previous it was less tolerant than anticipated under linear gap penalty. The effect might not be noticed unless the user explicitly sets `atol` to a number smaller than default (1e-5) and scores involve decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
+* Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
 
 ## Version 0.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Bug Fixes
 
-* Fixed `pair_align` raising `TypeError` when called with `atol=None`, a documented valid value equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
+* Fixed a subtle issue in `pair_align` floating-point arithmetic path. Previous it was less tolerant than anticipated under linear gap penalty. The effect might not be noticed unless the user explicitly sets `atol` to a number smaller than default (1e-5) and scores involve decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
+* Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
 
 ## Version 0.7.3
 

--- a/skbio/alignment/_cutils.pyx
+++ b/skbio/alignment/_cutils.pyx
@@ -244,6 +244,8 @@ def _trace_one_linear(
         if local and xabs(score) <= eps:
             break
         pos -= 1
+        # Don't pre-calculate `gap_extend + score`. Otherwise it will not match the
+        # arithmetic order of matrix filling, causing greater floating-point error.
 
         # deletion (vertical; gap in seq2)
         if xabs(scomat[i - 1, j] - gap_extend - score) <= eps:

--- a/skbio/alignment/_cutils.pyx
+++ b/skbio/alignment/_cutils.pyx
@@ -236,22 +236,21 @@ def _trace_one_linear(
        affine gap costs. Bull Math Biol, 48, 603-616.
 
     """
-    cdef floating score, gap_score
+    cdef floating score
 
     # will stop when reaching either edge of the matrix
     while i and j:
         score = scomat[i, j]
         if local and xabs(score) <= eps:
             break
-        gap_score = gap_extend + score
         pos -= 1
 
         # deletion (vertical; gap in seq2)
-        if xabs(scomat[i - 1, j] - gap_score) <= eps:
+        if xabs(scomat[i - 1, j] - gap_extend - score) <= eps:
             path[pos] = 2
             i -= 1
         # insertion (horizontal; gap in seq1)
-        elif xabs(scomat[i, j - 1] - gap_score) <= eps:
+        elif xabs(scomat[i, j - 1] - gap_extend - score) <= eps:
             path[pos] = 1
             j -= 1
         # substitution (diagonal; no gap)

--- a/skbio/alignment/tests/test_pair.py
+++ b/skbio/alignment/tests/test_pair.py
@@ -629,6 +629,19 @@ class PairAlignTests(unittest.TestCase):
         obs = pair_align("AAAA", "TTTT", mode="local", atol=None)
         self.assertEqual(obs.paths, [])
 
+    def test_pair_align_atol_zero(self):
+        """Zero tolerance uses the optimal decimal-score traceback."""
+        obs = pair_align(
+            "AB",
+            "BA",
+            sub_score=(0.1, -0.2),
+            gap_cost=0.2,
+            free_ends=False,
+            atol=0,
+        )
+        self.assertAlmostEqual(obs.score, -0.3)
+        self.assertEqual(obs.paths[0].to_cigar(), "1I1M1D")
+
     def test_pair_align_error(self):
         """Errors."""
         with self.assertRaises(ValueError) as cm:

--- a/skbio/alignment/tests/test_pair.py
+++ b/skbio/alignment/tests/test_pair.py
@@ -610,34 +610,36 @@ class PairAlignTests(unittest.TestCase):
                          gap_cost=(np.nan, np.nan))
         self.assertTrue(np.isnan(obs.score))
 
-    def test_pair_align_atol_none(self):
-        """atol=None is equivalent to atol=0 and must not raise."""
-        for mode in ("global", "local"):
-            for max_paths in (1, 5):
-                obs_none = pair_align(
-                    "ACGT", "ACGA", mode=mode, atol=None, max_paths=max_paths
-                )
-                obs_zero = pair_align(
-                    "ACGT", "ACGA", mode=mode, atol=0, max_paths=max_paths
-                )
-                self.assertEqual(obs_none.score, obs_zero.score)
-                self.assertEqual(len(obs_none.paths), len(obs_zero.paths))
-                for p_none, p_zero in zip(obs_none.paths, obs_zero.paths):
-                    self.assertEqual(p_none.to_cigar(), p_zero.to_cigar())
+    def test_pair_align_atol(self):
+        """Tolerance in score comparison."""
+        # In this case, one valid path is omitted due to float32 rounding when there is
+        # no tolerance. But a reasonable tolerance recovers this path.
+        seqs = ("AA", "AAAAA")
+        kwargs = {
+            "sub_score": (0.1, -0.1),
+            "gap_cost": 0.1,
+            "free_ends": False,
+            "max_paths": None,
+        }
 
-        # local alignment with no similarity: empty path list, no crash
-        obs = pair_align("AAAA", "TTTT", mode="local", atol=None)
-        self.assertEqual(obs.paths, [])
+        def _hitall(atol):
+            res = pair_align(*seqs, atol=atol, **kwargs)
+            obs = [path.to_cigar() for path in res.paths]
+            return "3I2M" in obs
 
-    def test_pair_align_atol_zero(self):
-        """Zero tolerance uses the optimal decimal-score traceback."""
+        self.assertTrue(_hitall(atol=1e-5))
+        self.assertTrue(_hitall(atol=1e-7))
+        self.assertFalse(_hitall(atol=1e-8))
+        self.assertFalse(_hitall(atol=0))
+
+        # atol=None is equivalent to atol=0 and won't raise.
+        self.assertFalse(_hitall(atol=None))
+
+        # This case is tricky and it fixed a subtle issue before #2513, which made
+        # the code less tolerant caused by equivalent mathematics but discrepant
+        # arithmetic paths in matrix filling vs trackback.
         obs = pair_align(
-            "AB",
-            "BA",
-            sub_score=(0.1, -0.2),
-            gap_cost=0.2,
-            free_ends=False,
-            atol=0,
+            "AB", "BA", sub_score=(0.1, -0.2), gap_cost=0.2, free_ends=False, atol=0
         )
         self.assertAlmostEqual(obs.score, -0.3)
         self.assertEqual(obs.paths[0].to_cigar(), "1I1M1D")

--- a/skbio/alignment/tests/test_pair.py
+++ b/skbio/alignment/tests/test_pair.py
@@ -570,7 +570,7 @@ class PairAlignTests(unittest.TestCase):
 
         # Make sure path length is always <= sum of sequence lengths. The maximum
         # happens when all characters are misaligned. This check is to make sure
-        # the pre-allocation of path in the trackback functions does not lead to
+        # the pre-allocation of path in the traceback functions does not lead to
         # overflow.
         seq1, seq2 = "AAAAA", "TTTTT"
         obs = pair_align(seq1, seq2).paths[0]
@@ -637,7 +637,7 @@ class PairAlignTests(unittest.TestCase):
 
         # This case is tricky and it fixed a subtle issue before #2513, which made
         # the code less tolerant caused by equivalent mathematics but discrepant
-        # arithmetic paths in matrix filling vs trackback.
+        # arithmetic paths in matrix filling vs traceback.
         obs = pair_align(
             "AB", "BA", sub_score=(0.1, -0.2), gap_cost=0.2, free_ends=False, atol=0
         )


### PR DESCRIPTION
This PR follows #2504. It was noticed that for pairwise sequence alignment under linear gap penalty, the arithmetic path of matrix filling and that of traceback are mathematically equivalent, but arithmetically non-identical in a subtle way, causing the arithmetic error greater than expected. This issue probably does't have any impact in typical use cases (scores are integers, `atol` is default). But it will emerge in the following extreme case:

```python
>>> kwargs = {
...     "sub_score": (0.1, -0.2),
...     "gap_cost": 0.2,
...     "free_ends": False,
... }
>>> obs = pair_align("AB", "BA", atol=0, **kwargs)
>>> assert np.isclose(obs.score, -0.3)
>>> assert obs.paths[0].to_cigar() == "2M"
```

This PR fixes this issue. Additionally, it adds a unit test to demonstrate a realistic case where the value of `atol` matters in retaining all correct alignment paths.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
