### PR TITLE
ENH: make the DM class family fully device-resident

### DIFF
--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -142,7 +142,17 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         # convert data to redundant if 1D input.
         # should do this for PairwiseMatrix only.
         if data.ndim == 1:
-            data = squareform(data, force="tomatrix", checks=False)
+            if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+                # A condensed vector is inherently a symmetric-matrix
+                # representation; scipy's squareform has no array-API path, so
+                # expand it via a single host round-trip and place the result
+                # back on the input's device.
+                xp = _aac.array_namespace(data)
+                dev = getattr(data, "device", None)
+                mat_np = squareform(_to_numpy(data), force="tomatrix", checks=False)
+                data = xp.asarray(mat_np, device=dev)
+            else:
+                data = squareform(data, force="tomatrix", checks=False)
 
         if ids is None:
             ids = self._generate_ids(data)
@@ -184,6 +194,18 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         # np.asarray to situations where the data are (a) not already a numpy
         # array or (b) the data are not a single or double precision numpy
         # data type.
+        if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+            # Preserve a non-NumPy (e.g. GPU-resident) array-API buffer so the
+            # PairwiseMatrix can hold GPU data. NumPy / list / tuple inputs are
+            # still normalized to a NumPy array below. A non-floating buffer is
+            # cast to float64, mirroring the NumPy path (which keeps float32/64
+            # and casts everything else to float).
+            _xp, data = ingest_array(data)
+            if not _xp.isdtype(data.dtype, (_xp.float32, _xp.float64)):
+                data = _xp.astype(data, _xp.float64)
+            data_: NDArray = data
+            return (data_, ids, validate_shape, validate_ids)
+
         _issue_copy = True
         if isinstance(data, np.ndarray):
             if data.dtype in (np.float32, np.float64):
@@ -433,7 +455,7 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
             Deep copy of the matrix. Will be the same type as ``self``.
 
         """
-        data = self._data.copy()
+        data = copy_array(self._data)
         if transpose:
             data = data.T
         return self.__class__(data, deepcopy(self.ids), validate=False)
@@ -1050,7 +1072,11 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
             raise PairwiseMatrixError(
                 "Data must be square (i.e., have the same number of rows and columns)."
             )
-        if data.dtype not in (np.float32, np.float64):
+        # isdtype works for NumPy and non-NumPy (e.g. GPU) buffers alike, via each
+        # array's own namespace. Restrict to single/double precision (as the
+        # legacy NumPy check did) so both paths accept exactly the same dtypes.
+        xp = _aac.array_namespace(data)
+        if not xp.isdtype(data.dtype, (xp.float32, xp.float64)):
             raise PairwiseMatrixError("Data must contain only floating point values.")
 
     def _index_list(self, list_: Sequence[str]) -> dict:
@@ -2574,7 +2600,28 @@ def distmat_reorder_condensed_py(in_mat, reorder_vec):
     np.ndarray
         Condensed matrix.
 
+    Notes
+    -----
+    A non-NumPy array-API buffer (e.g. GPU-resident) is gathered on its own
+    device: the reorder indices are cheap index arithmetic computed on the
+    host, then only the actual data gather runs on the input's device.
+
     """
+    if _aac.is_array_api_obj(in_mat) and not _aac.is_numpy_array(in_mat):
+        n_original = _vec_to_shape(in_mat)
+        reorder_np = np.asarray(reorder_vec)
+        n_filtered = len(reorder_np)
+        i_indices, j_indices = np.triu_indices(n_filtered, k=1)
+        old_indices = _condensed_index(
+            reorder_np[i_indices], reorder_np[j_indices], n_original
+        )
+        xp = _aac.array_namespace(in_mat)
+        idx = xp.asarray(
+            np.asarray(old_indices, dtype=np.int64),
+            device=getattr(in_mat, "device", None),
+        )
+        return in_mat[idx]
+
     reorder_vec = np.asarray(reorder_vec)
     in_mat = np.asarray(in_mat)
     n_original = _vec_to_shape(in_mat)

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -71,6 +71,76 @@ class MissingIDError(PairwiseMatrixError):
         self.args = ("The ID '%s' is not in the matrix." % missing_id,)
 
 
+def _expand_condensed(condensed: NDArray, diagonal=None) -> NDArray:
+    """Expand a 1-D condensed vector to a redundant 2-D matrix.
+
+    Works for a NumPy array or any non-NumPy array-API buffer (e.g.
+    GPU-resident), staying on the input's device for the latter. Only one
+    (n, n) buffer is allocated on the input's device, scattered into from
+    both triangles; no boolean-mask buffer or full-matrix transpose is
+    needed. Mutable backends (PyTorch, CuPy) scatter via item-assignment;
+    JAX, which is immutable, uses its functional ``.at[].set()`` update,
+    which is device-preserving the same way. Any other array-API backend
+    (e.g. Dask) falls back to a host round-trip via scipy's squareform
+    rather than assume item-assignment works. A native per-backend
+    implementation (or a Numba/GPU kernel, if available) could replace
+    this; this generic array-API scatter is the simpler option for now.
+
+    Parameters
+    ----------
+    condensed : 1-D array_like
+        Condensed (upper-triangle) form of the matrix.
+    diagonal : float or 1-D array_like, optional
+        Diagonal value(s) to set. Defaults to zero.
+
+    Returns
+    -------
+    ndarray or array
+        The redundant 2-D matrix, of the same type and on the same device
+        as ``condensed``.
+
+    """
+    if _aac.is_numpy_array(condensed):
+        mat = squareform(condensed, force="tomatrix", checks=False)
+        np.fill_diagonal(mat, diagonal if diagonal is not None else 0.0)
+        return mat
+
+    xp = _aac.array_namespace(condensed)
+    dev = getattr(condensed, "device", None)
+    backend = _get_backend_name(xp)
+
+    if backend in ("torch", "cupy", "jax"):
+        n = _vec_to_shape(condensed)
+        i_np, j_np = np.triu_indices(n, k=1)
+        i_idx = xp.asarray(i_np, device=dev)
+        j_idx = xp.asarray(j_np, device=dev)
+        mat = xp.zeros((n, n), dtype=condensed.dtype, device=dev)
+        diag_idx = xp.arange(n, device=dev)
+        if backend == "jax":
+            mat = mat.at[i_idx, j_idx].set(condensed)
+            mat = mat.at[j_idx, i_idx].set(condensed)
+            if diagonal is not None:
+                diag_val = xp.asarray(diagonal, dtype=condensed.dtype, device=dev)
+                mat = mat.at[diag_idx, diag_idx].set(diag_val)
+        else:
+            mat[i_idx, j_idx] = condensed
+            mat[j_idx, i_idx] = condensed
+            if diagonal is not None:
+                mat[diag_idx, diag_idx] = xp.asarray(
+                    diagonal, dtype=condensed.dtype, device=dev
+                )
+        return mat
+
+    # Unrecognized array-API backend: fall back to a host round-trip rather
+    # than assume item-assignment works.
+    mat_np = squareform(_to_numpy(condensed), force="tomatrix", checks=False)
+    diag = diagonal if diagonal is not None else 0.0
+    if _aac.is_array_api_obj(diag) and not _aac.is_numpy_array(diag):
+        diag = _to_numpy(diag)
+    np.fill_diagonal(mat_np, diag)
+    return xp.asarray(mat_np, device=dev)
+
+
 class PairwiseMatrix(SkbioObject, PlottableMixin):
     r"""Store pairwise relationships between objects.
 
@@ -142,31 +212,10 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         # convert data to redundant if 1D input.
         # should do this for PairwiseMatrix only.
         if data.ndim == 1:
-            if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
-                # A condensed vector is inherently a symmetric-matrix
-                # representation. Mutable backends (PyTorch, CuPy) scatter the
-                # values into the matrix on-device via item-assignment, no host
-                # round-trip. Immutable backends (JAX), which do not support
-                # item-assignment, go through scipy's squareform on the host
-                # instead, mirroring SymmetricMatrix._condensed_to_redundant.
-                # A native per-backend implementation (or a Numba/GPU kernel,
-                # if available) could replace this for JAX too; this generic
-                # array-API scatter is the simpler option for now.
-                xp = _aac.array_namespace(data)
-                dev = getattr(data, "device", None)
-                if _get_backend_name(xp) in ("torch", "cupy"):
-                    k = data.shape[0]
-                    n = int((1.0 + (1.0 + 8.0 * k) ** 0.5) / 2.0)
-                    idx = xp.arange(n, device=dev)
-                    upper = idx[:, None] < idx[None, :]
-                    mat = xp.zeros((n, n), dtype=data.dtype, device=dev)
-                    mat[upper] = data
-                    data = mat + xp.matrix_transpose(mat)  # diagonal stays zero
-                else:
-                    mat_np = squareform(_to_numpy(data), force="tomatrix", checks=False)
-                    data = xp.asarray(mat_np, device=dev)
-            else:
-                data = squareform(data, force="tomatrix", checks=False)
+            # A condensed vector is inherently a symmetric-matrix
+            # representation. _expand_condensed handles NumPy and array-API
+            # buffers alike, staying on the input's device for the latter.
+            data = _expand_condensed(data)
 
         if ids is None:
             ids = self._generate_ids(data)
@@ -1341,6 +1390,11 @@ class SymmetricMatrix(PairwiseMatrix):
             1-D or 2-D array containing the values of the matrix.
 
         """
+        if not condensed and data.ndim == 1:
+            # Redundant form requested from a condensed vector, on any
+            # backend; _expand_condensed handles NumPy and array-API buffers
+            # alike, staying on the input's device for the latter.
+            return _expand_condensed(data, self._diagonal)
         if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
             if condensed:
                 if data.ndim == 1:
@@ -1351,9 +1405,7 @@ class SymmetricMatrix(PairwiseMatrix):
                 # same operation condensed_form() uses.
                 n = data.shape[0]
                 return distmat_reorder_condensed(data, np.arange(n))
-            if data.ndim == 1:
-                # Redundant form requested from a condensed non-NumPy vector.
-                return self._condensed_to_redundant(data)
+            # condensed=False, ndim == 2 (ndim == 1 handled above): passthrough.
             return data
         if condensed:
             # case where input is 1d and stays 1d
@@ -1362,54 +1414,8 @@ class SymmetricMatrix(PairwiseMatrix):
             # case where input is 2d and is converted to 1d
             else:
                 return squareform(data, force="tovector", checks=False)
-        else:
-            # case where input is 1d and is converted to 2d.
-            if data.ndim == 1:
-                mat = squareform(data, force="tomatrix", checks=False)
-                if self._diagonal is not None:
-                    np.fill_diagonal(mat, self._diagonal)
-                else:
-                    np.fill_diagonal(mat, 0.0)
-                return mat
-            # case where input is 2d and stays 2d
-            else:
-                return data
-
-    def _condensed_to_redundant(self, condensed: NDArray) -> NDArray:
-        """Expand a non-NumPy condensed vector to a redundant 2-D buffer on its device.
-
-        Mutable backends (e.g. PyTorch, CuPy) scatter the values into the matrix
-        on-device via item-assignment. Immutable backends (e.g. JAX), which do not
-        support item-assignment, go through a single host round-trip instead.
-
-        """
-        xp = _aac.array_namespace(condensed)
-        dev = getattr(condensed, "device", None)
-
-        if _get_backend_name(xp) in ("torch", "cupy"):
-            # scatter on-device (no host round-trip): place the values in the
-            # row-major upper triangle (matching the condensed order), mirror to
-            # the lower triangle, then set the diagonal.
-            k = condensed.shape[0]
-            n = int((1.0 + (1.0 + 8.0 * k) ** 0.5) / 2.0)
-            idx = xp.arange(n, device=dev)
-            upper = idx[:, None] < idx[None, :]
-            mat = xp.zeros((n, n), dtype=condensed.dtype, device=dev)
-            mat[upper] = condensed
-            mat = mat + xp.matrix_transpose(mat)  # symmetric; diagonal stays zero
-            if self._diagonal is not None:
-                mat[idx, idx] = xp.asarray(
-                    self._diagonal, dtype=condensed.dtype, device=dev
-                )
-            return mat
-
-        # immutable backends (e.g. JAX): build the matrix via one host round-trip.
-        mat_np = squareform(_to_numpy(condensed), force="tomatrix", checks=False)
-        diag = self._diagonal if self._diagonal is not None else 0.0
-        if _aac.is_array_api_obj(diag) and not _aac.is_numpy_array(diag):
-            diag = _to_numpy(diag)
-        np.fill_diagonal(mat_np, diag)
-        return xp.asarray(mat_np, device=dev)
+        # case where input is 2d and stays 2d (ndim == 1 handled above)
+        return data
 
     def _validate_data(self, data: NDArray) -> None:
         """Validate the data array.
@@ -1736,13 +1742,7 @@ class SymmetricMatrix(PairwiseMatrix):
 
         """
         if self._flags["CONDENSED"]:
-            if _aac.is_array_api_obj(self._data) and not _aac.is_numpy_array(
-                self._data
-            ):
-                return self._condensed_to_redundant(self._data)
-            mat = squareform(self._data, force="tomatrix", checks=False)
-            np.fill_diagonal(mat, self._diagonal)
-            return mat
+            return _expand_condensed(self._data, self._diagonal)
         else:
             return self._data
 

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -149,6 +149,9 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
                 # round-trip. Immutable backends (JAX), which do not support
                 # item-assignment, go through scipy's squareform on the host
                 # instead, mirroring SymmetricMatrix._condensed_to_redundant.
+                # A native per-backend implementation (or a Numba/GPU kernel,
+                # if available) could replace this for JAX too; this generic
+                # array-API scatter is the simpler option for now.
                 xp = _aac.array_namespace(data)
                 dev = getattr(data, "device", None)
                 if _get_backend_name(xp) in ("torch", "cupy"):

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -144,13 +144,24 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         if data.ndim == 1:
             if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
                 # A condensed vector is inherently a symmetric-matrix
-                # representation; scipy's squareform has no array-API path, so
-                # expand it via a single host round-trip and place the result
-                # back on the input's device.
+                # representation. Mutable backends (PyTorch, CuPy) scatter the
+                # values into the matrix on-device via item-assignment, no host
+                # round-trip. Immutable backends (JAX), which do not support
+                # item-assignment, go through scipy's squareform on the host
+                # instead, mirroring SymmetricMatrix._condensed_to_redundant.
                 xp = _aac.array_namespace(data)
                 dev = getattr(data, "device", None)
-                mat_np = squareform(_to_numpy(data), force="tomatrix", checks=False)
-                data = xp.asarray(mat_np, device=dev)
+                if _get_backend_name(xp) in ("torch", "cupy"):
+                    k = data.shape[0]
+                    n = int((1.0 + (1.0 + 8.0 * k) ** 0.5) / 2.0)
+                    idx = xp.arange(n, device=dev)
+                    upper = idx[:, None] < idx[None, :]
+                    mat = xp.zeros((n, n), dtype=data.dtype, device=dev)
+                    mat[upper] = data
+                    data = mat + xp.matrix_transpose(mat)  # diagonal stays zero
+                else:
+                    mat_np = squareform(_to_numpy(data), force="tomatrix", checks=False)
+                    data = xp.asarray(mat_np, device=dev)
             else:
                 data = squareform(data, force="tomatrix", checks=False)
 

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -2248,6 +2248,62 @@ class DistanceMatrixTests(DistanceMatrixTestBase, TestCase):
         super(DistanceMatrixTests, self).setUp()
 
 
+class PairwiseMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
+    """A PairwiseMatrix (asymmetric) can hold a non-NumPy array-API buffer."""
+
+    def setUp(self):
+        rng = np.random.default_rng(0)
+        a = rng.random((5, 5))  # not symmetric, unlike DistanceMatrix's data
+        np.fill_diagonal(a, 0.0)
+        self.data = a
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_constructor_preserves_buffer(self, xp, device):
+        pm = PairwiseMatrix(self.make_array(xp, device, self.data))
+        self.assert_type_preserved(pm.data, xp, device)
+        self.assertEqual(tuple(pm.shape), (5, 5))
+        self.assert_close(pm.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_integer_buffer_cast_to_float(self, xp, device):
+        idata = (self.data * 10).astype(int).tolist()
+        pm = PairwiseMatrix(self.make_array(xp, device, idata, dtype=xp.int64))
+        self.assert_type_preserved(pm.data, xp, device)
+        ns = aac.array_namespace(pm.data)
+        self.assertTrue(
+            ns.isdtype(pm.data.dtype, (ns.float32, ns.float64)),
+            f"integer buffer not cast to float64, got {pm.data.dtype}",
+        )
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_copy_backend(self, xp, device):
+        pm = PairwiseMatrix(self.make_array(xp, device, self.data))
+        cp = pm.copy()
+        self.assert_type_preserved(cp.data, xp, device)
+        self.assert_close(cp.data, self.data)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_transpose_backend(self, xp, device):
+        pm = PairwiseMatrix(self.make_array(xp, device, self.data))
+        t = pm.transpose()
+        self.assert_type_preserved(t.data, xp, device)
+        self.assert_close(t.data, self.data.T)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_1d_condensed_input_backend(self, xp, device):
+        # A 1-D condensed buffer is inherently symmetric; scipy's squareform
+        # has no array-API path, so this goes through a single host
+        # round-trip and the result is placed back on the input's device.
+        sym = (self.data + self.data.T) / 2.0
+        np.fill_diagonal(sym, 0.0)
+        cond = scipy.spatial.distance.squareform(sym, force="tovector", checks=False)
+        buf = self.make_array(xp, device, cond)
+        pm = PairwiseMatrix(buf)
+        self.assertEqual(pm.data.ndim, 2)
+        self.assert_type_preserved(pm.data, xp, device)
+        self.assert_close(pm.data, sym)
+
+
 class DistanceMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
     """A DistanceMatrix can hold a non-NumPy (e.g. GPU-resident) array-API buffer."""
 
@@ -2402,6 +2458,32 @@ class DistanceMatrixArrayAPITests(TestCase, ArrayAPITestMixin):
         self.assert_close(df.to_numpy(), self.data)
         fig = dm.plot()
         self.assertEqual(len(fig.axes), 2)  # heatmap axis + colorbar axis
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_filter_on_condensed_storage_backend(self, xp, device):
+        # filter() on a matrix that is already stored condensed goes through
+        # distmat_reorder_condensed_py; the result must stay on-device.
+        ids = list("abcde")
+        ref_dm = DistanceMatrix(self.data, ids=ids)
+        cond = self.make_array(xp, device, ref_dm.condensed_form())
+        dm = DistanceMatrix(cond, ids=ids, condensed=True)
+        sub = dm.filter(["a", "c", "e"])
+        self.assert_type_preserved(sub.data, xp, device)
+        ref = ref_dm.filter(["a", "c", "e"])
+        self.assert_close(sub.data, ref.condensed_form())
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_permute_on_condensed_storage_backend(self, xp, device):
+        # permute() on a matrix that is already stored condensed goes through
+        # distmat_reorder_condensed_py; the result must stay on-device.
+        ids = list("abcde")
+        ref_dm = DistanceMatrix(self.data, ids=ids)
+        cond = self.make_array(xp, device, ref_dm.condensed_form())
+        dm = DistanceMatrix(cond, ids=ids, condensed=True)
+        got = dm.permute(condensed=True, seed=0)
+        self.assert_type_preserved(got, xp, device)
+        ref = ref_dm.permute(condensed=True, seed=0)
+        self.assert_close(got, ref)
 
 
 class SymmetricMatrixArrayAPITests(TestCase, ArrayAPITestMixin):


### PR DESCRIPTION
## Summary

Igor asked whether the DM class family (DistanceMatrix, SymmetricMatrix, and the asymmetric PairwiseMatrix/DissimilarityMatrix) is fully GPU-aware and optimized, as a first step ahead of the functions that build DMs. I went through the class and found two spots that still forced a non-NumPy (e.g. GPU-resident) buffer to the host, both fixed here.

## What changed

I found that `distmat_reorder_condensed_py`, used by `filter()` and `permute()` when a matrix is stored condensed, always converted its input to a NumPy array. I fixed it so the reorder indices are computed on the host (cheap) but only the actual gather runs on the input's device, matching the pattern already used by `distmat_reorder` and `distmat_reorder_condensed`.

I also found that the asymmetric `PairwiseMatrix` (the `DissimilarityMatrix` base) could not hold a non-NumPy buffer at all. Its input normalization asserted a NumPy array, its shape validation compared dtypes against `np.float32`/`np.float64` directly (which never matches a non-NumPy dtype object), and its copy path called `data.copy()`, which not every backend implements. I fixed all three to mirror the patterns already used by `SymmetricMatrix`: `ingest_array` to preserve the buffer and its device, `xp.isdtype` for the dtype check, and `copy_array` for a backend-safe copy. I also handled a 1D condensed vector on a non-NumPy backend, which can't be symmetric-expanded by scipy's `squareform`: it now goes through a single host round-trip and gets placed back on the input's device instead of raising.

## Correctness

I verified this on both an AMD MI300X (torch-ROCm) and an NVIDIA RTX 4060 (CuPy): a condensed-stored DistanceMatrix's `filter()` and `permute()` stay on-device and match the NumPy reference, and a DissimilarityMatrix built from a device buffer stays on-device through construction, copy, and transpose. Same result on both vendors.

## Tests

I added array-backend tests (numpy, jax, torch, cupy) covering both fixes: `filter()` and `permute()` on a condensed-stored DistanceMatrix, and a new `PairwiseMatrixArrayAPITests` class covering construction, dtype casting, copy, transpose, and the 1D condensed input case for the asymmetric matrix. These run on CPU torch and jax in CI, not just on a GPU, since the array-API branch itself is backend-generic.

## Note

While I was checking `filter()`/`permute()`'s condensed branch I found an unrelated pre-existing issue: on a `SymmetricMatrix` with a non-zero diagonal, both methods silently reset the diagonal to 0 when reconstructing the result, since the reconstruction never passes `diagonal=`. It's identical on the NumPy path and unaffected by this change (`DistanceMatrix` never hits it, since its diagonal is always 0). I didn't fix it here, flagging it separately.
