### PR TITLE
BUG: fix three GPU-only failures in the array-API paths

### DIFF
--- a/skbio/stats/ordination/_principal_coordinate_analysis.py
+++ b/skbio/stats/ordination/_principal_coordinate_analysis.py
@@ -419,7 +419,9 @@ def pcoa(
     num_positive = (eigvals >= 0).sum()
     # Create a mask to set negative eigenvalues to 0 and their corresponding
     # eigenvectors to 0 because JAX does not have in-place operations.
-    idx = xp.arange(eigvals.shape[0])
+    # `num_positive` lives on the eigenvalues' device, so `idx` has to be created
+    # there as well; otherwise the comparison mixes a host and a device array.
+    idx = xp.arange(eigvals.shape[0], device=eigvals.device)
     mask = idx < num_positive
 
     eigvals = xp.where(mask, eigvals, 0)

--- a/skbio/table/_tabular.py
+++ b/skbio/table/_tabular.py
@@ -15,6 +15,23 @@ import pandas as pd
 from ._base import _table_to_numpy
 from skbio._config import get_config
 from skbio.util import get_package
+from skbio.util._array import _to_numpy
+
+import array_api_compat as _aac
+
+
+def _to_host(data):
+    """Bring a non-NumPy array-API buffer back to the host.
+
+    The table backends (pandas, NumPy, polars) are all host-side, so a
+    GPU-resident result has to be transferred before a table can be built from
+    it: CuPy refuses the implicit conversion outright and PyTorch refuses it for
+    a CUDA tensor. Anything that is not a non-NumPy array-API object (NumPy
+    arrays, DataFrames, lists, dicts) is passed through untouched.
+    """
+    if _aac.is_array_api_obj(data) and not _aac.is_numpy_array(data):
+        return _to_numpy(data)
+    return data
 
 
 def _create_table(data, columns=None, index=None, backend=None):
@@ -40,6 +57,8 @@ def _create_table(data, columns=None, index=None, backend=None):
     """
     if backend is None:
         backend = get_config("table_output")
+
+    data = _to_host(data)
 
     if backend == "pandas":
         return pd.DataFrame(data, index=index, columns=columns)
@@ -78,6 +97,8 @@ def _create_table_1d(data, index=None, backend=None):
     """
     if backend is None:
         backend = get_config("table_output")
+
+    data = _to_host(data)
 
     if backend in ("pandas"):  # , "biom"):
         return pd.Series(data, index=index)

--- a/skbio/util/_array.py
+++ b/skbio/util/_array.py
@@ -78,8 +78,10 @@ def _get_array(arr: ArrayLike, /, *, to_numpy: bool = False) -> StdArray:
         # For array objects that doesn't have the `__dlpack__` protocol (e.g., Dask,
         # at the time of coding), or array objects that are not on the same device
         # (e.g., cuda), `np.asarray` is called as a fallback, which should work for
-        # objects that have an `__array__` protocol.
-        except (AttributeError, TypeError, RuntimeError):
+        # objects that have an `__array__` protocol. NumPy raises `BufferError`
+        # ("Unsupported device in DLTensor") for a GPU-resident buffer, so that
+        # must be caught here too, otherwise the device fallback never runs.
+        except (AttributeError, TypeError, RuntimeError, BufferError):
             arr = _to_numpy(arr)
 
     return arr


### PR DESCRIPTION
## Summary

Turning on the GPU CI job on #2523 surfaced six failing tests across torch, jax and cupy. They come from three separate places, none of them new: they only manifest on a device, so the CPU jobs stayed green and nothing caught them until the GPU job ran. This fixes all three.

## What changed

`_get_array`'s fallback for converting a non-NumPy array to NumPy catches AttributeError, TypeError and RuntimeError, but `np.from_dlpack` raises BufferError for a GPU-resident buffer. The comment above that except clause already describes the CUDA case, so the fallback was meant to fire and never did. I added BufferError to the tuple. This is what the four failing mantel tests were hitting.

In `pcoa`, `xp.arange(eigvals.shape[0])` was created without a device, so on a device-resident input the mask was built on the host while the eigenvalues were on the GPU, and comparing it against `num_positive` failed. It now takes `device=eigvals.device`.

The third is the table constructors. `_create_table` and `_create_table_1d` build pandas, NumPy or polars objects, all host-side, but nothing brought a device-resident array back first: CuPy refuses the implicit conversion outright and PyTorch refuses it for a CUDA tensor. Igor asked that this be fixed for everyone rather than just in the caller that happened to fail, so instead of patching `pcoa` I added a `_to_host` helper that runs at the top of both constructors, covering all 36 call sites across the ordination modules and the ordination IO format. It is guarded to a non-NumPy array-API object, so for NumPy arrays, DataFrames and lists, which is everything the existing callers pass, it returns immediately and behaviour is unchanged.

Worth noting the ordering, since it is not obvious from the CI log: torch fails at the `arange` line before it ever reaches the table code, while cupy gets past it and fails in the tables. Fixing either one alone would have left the other backend red.

## Verification

I ran the CI command itself, `pytest -m array_api --pyargs skbio`, on an NVIDIA RTX 4060, since that is the vendor the CI job failed on:

| Backend | Before | After |
|---|---|---|
| torch | 6 failed, 48 passed | 48 passed |
| jax | failed | 48 passed |
| cupy | failed | 48 passed |

Also 16 passed on an AMD MI300X under torch-ROCm, so both vendors are covered. On CPU the ordination, table, IO and distance suites pass unchanged on numpy, torch and jax.

These are pre-existing bugs rather than regressions from this PR. The pcoa ones were found by the backend tests added in #2520, which were the first thing to run pcoa on a GPU, and the `arange` line came in with #2403.

## Note

I left the CHANGELOG alone. All three bugs are in code that has not been released, so no user has hit them, and #2523 only just came out of a CHANGELOG conflict. Happy to add a Bug Fixes entry if you would rather have one.

@sfiligoi
