### PR TITLE
Improved `rclr` function to avoid zero division warning

### DIFF
--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -46,7 +46,7 @@ def _check_composition(
     axis : int, optional
         Axis that represents each composition. Default is the last axis (-1).
     nozero : bool, optional
-        If True, matrix cannot have zero values.
+        If True, matrix must contain only positive values.
     maxdim : int, optional
         Maximum number of dimensions allowed. Default is None.
     allnum : bool, optional
@@ -57,35 +57,39 @@ def _check_composition(
     TypeError
         If the matrix is not numeric.
     ValueError
-        If the matrix contains nan or infinite values.
+        If the matrix contains NaN (allnum=True) or infinite values.
     ValueError
-        If any values in the matrix are negative.
+        If any values in the matrix are zero (nozero=True) or negative.
     ValueError
-        If there are compositions that have all zeros.
+        If there are compositions full of zeros or NaNs (no observation).
     ValueError
         If the matrix has more than maximum number of dimensions.
 
     """
     if not xp.isdtype(mat.dtype, "numeric"):
         raise TypeError("Input matrix must have a numeric data type.")
+    if maxdim is not None and mat.ndim > maxdim:
+        raise ValueError(f"Input matrix can only have {maxdim} dimensions or less.")
     if allnum:
-        # Don't allow infinite or NaN values.
         if not xp.all(xp.isfinite(mat)):
             raise ValueError("Input matrix cannot have infinite or NaN values.")
     else:
-        # Allow NaN, but not infinite.
         if xp.any(xp.isinf(mat)):
             raise ValueError("Input matrix cannot have infinite values.")
     if nozero:
         if xp.any(mat <= 0):
-            raise ValueError("Input matrix cannot have negative or zero components.")
+            raise ValueError("Input matrix must have strictly positive components.")
     else:
         if xp.any(mat < 0):
             raise ValueError("Input matrix cannot have negative components.")
-        if xp.any(~xp.any(mat, axis=axis)):
-            raise ValueError("Input matrix cannot have compositions with all zeros.")
-    if maxdim is not None and mat.ndim > maxdim:
-        raise ValueError(f"Input matrix can only have {maxdim} dimensions or less.")
+        if allnum:
+            observed = xp.any(mat, axis=axis)
+        else:
+            observed = xp.any(mat > 0, axis=axis)
+        if xp.any(~observed):
+            raise ValueError(
+                "Input matrix cannot have compositions without observed components."
+            )
 
 
 @array_api_doc(
@@ -661,7 +665,7 @@ def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
     """
     xp, mat = ingest_array(mat)
     if validate:
-        _check_composition(xp, mat, allnum=False)
+        _check_composition(xp, mat, axis=axis, allnum=False)
     return _rclr(xp, mat, axis)
 
 

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -595,9 +595,9 @@ def _clr_inv(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
 def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
     r"""Perform robust centre log ratio (rclr) transformation.
 
-    The robust CLR transformation is similar to the standard CLR transformation,
-    but it only operates on observed (non-zero) values [1]_. This makes it suitable
-    for sparse compositional data.
+    The robust CLR transformation is similar to the standard CLR transformation, but it
+    only operates on observed (non-zero) values [1]_. This makes it suitable for sparse
+    compositional data.
 
     For each composition, the transformation computes:
 
@@ -605,22 +605,20 @@ def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
 
         rclr(x_i) = \ln(x_i) - \frac{1}{|S|} \sum_{j \in S} \ln(x_j)
 
-    where :math:`S` is the set of indices with non-zero values, and :math:`|S|`
-    is the number of non-zero values.
+    where :math:`S` is the set of indices with non-zero values, and :math:`|S|` is the
+    number of non-zero values.
 
     Parameters
     ----------
     mat : array_like of shape (..., n_components, ...)
-        A matrix of non-negative values. Zeros are allowed and will become
-        NaN in the output. NaN values in the input are preserved (representing
-        missing entries).
+        A matrix of non-negative values. Zeros are allowed and will become NaN in the
+        output. NaN values in the input are preserved (representing missing entries).
     axis : int, optional
-        Axis along which rclr transformation will be performed. Each vector
-        on this axis is considered as a composition. Default is the last
-        axis (-1).
+        Axis along which rclr transformation will be performed. Each vector on this
+        axis is considered as a composition. Default is the last axis (-1).
     validate : bool, default True
-        Check if the matrix consists of non-negative, finite values.
-        NaN values are allowed as missing entries.
+        Check if the matrix consists of non-negative, finite values. NaN values are
+        allowed as missing entries.
 
     Returns
     -------
@@ -633,15 +631,14 @@ def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
 
     Notes
     -----
-    The rclr transformation has several advantages for sparse compositional
-    data:
+    The rclr transformation has several advantages for sparse compositional data:
 
-    1. It does not require pseudocount addition, which can bias results
-    2. It preserves the zero/non-zero structure of the data
-    3. It allows for matrix completion methods to be applied
+    1. It does not require pseudocount addition, which can bias results.
+    2. It preserves the zero/non-zero structure of the data.
+    3. It allows for matrix completion methods to be applied.
 
-    The geometric mean is computed only over non-zero values in each
-    composition, making it "robust" to the presence of zeros.
+    The geometric mean is computed only over non-zero values in each composition,
+    making it "robust" to the presence of zeros.
 
     References
     ----------
@@ -672,26 +669,37 @@ def rclr(mat: ArrayLike, axis: int = -1, validate: bool = True) -> StdArray:
 def _rclr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     """Perform rclr transform."""
 
-    # Track which values were observed in the original input
-    observed_mask = (mat != 0) & ~xp.isnan(mat)
+    # Mask observed values (excluding zero and NaN) in the input matrix.
+    # observed_mask = (mat != 0) & ~xp.isnan(mat)
+    obs_mask = mat > 0
 
-    # Take log (will give -inf for zeros, NaN for NaN)
-    log_safe = xp.where(observed_mask, xp.log(mat), 0.0)
+    # Safe logarithm on observed values, while unobserved values (zero and NaN) become
+    # zeros. The use of Python scalar 1 ensures that the output of `where` matches the
+    # data type of `mat`. This behavior is compliant with array API.
+    safe_mat = xp.where(obs_mask, mat, 1)
+    log_safe = xp.log(safe_mat)
+
+    # Alternatively, one can do the following, wwhich however will raise a warning.
+    # log_safe = xp.where(observed_mask, xp.log(mat), 0.0)
 
     # Count observed values from mask
-    n_observed = xp.sum(observed_mask, axis=axis, keepdims=True)
+    n_obs = xp.sum(obs_mask, axis=axis, keepdims=True)
+
+    # Replace 0 (all-missing compositions) with 1 for safe division.
+    # This shouldn't happen if input has been validated.
+    # n_obs = xp.where(n_obs > 0, n_obs, 1)
 
     # Sum logs for observed values only
     log_sum = xp.sum(log_safe, axis=axis, keepdims=True)
 
-    # Geometric mean
-    geo_mean_log = log_sum / n_observed
+    # Calculate geometric mean
+    geo_mean_log = log_sum / n_obs
 
     # Center by geometric mean
-    result = log_safe - geo_mean_log
+    centered = log_safe - geo_mean_log
 
-    # Replace non-observed with NaN
-    result = xp.where(observed_mask, result, xp.nan)
+    # Replace unobserved calues with NaN
+    result = xp.where(obs_mask, centered, xp.nan)
 
     return result
 

--- a/skbio/stats/composition/_base.py
+++ b/skbio/stats/composition/_base.py
@@ -679,7 +679,7 @@ def _rclr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     safe_mat = xp.where(obs_mask, mat, 1)
     log_safe = xp.log(safe_mat)
 
-    # Alternatively, one can do the following, wwhich however will raise a warning.
+    # Alternatively, one can do the following, which however will raise a warning.
     # log_safe = xp.where(observed_mask, xp.log(mat), 0.0)
 
     # Count observed values from mask
@@ -698,7 +698,7 @@ def _rclr(xp: ModuleType, mat: StdArray, axis: int) -> StdArray:
     # Center by geometric mean
     centered = log_safe - geo_mean_log
 
-    # Replace unobserved calues with NaN
+    # Replace unobserved values with NaN
     result = xp.where(obs_mask, centered, xp.nan)
 
     return result

--- a/skbio/stats/composition/tests/test_base.py
+++ b/skbio/stats/composition/tests/test_base.py
@@ -120,7 +120,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
             _check_composition(np, self.bad1)
         self.assertEqual(str(cm.exception), msg)
 
-        msg = "Input matrix cannot have compositions with all zeros."
+        msg = "Input matrix cannot have compositions without observed components."
         with self.assertRaises(ValueError) as cm:
             _check_composition(np, self.bad3)
         self.assertEqual(str(cm.exception), msg)
@@ -146,7 +146,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
             _check_composition(np, np.array(0))
         self.assertEqual(str(cm.exception), msg)
 
-        msg = "Input matrix cannot have negative or zero components."
+        msg = "Input matrix must have strictly positive components."
         self.assertIsNone(_check_composition(np, self.cdata3))
         with self.assertRaises(ValueError) as cm:
             _check_composition(np, self.cdata3, nozero=True)
@@ -157,6 +157,27 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
         self.assertIsNone(_check_composition(np, self.cdata9, maxdim=3))
         with self.assertRaises(ValueError) as cm:
             _check_composition(np, self.cdata9, maxdim=2)
+        self.assertEqual(str(cm.exception), msg)
+
+        # NaN values
+        mat = np.array([[3.0, 2.5], [np.nan, 1.0]])
+        msg = "Input matrix cannot have infinite or NaN values."
+        with self.assertRaises(ValueError) as cm:
+            _check_composition(np, mat)
+        self.assertEqual(str(cm.exception), msg)
+        self.assertIsNone(_check_composition(np, mat, allnum=False))
+
+        # all-NaN composition
+        msg = "Input matrix cannot have compositions without observed components."
+        mat = np.array([[np.nan, 1.0], [np.nan, 2.0]])
+        with self.assertRaises(ValueError) as cm:
+            _check_composition(np, mat, axis=0, allnum=False)
+        self.assertEqual(str(cm.exception), msg)
+
+        # mixture of zero and NaN
+        mat = np.array([[1.2, 2.6, np.nan], [0.0, np.nan, 0.0]])
+        with self.assertRaises(ValueError) as cm:
+            _check_composition(np, mat, allnum=False)
         self.assertEqual(str(cm.exception), msg)
 
     def test_check_basis(self):
@@ -271,7 +292,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
         npt.assert_array_equal(obs.round(3), exp)
 
         # all-zero composition
-        msg = "Input matrix cannot have compositions with all zeros."
+        msg = "Input matrix cannot have compositions without observed components."
         with self.assertRaises(ValueError) as cm:
             closure(self.bad3)
         self.assertEqual(str(cm.exception), msg)
@@ -502,7 +523,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
         npt.assert_allclose(cmat, exp)
 
         # invalid input matrix
-        msg = "Input matrix cannot have negative or zero components."
+        msg = "Input matrix must have strictly positive components."
 
         # negative value
         with self.assertRaises(ValueError) as cm:
@@ -668,7 +689,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
         npt.assert_allclose(obs, exp)
 
     def test_ilr_errors(self):
-        msg = "Input matrix cannot have negative or zero components."
+        msg = "Input matrix must have strictly positive components."
         with self.assertRaises(ValueError) as cm:
             ilr(self.bad1)
         self.assertEqual(str(cm.exception), msg)
@@ -1173,6 +1194,20 @@ class TestRclr(TestCase, ArrayAPITestMixin):
             rclr(mat)
 
         self.assertIn("negative", str(context.exception))
+
+    def test_rclr_empty_composition(self):
+        mat = np.array([[0, 0, 0], [1, 2, 3]])
+        with self.assertRaises(ValueError):
+            rclr(mat)
+
+        _ = rclr(mat, axis=0)
+
+        with self.assertRaises(ValueError):
+            rclr(mat.T, axis=0)
+
+        mat = np.array([[0., np.nan, 0.]])
+        with self.assertRaises(ValueError):
+            rclr(mat)
 
     def test_rclr_inf_error(self):
         """Test that infinite values raise an error."""


### PR DESCRIPTION
Previously it could raise a zero division warning. This patch fixed it. Compute may become less efficient though in order to create an intermediate array. Also fixed composition checking.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
