### PR TITLE
DOC: note the default-device requirement of the Numba GPU kernels

### DIFF
--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -321,6 +321,15 @@ def mantel(
     to the array-API path, which runs on the device regardless. The result is
     identical across all paths.
 
+    With ``engine="numba"``, GPU buffers must belong to the default device. On a
+    system with several devices, the default must be changed to match the buffer
+    ownership before this function is invoked, through
+    ``numba.cuda.select_device`` on CUDA or ``numba.hip.select_device`` on ROCm.
+    A mismatch is not reported when the kernel is launched, and on ROCm it has
+    been observed to leave the GPU context unusable for the rest of the process.
+    The array-API path, taken when ``engine="numba"`` is not requested, honors
+    whichever device the input is on.
+
     ``np.nan`` will be returned for the p-value if `permutations` is zero or if
     the correlation coefficient is ``np.nan``. The correlation coefficient will
     be ``np.nan`` if one or both of the inputs does not have any variation

--- a/skbio/stats/distance/_permanova.py
+++ b/skbio/stats/distance/_permanova.py
@@ -493,6 +493,15 @@ def permanova(
     to the array-API path, which runs on the device regardless. The result is
     identical across all paths.
 
+    With ``engine="numba"``, GPU buffers must belong to the default device. On a
+    system with several devices, the default must be changed to match the buffer
+    ownership before this function is invoked, through
+    ``numba.cuda.select_device`` on CUDA or ``numba.hip.select_device`` on ROCm.
+    A mismatch is not reported when the kernel is launched, and on ROCm it has
+    been observed to leave the GPU context unusable for the rest of the process.
+    The array-API path, taken when ``engine="numba"`` is not requested, honors
+    whichever device the input is on.
+
     See [1]_ for the original method reference, as well as ``vegan::adonis``,
     available in R's vegan package [2]_.
 

--- a/web/devdoc/array_api.rst
+++ b/web/devdoc/array_api.rst
@@ -209,3 +209,32 @@ A few cross-backend differences come up often enough to call out:
 - Some array API standard functions are unimplemented in certain
   backends. Check the library's documentation if you hit
   ``AttributeError`` on ``xp``.
+
+Multi-GPU systems
+-----------------
+
+The array-API paths honor whichever device the input array is on, because
+every intermediate is allocated with ``device=`` taken from the input.
+
+The fused Numba GPU kernels (currently ``permanova`` and ``mantel`` with
+``engine="numba"``) do not. They allocate and launch on Numba's *current*
+device. GPU buffers must therefore belong to the default device. If you use
+multiple devices, change the default to match the buffer ownership before
+invoking these functions::
+
+    from numba import cuda        # use hip instead of cuda on ROCm
+
+    cuda.select_device(buffer_device_ordinal)
+    result = permanova(dm, grouping, engine="numba")
+
+The failure mode is worth knowing, because it is not a clean error. The
+``__cuda_array_interface__`` protocol carries no device field, so nothing in
+the handoff identifies which device the buffer belongs to. Launching against a
+buffer from another device reports nothing at launch time; on ROCm the illegal
+access has been observed to surface only at the next synchronizing call, and
+to leave the GPU context unusable for the remainder of the process, so a later
+and entirely valid operation fails instead.
+
+The array-API path has no such constraint and is device-correct on any GPU.
+Contributors adding new Numba GPU kernels should be aware of the same
+limitation.


### PR DESCRIPTION
## Summary

Following on from the multi-GPU discussion, this documents the default-device requirement as a known limitation rather than changing the behaviour.

## What changed

The fused Numba GPU kernels for `permanova` and `mantel` allocate and launch on Numba's current device, so a GPU buffer belonging to a different device is not supported. Nothing detects the mismatch: `__cuda_array_interface__` carries no device field, the launch itself reports no error, and on ROCm the illegal access surfaces only at the next synchronizing call and leaves the GPU context unusable for the rest of the process, so a later and entirely valid operation fails instead.

I added a paragraph to the `permanova` and `mantel` docstrings, directly after the existing ROCm-PyTorch note so the GPU caveats read together, and a "Multi-GPU systems" section to the array API developer page. Both state that GPU buffers must belong to the default device, and that on a system with several devices the default has to be changed to match the buffer ownership before the call, through `numba.cuda.select_device` or `numba.hip.select_device`. Both also note the array-API path is unaffected, which I checked rather than assumed: its allocations all take `device=` from the input.

## Verification

I tested this on an eight-GPU MI300X node rather than describing it from the source. With a torch buffer on device 1 and Numba's context on device 0, the launch returns without error and the failure surfaces at the copy back as `HipAPIError [700] hipErrorIllegalAddress` against `cuMemcpyDtoH`, after which a valid same-device operation in the same process also fails. Selecting the buffer's device beforehand gives correct results, which is the workaround documented here. The same-device control in the same process was correct throughout.

I could not test the CUDA equivalent, since the NVIDIA machine available to me has a single GPU, so the context behaviour is attributed to ROCm only rather than stated generally.

## Note

Docs only, no code or behaviour changes. I left the CHANGELOG alone since this adds no public API and #2523 currently has a conflict there, but happy to add an entry if you would prefer one.

@sfiligoi
