### PR TITLE
BUG: fix center_distance_matrix public wiring and two torch pcoa crashes

### DIFF
--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -23,6 +23,7 @@ from ._mantel_gpu import _run_mantel_gpu
 from skbio.stats.distance import DistanceMatrix
 from skbio.util import get_rng
 from skbio.util._array import ingest_array, _get_array
+from skbio.util._decorator import array_api_doc
 from skbio._config import _resolve_engine
 
 import array_api_compat as _aac
@@ -161,6 +162,7 @@ if NUMBA_AVAILABLE:
             permuted_stats[p] = my_ps
 
 
+@array_api_doc(backends=["numpy", "jax", "torch", "cupy"])
 def mantel(
     x: DistanceMatrix | ArrayLike,
     y: DistanceMatrix | ArrayLike,
@@ -264,7 +266,13 @@ def mantel(
         implementation. ``"numba"`` uses the optional Numba implementation
         and requires Numba to be installed. If not provided, the global
         default is used (see :func:`skbio.set_config`). Only applies to the
-        ``"pearson"`` and ``"spearman"`` methods.
+        ``"pearson"`` and ``"spearman"`` methods. When both distance matrices
+        are resident on a CuPy- or PyTorch-backed GPU (CUDA or ROCm) and
+        ``engine="numba"``, a fused GPU kernel is used; matrices on other
+        backends use the array-API path instead (see Notes for the
+        ROCm-PyTorch case).
+
+        .. versionadded:: 0.7.4
 
     Returns
     -------
@@ -305,6 +313,13 @@ def mantel(
     The Mantel test was first described in [2]_. The general algorithm and
     interface are similar to ``vegan::mantel``, available in R's vegan
     package [3]_.
+
+    On GPU-resident distance matrices with ``engine="numba"``, a fused GPU kernel
+    runs on CuPy or PyTorch matrices, on both CUDA and ROCm devices. The exception
+    is ROCm PyTorch on stacks where a Numba HIP kernel cannot be compiled after
+    ROCm PyTorch has been imported in the same process; those matrices fall back
+    to the array-API path, which runs on the device regardless. The result is
+    identical across all paths.
 
     ``np.nan`` will be returned for the p-value if `permutations` is zero or if
     the correlation coefficient is ``np.nan``. The correlation coefficient will

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -29,7 +29,7 @@ from skbio.binaries import (
     permanova as _skbb_permanova,
 )
 from skbio.util import get_rng
-from skbio.util._decorator import params_aliased
+from skbio.util._decorator import params_aliased, array_api_doc
 from skbio.util._array import ingest_array
 from skbio._config import _resolve_engine
 
@@ -376,6 +376,7 @@ if NUMBA_AVAILABLE:
 
 
 @params_aliased([("distmat", "distance_matrix", "0.7.0", False)])
+@array_api_doc(backends=["numpy", "jax", "torch", "cupy"])
 def permanova(
     distmat: DistanceMatrix,
     grouping: pd.DataFrame | ArrayLike,
@@ -461,6 +462,8 @@ def permanova(
         (CUDA or ROCm) and ``engine="numba"``, a fused GPU kernel is used;
         matrices on other backends use the array-API path instead (see Notes for
         the ROCm-PyTorch case).
+
+        .. versionadded:: 0.7.4
 
     Returns
     -------

--- a/skbio/stats/ordination/__init__.py
+++ b/skbio/stats/ordination/__init__.py
@@ -174,7 +174,11 @@ References
 from ._redundancy_analysis import rda
 from ._correspondence_analysis import ca
 from ._canonical_correspondence_analysis import cca
-from ._principal_coordinate_analysis import pcoa, pcoa_biplot
+from ._principal_coordinate_analysis import (
+    pcoa,
+    pcoa_biplot,
+    center_distance_matrix,
+)
 from ._principal_component_analysis import pca
 from ._ordination_results import OrdinationResults
 from ._mmvec import mmvec, MMvec, MMvecResult
@@ -185,7 +189,6 @@ from ._utils import (
     corr,
     e_matrix,
     f_matrix,
-    center_distance_matrix,
 )
 
 __all__ = [

--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -23,7 +23,7 @@ from skbio.binaries import (
     pcoa_fsvd_available as _skbb_pcoa_fsvd_available,
     pcoa_fsvd as _skbb_pcoa_fsvd,
 )
-from skbio.util._decorator import params_aliased
+from skbio.util._decorator import params_aliased, array_api_doc
 from skbio.util._array import ingest_array, _to_numpy
 
 
@@ -45,12 +45,40 @@ def f_matrix(E_matrix):
     return E_matrix - row_means - col_means + matrix_mean
 
 
+@array_api_doc(backends=["numpy", "jax", "torch", "cupy"])
 def center_distance_matrix(distance_matrix, inplace=False, engine=None):
     """Center a distance matrix.
 
-    Note: For JAX arrays (immutable) and CuPy arrays (GPU), the ``inplace``
+    Parameters
+    ----------
+    distance_matrix : 2D array_like
+        Distance matrix.
+    inplace : bool, optional
+        Whether to center the given distance matrix in-place, which is more
+        efficient in terms of memory and computation. Ignored for JAX and
+        CuPy arrays (see Notes); the centered array is always returned.
+    engine : {"cython", "numba"}, optional
+        Compute engine to use for a NumPy-backed distance matrix. ``"cython"``
+        (default) uses the Cython implementation. ``"numba"`` uses the
+        optional Numba implementation and requires Numba to be installed. If
+        not provided, the global default is used (see
+        :func:`skbio.set_config`). Ignored for non-NumPy array-API buffers,
+        which always take the backend-agnostic double-centering path.
+
+        .. versionadded:: 0.7.4
+
+    Returns
+    -------
+    ndarray or array
+        The centered distance matrix, of the same type and on the same device
+        as the input.
+
+    Notes
+    -----
+    For JAX arrays (immutable) and CuPy arrays (GPU), the ``inplace``
     argument is accepted for API compatibility but ignored. The function
     always returns a centered array.
+
     """
     # For true NumPy arrays, use the Cython- or Numba-accelerated
     # implementation, which also supports in-place modification.
@@ -93,6 +121,7 @@ def _host_partial_eigh(matrix_any, subidx):
         ("distmat", "distance_matrix", "0.7.0", False),
     ]
 )
+@array_api_doc(backends=["numpy", "jax", "torch", "cupy"])
 def pcoa(
     distmat,
     method="eigh",
@@ -151,6 +180,8 @@ def pcoa(
         installed. If not provided, the global default is used (see
         :func:`skbio.set_config`). When ``"numba"`` is selected, the optional
         scikit-bio-binaries acceleration is not used.
+
+        .. versionadded:: 0.7.4
 
     Returns
     -------
@@ -355,12 +386,12 @@ def pcoa(
     # by L&L to deal with negative eigenvalues. We raise a warning
     # in that case. First, we make values close to 0 equal to 0.
     xp, eigvals = ingest_array(eigvals)
-    negative_close_to_zero = xp.isclose(eigvals, 0)
+    negative_close_to_zero = xp.isclose(eigvals, xp.zeros_like(eigvals))
     eigvals = xp.where(negative_close_to_zero, 0, eigvals)
 
     # eigvals might not be ordered, so we first sort them, then analogously
     # sort the eigenvectors by the ordering of the eigenvalues too
-    idxs_descending = eigvals.argsort()[::-1]
+    idxs_descending = xp.flip(eigvals.argsort(), axis=0)
     eigvals = eigvals[idxs_descending]
     eigvecs = eigvecs[:, idxs_descending]
 

--- a/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_coordinate_analysis.py
@@ -540,5 +540,43 @@ class TestFSVDBackends(TestCase, ArrayAPITestMixin):
         self.assert_close(xp.abs(res_vecs), np.abs(ref_vecs), rtol=1e-5, atol=1e-5)
 
 
+class TestPCoABackends(TestCase, ArrayAPITestMixin):
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_pcoa_eigh_matches_numpy(self, xp, device):
+        dm_np = DistanceMatrix(np.asarray(_DM, dtype=np.float64))
+        expected = pcoa(dm_np, method="eigh", dimensions=3, seed=0)
+
+        dm = DistanceMatrix(self.make_array(xp, device, _DM))
+        result = pcoa(dm, method="eigh", dimensions=3, seed=0)
+
+        assert_ordination_results_equal(result, expected,
+                                        ignore_directionality=True)
+
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_pcoa_fsvd_matches_numpy(self, xp, device):
+        dm_np = DistanceMatrix(np.asarray(_DM, dtype=np.float64))
+        expected = pcoa(dm_np, method="fsvd", dimensions=3, seed=0)
+
+        dm = DistanceMatrix(self.make_array(xp, device, _DM))
+        result = pcoa(dm, method="fsvd", dimensions=3, seed=0)
+
+        assert_ordination_results_equal(result, expected,
+                                        ignore_directionality=True)
+
+
+class TestCenterDistanceMatrixPublicWiring(TestCase):
+    def test_public_name_is_array_api_aware_implementation(self):
+        # skbio.stats.ordination.center_distance_matrix must resolve to the
+        # array-API-aware implementation in this module, not the NumPy-only
+        # one in _utils.py (which it is built on top of via the "cython"/
+        # "numba" engines). Importing it under a different local name here
+        # so this doesn't just compare the same import against itself.
+        from skbio.stats.ordination import (
+            center_distance_matrix as public_center_distance_matrix,
+        )
+
+        self.assertIs(public_center_distance_matrix, center_distance_matrix)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

You asked back on August 2nd to add versionadded tags and the array-API compatibility grid to permanova, mantel, pcoa, and center_distance_matrix, and confirmed the backend list should be numpy, jax, torch, and cupy, not dask. While putting that together I found the documentation would have been claiming support that didn't actually work, so this PR fixes three real bugs first and adds the documentation on top of working code.

## What changed

The public skbio.stats.ordination.center_distance_matrix was wired to the wrong function. __init__.py imported it from _utils.py, a NumPy-only implementation used internally by pcoa() as its Cython/Numba-accelerated engine, instead of from _principal_coordinate_analysis.py, where the actual array-API-aware version already lives and which pcoa() itself correctly calls. A user calling the public name on a torch, jax, or cupy buffer would hit the NumPy-only path and crash. I fixed the import to point at the right function. This changes nothing for NumPy input, since the array-API-aware version still calls the same Cython/Numba engine for a real np.ndarray.

pcoa() crashed on torch for both the eigh and fsvd methods. xp.isclose(eigvals, 0) fails because the array-API standard requires both arguments to be arrays, and torch's backend enforces that strictly while NumPy and JAX tolerate a bare Python int. I fixed it with xp.zeros_like(eigvals). Fixing that surfaced a second crash in the same block: eigvals.argsort()[::-1] also fails on torch, which doesn't support negative-step slicing. I fixed that with xp.flip(eigvals.argsort(), axis=0).

I then added the versionadded 0.7.4 tags and the array-API compatibility grid to all four functions, with the backend list you confirmed.

## Correctness

I verified both pcoa fixes against a NumPy reference on torch and jax, both eigh and fsvd, agreement under 4e-16. I also checked cupy specifically, since it isn't installed in my local environment: ran the two exact fixed expressions on AMD's cupy-ROCm build and confirmed neither crashes and both produce correct values.

## Tests

I added TestPCoABackends, covering both eigh and fsvd against a NumPy reference across numpy, jax, torch, and cupy, and a direct identity test guarding the wiring fix specifically, since the existing TestCenterDistanceMatrixBackends imports center_distance_matrix directly from _principal_coordinate_analysis and would never have caught the public-import bug. Neither of the two bugs had any test coverage before this.

@sfiligoi
