### PR TITLE
FIX: normalize pandas StringDtype columns before patsy dmatrix in anc…

### DIFF
--- a/skbio/stats/composition/_utils.py
+++ b/skbio/stats/composition/_utils.py
@@ -305,5 +305,7 @@ def _type_cast_to_float(df):
         try:
             df[col] = df[col].astype("float64")
         except (ValueError, TypeError):
-            continue
+            # patsy's dmatrix() cannot handle pandas' StringDtype
+            if isinstance(df[col].dtype, pd.StringDtype):
+                df[col] = df[col].astype(object)
     return df

--- a/skbio/stats/composition/tests/test_ancombc.py
+++ b/skbio/stats/composition/tests/test_ancombc.py
@@ -45,6 +45,7 @@ class AncombcTests(TestCase):
             ["treatment", "treatment", "treatment", "placebo", "placebo", "placebo"],
             index=["s1", "s2", "s3", "s4", "s5", "s6"],
             name="grouping",
+            dtype=object,
         )
 
     def test_estimate_params(self):
@@ -241,6 +242,7 @@ class AncombcTests(TestCase):
         meta_data["bmi"] = pd.Categorical(
             meta_data["bmi"], categories=["obese", "overweight", "lean"]
         )
+        meta_data["region"] = meta_data["region"].astype(object)
         feature_table = np.log1p(table.to_numpy())
         dmat = dmatrix("age + region + bmi", meta_data)
         covars = dmat.design_info.column_names


### PR DESCRIPTION
Context: Guix is bumping Pandas to version 3.0, and it made the package (version 0.7.3, but it doesn't look fixed on master either) fail to build properly.  This is a derived fix to make it build properly on Pandas@3.0.

Disclaimer : The fix was suggested by generative AI, although I tested the results and read the logic carefully. This is a small fix so I don't think it can be considered original, I'm ticking the "not include" option below.

--- 

Pandas 3.0 made its own extension StringDtype (rather than NumPy object) the default dtype for string columns. NumPy's issubdtype, which patsy's dmatrix() uses internally to detect categorical columns, cannot interpret StringDtype and raises a TypeError, breaking ancombc() whenever metadata contains string columns.

_type_cast_to_float() now falls back to plain NumPy object dtype for columns that are pandas StringDtype and cannot be cast to float, leaving other non-numeric dtypes (e.g. category) untouched so that patsy's own handling of pandas Categorical columns (and their explicit category order) is not disturbed.

test_ancombc.py builds a couple of dmatrix() calls directly from test fixtures, bypassing _type_cast_to_float, so those fixtures needed the same object-dtype normalization applied explicitly.

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md). (There are none)

* [x] This pull request does not include code, documentation, or other content derived from external source(s).
