### PR TITLE
ENH: read and write BPTree via the newick format through skbio.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Added `BPTree`, a succinct balanced-parentheses representation of trees for memory-efficient storage and fast topological queries on very large trees. Ported from [improved-octo-waddle](https://github.com/biocore/improved-octo-waddle) ([#2498](https://github.com/scikit-bio/scikit-bio/pull/2498)).
+* `BPTree` reads and writes the `newick` format through the `skbio.io` registry, mirroring `TreeNode`: `BPTree.read` and `BPTree.write` delegate to the registry with `newick` as the default format. The reader and writer translate directly to and from `BPTree`'s parenthesis/name/length/edge arrays without constructing any intermediate per-node objects, and are backed by a compiled (Cython) implementation so that reading and writing stay fast on trees with millions to billions of nodes. ([#2528](https://github.com/scikit-bio/scikit-bio/pull/2528)).
 
 ## Version 0.7.3
 

--- a/doc/source/_templates/BP.rst
+++ b/doc/source/_templates/BP.rst
@@ -11,6 +11,8 @@
 
       ~{{ name }}.read
       ~{{ name }}.write
+      ~{{ name }}.to_npz
+      ~{{ name }}.from_npz
 
    .. rubric:: Tree navigation
 

--- a/skbio/io/format/newick.py
+++ b/skbio/io/format/newick.py
@@ -176,17 +176,10 @@ In addition to :class:`~skbio.tree.TreeNode`, this format reads and writes
 :class:`~skbio.tree.BPTree`, the succinct balanced-parentheses representation
 intended for very large trees. Reading and writing a ``BPTree`` never
 materializes a ``TreeNode`` (or any other per-node object): the parenthesis,
-name, length, and edge-number arrays are built directly, preserving
-``BPTree``'s memory scalability. For throughput on trees with millions to
-billions of nodes, the ``BPTree`` reader and writer are backed by a compiled
-(Cython) implementation in :mod:`skbio.tree.bp`.
-
-Edge numbers -- integer identifiers assigned to edges (as used by phylogenetic
-placement) -- are written in the canonical ``{N}`` form immediately after a
-branch length (e.g. ``A:0.01{4}``). On read they are parsed into the tree's
-edge array when present (both ``{N}`` and ``[N]`` are accepted). The ``BPTree``
-writer accepts an `include_edge_nums` parameter (``False`` by default); when
-``True`` it emits the ``{N}`` suffix for every node.
+name, and length arrays are built directly, preserving ``BPTree``'s memory
+scalability. For throughput on trees with millions to billions of nodes, the
+``BPTree`` reader and writer are backed by a compiled (Cython) implementation
+in :mod:`skbio.tree.bp`.
 
 .. note:: Because the ``BPTree`` reader uses its own compiled newick scanner
    rather than the tokenizer described above, the ``convert_underscores``
@@ -544,7 +537,9 @@ def _newick_to_bp(fh, cls=None):
 
 
 @newick.writer(BPTree)
-def _bp_to_newick(obj, fh, include_edge_nums=False):
+def _bp_to_newick(obj, fh):
     from skbio.tree.bp._bp_io import write_newick
 
-    write_newick(obj, fh, include_edge_nums)
+    # Edge numbers are not part of the newick spec; they are handled by the
+    # jplace format. The compiled writer still takes the flag, so pass False.
+    write_newick(obj, fh, False)

--- a/skbio/io/format/newick.py
+++ b/skbio/io/format/newick.py
@@ -17,6 +17,8 @@ Format Support
 +======+======+===============================================================+
 |Yes   |Yes   |:mod:`skbio.tree.TreeNode`                                     |
 +------+------+---------------------------------------------------------------+
+|Yes   |Yes   |:mod:`skbio.tree.BPTree`                                       |
++------+------+---------------------------------------------------------------+
 
 Format Specification
 --------------------
@@ -168,6 +170,29 @@ program in which the underscores were not escaped. This parameter only affects
 `read` operations. It does not exist for `write` operations; they will always
 properly escape underscores.
 
+Balanced parentheses trees
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+In addition to :class:`~skbio.tree.TreeNode`, this format reads and writes
+:class:`~skbio.tree.BPTree`, the succinct balanced-parentheses representation
+intended for very large trees. Reading and writing a ``BPTree`` never
+materializes a ``TreeNode`` (or any other per-node object): the parenthesis,
+name, length, and edge-number arrays are built directly, preserving
+``BPTree``'s memory scalability. For throughput on trees with millions to
+billions of nodes, the ``BPTree`` reader and writer are backed by a compiled
+(Cython) implementation in :mod:`skbio.tree.bp`.
+
+Edge numbers -- integer identifiers assigned to edges (as used by phylogenetic
+placement) -- are written in the canonical ``{N}`` form immediately after a
+branch length (e.g. ``A:0.01{4}``). On read they are parsed into the tree's
+edge array when present (both ``{N}`` and ``[N]`` are accepted). The ``BPTree``
+writer accepts an `include_edge_nums` parameter (``False`` by default); when
+``True`` it emits the ``{N}`` suffix for every node.
+
+.. note:: Because the ``BPTree`` reader uses its own compiled newick scanner
+   rather than the tokenizer described above, the ``convert_underscores``
+   behavior does not apply to it -- underscores in unquoted ``BPTree`` labels
+   are preserved literally.
+
 Examples
 --------
 This is a simple Newick string.
@@ -221,7 +246,7 @@ References
 # ----------------------------------------------------------------------------
 
 from skbio.io import create_format, NewickFormatError
-from skbio.tree import TreeNode
+from skbio.tree import TreeNode, BPTree
 
 newick = create_format("newick")
 
@@ -488,3 +513,38 @@ def _tokenize_newick(fh, convert_underscores=True):
             #      the sequence ''' to result in ''.
             #    * We have encountered whitespace that is not properly escaped.
             last_non_ws_char = character
+
+
+# ---------------------------------------------------------------------------
+# BPTree support
+#
+# BPTree is a succinct balanced-parentheses tree intended for very large trees.
+# Its reader/writer never build a TreeNode (or any other per-node object) as an
+# intermediary -- doing so would allocate one Python object per node and defeat
+# BPTree's memory scalability. To keep reading and writing fast on trees with
+# millions to billions of nodes, the parenthesis/name/length/edge arrays are
+# scanned and serialized by the compiled (Cython) backend in ``skbio.tree.bp``;
+# the registry reader and writer below are thin adapters over it.
+# ---------------------------------------------------------------------------
+
+
+@newick.reader(BPTree)
+def _newick_to_bp(fh, cls=None):
+    from skbio.tree.bp._bp_io import parse_newick
+
+    # The compiled parser scans the whole string at once, so materialize the
+    # handle's contents before handing it off. It raises ValueError on malformed
+    # input; re-raise as the format's error type per the registry convention.
+    try:
+        return parse_newick(fh.read())
+    except ValueError as e:
+        raise NewickFormatError(
+            "Could not parse file as newick into a BPTree: %s" % e
+        ) from e
+
+
+@newick.writer(BPTree)
+def _bp_to_newick(obj, fh, include_edge_nums=False):
+    from skbio.tree.bp._bp_io import write_newick
+
+    write_newick(obj, fh, include_edge_nums)

--- a/skbio/io/format/tests/test_newick.py
+++ b/skbio/io/format/tests/test_newick.py
@@ -9,10 +9,15 @@
 import io
 import unittest
 
+import numpy as np
+import numpy.testing as npt
+
 from skbio import TreeNode
+from skbio.tree import BPTree
 from skbio.io import NewickFormatError
 from skbio.io.format.newick import (
-    _newick_to_tree_node, _tree_node_to_newick, _newick_sniffer)
+    _newick_to_tree_node, _tree_node_to_newick, _newick_sniffer,
+    _newick_to_bp, _bp_to_newick)
 
 
 class TestNewick(unittest.TestCase):
@@ -363,6 +368,119 @@ class TestNewick(unittest.TestCase):
             fh = io.StringIO(invalid)
             self.assertEqual(_newick_sniffer(fh), (False, {}))
             fh.close()
+
+
+class TestNewickBPTree(unittest.TestCase):
+    # A diverse battery of valid newick strings covering multifurcation,
+    # single-descendant chains, unnamed/unlengthed nodes, quoted labels
+    # containing structural characters, exponent lengths, and edge numbers.
+    battery = [
+        "((a:2,b):1,(c:4,d)y:20,e)r;",
+        "(((a:1,b:2.5)c:6,d:8,(e),(f,g,(h:1,i:2)j:1)k:1.2)l,m:2)r;",
+        "(((a)b)c,((d)e)f)r;",
+        "((a,b)c,d,(e))r;",
+        "((a,(b,c):5)'d','e; foo':10,((f))g)r;",
+        "(('foo,bar':1,baz:2)x:3)r;",
+        "(('foo(b)ar':1,baz:2)x:3)r;",
+        '((foo"bar":1,baz:2)x:3)r;',
+        "((b:3)a:2)root:1;",
+        "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};",
+        "(a:1e-3,b:2.5E2)r;",
+        "((:0.25,:0.5):0.0,x)r;",
+    ]
+
+    def _read_bp(self, s):
+        return _newick_to_bp(io.StringIO(s))
+
+    def test_exact_arrays(self):
+        # A subset of the balanced-parentheses regression oracle, driving the
+        # registry reader that delegates to the compiled parser.
+        in_ = "((a:2,b):1,(c:4,d)y:20,e)r;"
+        exp_bp = [1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0]
+        exp_n = ['r', None, 'a', None, 'b', None, None, 'y', 'c', None, 'd',
+                 None, None, 'e', None, None]
+        exp_l = [0, 1, 2, 0, 0, 0, 0, 20, 4, 0, 0, 0, 0, 0, 0, 0]
+
+        obs = self._read_bp(in_)
+        npt.assert_equal(obs.data, np.asarray(exp_bp, dtype=np.uint8))
+        for i, (e_n, e_l) in enumerate(zip(exp_n, exp_l)):
+            self.assertEqual(obs.name(i), e_n)
+            self.assertEqual(obs.length(i), e_l)
+
+    def test_exact_arrays_singledesc(self):
+        in_ = "(((a)b)c,((d)e)f)r;"
+        exp_bp = [1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0]
+        exp_n = ['r', 'c', 'b', 'a', None, None, None, 'f', 'e', 'd', None,
+                 None, None, None]
+        obs = self._read_bp(in_)
+        npt.assert_equal(obs.data, np.asarray(exp_bp, dtype=np.uint8))
+        for i, e_n in enumerate(exp_n):
+            self.assertEqual(obs.name(i), e_n)
+
+    def test_edge_numbers(self):
+        in_ = "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};"
+        obs = self._read_bp(in_)
+        self.assertEqual(obs.edge(2), 0)
+        self.assertEqual(obs.edge(4), 1)
+        self.assertEqual(obs.edge(1), 3)
+        self.assertEqual(obs.edge(7), 4)
+        self.assertEqual(obs.edge(0), 5)
+        self.assertEqual(obs.edge_from_number(0), 2)
+        self.assertEqual(obs.edge_from_number(5), 0)
+
+    def test_write_roundtrip(self):
+        for s in self.battery:
+            bp = self._read_bp(s)
+            buf = io.StringIO()
+            _bp_to_newick(bp, buf)
+            buf.seek(0)
+            obs = self._read_bp(buf.getvalue())
+            npt.assert_equal(obs.data, bp.data, err_msg="round-trip topo %r" % s)
+            for i in range(bp.data.size):
+                self.assertEqual(obs.name(i), bp.name(i))
+                self.assertAlmostEqual(obs.length(i), bp.length(i))
+
+    def test_write_edge_numbers_roundtrip(self):
+        in_ = "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};"
+        bp = self._read_bp(in_)
+        buf = io.StringIO()
+        _bp_to_newick(bp, buf, include_edge_nums=True)
+        buf.seek(0)
+        obs = self._read_bp(buf.getvalue())
+        for i in range(bp.data.size):
+            self.assertEqual(obs.edge(i), bp.edge(i))
+
+    def test_read_via_registry_and_sniff(self):
+        s = "((a:2,b):1,(c:4,d)y:20,e)r;"
+        # explicit format
+        exp = self._read_bp(s)
+        obs = BPTree.read([s], format="newick")
+        npt.assert_equal(obs.data, exp.data)
+        # format inference (the newick sniffer dispatches to the BPTree reader
+        # because into=BPTree)
+        obs2 = BPTree.read([s])
+        npt.assert_equal(obs2.data, exp.data)
+
+    def test_write_via_registry_default_format(self):
+        s = "((a:2,b):1,(c:4,d)y:20,e)r;"
+        bp = BPTree.read([s], format="newick")
+        buf = io.StringIO()
+        bp.write(buf)  # default_write_format == "newick"
+        buf.seek(0)
+        obs = BPTree.read(buf)
+        npt.assert_equal(obs.data, bp.data)
+
+    def test_invalid_missing_semicolon(self):
+        with self.assertRaises(NewickFormatError):
+            _newick_to_bp(io.StringIO("((a,b)c,d)r"))
+
+    def test_invalid_single_node(self):
+        with self.assertRaises(NewickFormatError):
+            _newick_to_bp(io.StringIO("i:1;"))
+
+    def test_invalid_unbalanced(self):
+        with self.assertRaises(NewickFormatError):
+            _newick_to_bp(io.StringIO("((a,b)c,d));"))
 
 
 if __name__ == '__main__':

--- a/skbio/io/format/tests/test_newick.py
+++ b/skbio/io/format/tests/test_newick.py
@@ -373,7 +373,7 @@ class TestNewick(unittest.TestCase):
 class TestNewickBPTree(unittest.TestCase):
     # A diverse battery of valid newick strings covering multifurcation,
     # single-descendant chains, unnamed/unlengthed nodes, quoted labels
-    # containing structural characters, exponent lengths, and edge numbers.
+    # containing structural characters, and exponent lengths.
     battery = [
         "((a:2,b):1,(c:4,d)y:20,e)r;",
         "(((a:1,b:2.5)c:6,d:8,(e),(f,g,(h:1,i:2)j:1)k:1.2)l,m:2)r;",
@@ -384,7 +384,7 @@ class TestNewickBPTree(unittest.TestCase):
         "(('foo(b)ar':1,baz:2)x:3)r;",
         '((foo"bar":1,baz:2)x:3)r;',
         "((b:3)a:2)root:1;",
-        "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};",
+        "((A:.01, B:.01)D:.01, C:.01)r;",
         "(a:1e-3,b:2.5E2)r;",
         "((:0.25,:0.5):0.0,x)r;",
     ]
@@ -417,17 +417,6 @@ class TestNewickBPTree(unittest.TestCase):
         for i, e_n in enumerate(exp_n):
             self.assertEqual(obs.name(i), e_n)
 
-    def test_edge_numbers(self):
-        in_ = "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};"
-        obs = self._read_bp(in_)
-        self.assertEqual(obs.edge(2), 0)
-        self.assertEqual(obs.edge(4), 1)
-        self.assertEqual(obs.edge(1), 3)
-        self.assertEqual(obs.edge(7), 4)
-        self.assertEqual(obs.edge(0), 5)
-        self.assertEqual(obs.edge_from_number(0), 2)
-        self.assertEqual(obs.edge_from_number(5), 0)
-
     def test_write_roundtrip(self):
         for s in self.battery:
             bp = self._read_bp(s)
@@ -439,16 +428,6 @@ class TestNewickBPTree(unittest.TestCase):
             for i in range(bp.data.size):
                 self.assertEqual(obs.name(i), bp.name(i))
                 self.assertAlmostEqual(obs.length(i), bp.length(i))
-
-    def test_write_edge_numbers_roundtrip(self):
-        in_ = "((A:.01{0}, B:.01{1})D:.01{3}, C:.01{4}) {5};"
-        bp = self._read_bp(in_)
-        buf = io.StringIO()
-        _bp_to_newick(bp, buf, include_edge_nums=True)
-        buf.seek(0)
-        obs = self._read_bp(buf.getvalue())
-        for i in range(bp.data.size):
-            self.assertEqual(obs.edge(i), bp.edge(i))
 
     def test_read_via_registry_and_sniff(self):
         s = "((a:2,b):1,(c:4,d)y:20,e)r;"

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -271,7 +271,7 @@ cdef class BPTree:
         import skbio.io
 
         return skbio.io.write(
-            self, into=file, format=format or "newick", **kwargs
+            self, into=file, format=format or self.default_write_format, **kwargs
         )
 
     @staticmethod
@@ -310,8 +310,8 @@ cdef class BPTree:
 
         The parentheses bit array, node names, and branch lengths are stored;
         edge numbers are not. This is a lightweight binary dump, distinct from
-        the registry-based :meth:`write` (which defaults to newick and does
-        preserve edge numbers).
+        the registry-based :meth:`write` (which defaults to the ``newick``
+        format).
 
         Parameters
         ----------

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -262,6 +262,7 @@ cdef class BPTree:
         See Also
         --------
         read
+        to_npz
         skbio.io.registry.write
         skbio.io.format.newick
 
@@ -294,6 +295,7 @@ cdef class BPTree:
         See Also
         --------
         write
+        from_npz
         skbio.io.registry.read
         skbio.io.format.newick
 
@@ -302,6 +304,61 @@ cdef class BPTree:
         import skbio.io
 
         return skbio.io.read(file, into=BPTree, format=format, **kwargs)
+
+    def to_npz(self, object file):
+        """Save the tree to a compressed NumPy ``.npz`` archive.
+
+        The parentheses bit array, node names, and branch lengths are stored;
+        edge numbers are not. This is a lightweight binary dump, distinct from
+        the registry-based :meth:`write` (which defaults to newick and does
+        preserve edge numbers).
+
+        Parameters
+        ----------
+        file : str or file-like object
+            Path or open file handle to write to.
+
+        See Also
+        --------
+        from_npz
+        write
+
+        """
+        np.savez_compressed(
+            file, names=self._names, lengths=self._lengths, B=self.data
+        )
+
+    @classmethod
+    def from_npz(cls, object file):
+        """Load a tree from a NumPy ``.npz`` archive written by ``to_npz``.
+
+        Parameters
+        ----------
+        file : str or file-like object
+            Path or open file handle to read from.
+
+        Returns
+        -------
+        BPTree
+            The reconstructed tree, with node names and branch lengths.
+
+        Warnings
+        --------
+        This method calls :func:`numpy.load` with ``allow_pickle=True`` in
+        order to restore the object-dtype ``names`` array. Loading a pickled
+        array can execute arbitrary code, so only read ``.npz`` archives from
+        trusted sources.
+
+        See Also
+        --------
+        to_npz
+        read
+
+        """
+        # names is an object array pickled by ``to_npz``, so unpickling must be
+        # allowed to restore it
+        data = np.load(file, allow_pickle=True)
+        return cls(data["B"], names=data["names"], lengths=data["lengths"])
 
     @classmethod
     def from_treenode(cls, tree):

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -245,55 +245,63 @@ cdef class BPTree:
             _e_index[i] = self._excess(i)
         self._e_index = _e_index
 
-    def write(self, object fname):
-        """Save the tree to a compressed NumPy ``.npz`` archive.
+    default_write_format = "newick"
 
-        The parentheses bit array, node names, and branch lengths are stored.
+    def write(self, object file, format=None, **kwargs):
+        """Write the tree to a file via the ``skbio.io`` registry.
 
         Parameters
         ----------
-        fname : str or file-like object
+        file : str or file-like object
             Path or open file handle to write to.
+        format : str, optional
+            The file format to write. Defaults to ``"newick"``.
+        kwargs : dict, optional
+            Format-specific parameters passed to the writer.
 
         See Also
         --------
         read
+        skbio.io.registry.write
+        skbio.io.format.newick
 
         """
-        np.savez_compressed(fname, names=self._names, lengths=self._lengths,
-                            B=self.data)
+        # imported lazily to avoid an import cycle at module load time
+        import skbio.io
+
+        return skbio.io.write(
+            self, into=file, format=format or "newick", **kwargs
+        )
 
     @staticmethod
-    def read(object fname):
-        """Load a tree from a NumPy ``.npz`` archive written by ``write``.
+    def read(object file, format=None, **kwargs):
+        """Read a tree from a file via the ``skbio.io`` registry.
 
         Parameters
         ----------
-        fname : str or file-like object
+        file : str or file-like object
             Path or open file handle to read from.
+        format : str, optional
+            The file format to read. If omitted, the format is inferred.
+        kwargs : dict, optional
+            Format-specific parameters passed to the reader.
 
         Returns
         -------
         BPTree
-            The reconstructed tree, with node names and branch lengths.
+            The parsed tree.
 
         See Also
         --------
         write
-
-        Warnings
-        --------
-        This method calls :func:`numpy.load` with ``allow_pickle=True`` in
-        order to restore the object-dtype ``names`` array. Loading a pickled
-        array can execute arbitrary code, so only read ``.npz`` archives from
-        trusted sources.
+        skbio.io.registry.read
+        skbio.io.format.newick
 
         """
-        # names is an object array pickled by ``write``, so unpickling must be
-        # allowed to restore it
-        data = np.load(fname, allow_pickle=True)
-        bp = BPTree(data['B'], names=data['names'], lengths=data['lengths'])
-        return bp
+        # imported lazily to avoid an import cycle at module load time
+        import skbio.io
+
+        return skbio.io.read(file, into=BPTree, format=format, **kwargs)
 
     @classmethod
     def from_treenode(cls, tree):

--- a/skbio/tree/bp/_bp_io.pyx
+++ b/skbio/tree/bp/_bp_io.pyx
@@ -152,9 +152,9 @@ def write_newick(BPTree tree, object output, bint include_edge):
                     output.write(name)
 
             if include_edge:
-                output.write(':%f{%d}' % (length, edge))
+                output.write(':%s{%d}' % (length, edge))
             else:
-                output.write(':%f' % length)
+                output.write(':%s' % length)
 
             if tree.next_sibling(open_paren_stack.pop()) == 0:
                 if idx != root_close:
@@ -162,7 +162,7 @@ def write_newick(BPTree tree, object output, bint include_edge):
             else:
                 output.write(',')
 
-    output.write(';')
+    output.write(';\n')
 
 
 cpdef parse_newick(unicode data):

--- a/skbio/tree/tests/bp/test_bp.py
+++ b/skbio/tree/tests/bp/test_bp.py
@@ -395,6 +395,29 @@ class BPTests(TestCase):
             self.assertEqual(obs.name(i), self.bptree.name(i))
             self.assertEqual(obs.length(i), self.bptree.length(i))
 
+    def test_to_from_npz_roundtrip(self):
+        # to_npz/from_npz are the binary serialization path, separate from the
+        # registry-backed read/write. They preserve topology, names, and
+        # lengths (edge numbers are not stored).
+        names = np.array(['r', '2', '3', None, '4', None, '5', '6', None, None,
+                          None, '7', None, '8', '9', '10', None, '11', None,
+                          None, None, None])
+        lengths = np.array([0, 1, 2, 0, 3, 0, 4, 5, 0, 0, 0, 6, 0, 7, 8, 9, 0,
+                            10, 0, 0, 0, 0], dtype=np.double)
+        self.bptree.set_names(names)
+        self.bptree.set_lengths(lengths)
+
+        buf = io.BytesIO()
+        self.bptree.to_npz(buf)
+        buf.seek(0)
+        obs = BPTree.from_npz(buf)
+
+        npt.assert_equal(obs.data, self.bptree.data)
+        for i in range(obs.data.size):
+            self.assertEqual(obs.name(i), self.bptree.name(i))
+            self.assertEqual(obs.length(i), self.bptree.length(i))
+        self.assertEqual(obs.count(tips=True), self.bptree.count(tips=True))
+
 
 if __name__ == '__main__':
     main()

--- a/skbio/tree/tests/bp/test_bp.py
+++ b/skbio/tree/tests/bp/test_bp.py
@@ -347,7 +347,9 @@ class BPTests(TestCase):
         self.assertEqual(self.bptree.length(7), 5.43)
 
     def test_write_read_roundtrip(self):
-        # give the tree names and lengths so the round-trip has data to preserve
+        # BPTree.read/write delegate to the skbio.io registry; the default
+        # format is newick. Give the tree names and lengths so the round-trip
+        # has data to preserve.
         names = np.array(['r', '2', '3', None, '4', None, '5', '6', None, None,
                           None, '7', None, '8', '9', '10', None, '11', None,
                           None, None, None])
@@ -357,12 +359,12 @@ class BPTests(TestCase):
         self.bptree.set_lengths(lengths)
 
         # round-trip through a file-like object
-        buf = io.BytesIO()
+        buf = io.StringIO()
         self.bptree.write(buf)
         buf.seek(0)
         obs = BPTree.read(buf)
 
-        # topology, names, and lengths are preserved (edges are not stored)
+        # topology, names, and lengths are preserved
         npt.assert_equal(obs.data, self.bptree.data)
         for i in range(obs.data.size):
             self.assertEqual(obs.name(i), self.bptree.name(i))
@@ -380,9 +382,7 @@ class BPTests(TestCase):
         self.bptree.set_names(names)
         self.bptree.set_lengths(lengths)
 
-        # np.savez_compressed appends ".npz" to a bare filename, so the path
-        # must already carry that suffix to round-trip via read()
-        fd, path = tempfile.mkstemp(suffix='.npz')
+        fd, path = tempfile.mkstemp(suffix='.nwk')
         os.close(fd)
         try:
             self.bptree.write(path)


### PR DESCRIPTION
## Summary

Wire `BPTree`'s newick I/O into the `skbio.io` registry so it behaves like `TreeNode`: `BPTree.read()` / `BPTree.write()` delegate to the registry, with `newick` as the default write format. Reading and writing never materialize a `TreeNode` (or any per-node object) — the parenthesis, name, length, and edge arrays are built and serialized directly — and both paths are backed by the existing compiled (Cython) parser, so they stay fast on very large trees.

Addresses the review feedback on #2498 asking that `BPTree` read/write newick through the shared registry rather than as bespoke methods.

## What's in this PR

- `BPTree.read` / `BPTree.write` now route through `skbio.io` (`default_write_format = "newick"`), mirroring `TreeNode`.
- A `newick` reader and writer registered for `BPTree` in `skbio/io/format/newick.py`, implemented as thin adapters over the compiled `parse_newick` / `write_newick`.
- The former npz serialization is **kept, not removed** — it moves to dedicated `BPTree.to_npz` / `BPTree.from_npz` methods (logic unchanged) now that `read`/`write` carry the registry meaning. `.npz` stores topology, names, and branch lengths (not edge numbers).

## Design note (grammar)

The `BPTree` reader uses the compiled newick scanner rather than the shared pure-Python tokenizer, so `convert_underscores` does not apply to it (underscores in unquoted `BPTree` labels are preserved literally) and `[N]` is read as an edge number rather than a comment. This is documented in the format docstring.

## Scope / follow-ups

Deliberately scoped to **newick only**. Planned as separate follow-up PRs:

- **jplace** as its own `skbio.io` format (per @qiyunzhu's suggestion).

## Testing

- New `TestNewickBPTree`: exact BP arrays, `{N}` edge numbers, write round-trips, registry read + sniffing, and error handling.
- `BPTree` newick round-trips via `read`/`write`, plus a `to_npz`/`from_npz` round-trip test.
- Full `skbio/io` and `skbio/tree` suites pass, plus the newick doctest.

Please complete the following checklist:
* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [x] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.
* [x] This pull request does not include code, documentation, or other content derived from external source(s).