### PR TITLE
Updating unit test coverage calculation and reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,7 @@ coverage:
         target: 80%
 
 ignore:
-  - "*/tests/*"
-  - "test_*.py"
+  - "**/tests/**"
+  - "**/test_*.py"
   - "util/_typing.py"
   - "util/_testing.py"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,22 +1,23 @@
 # this file is based on the examples provided on scikit-learn's .coveragerc
 
 [run]
-omit =
-    */tests*
-    */__init__.py
 source = skbio
 branch = True
-include = */skbio/*
 relative_files = True
+omit =
+    **/tests/**
+    **/test_*.py
+    **/__init__.py
 
 [report]
+omit =
+    **/tests/**
+    **/test_*.py
+    **/__init__.py
+    util/_typing.py
+    util/_testing.py
 exclude_lines =
     pass
     pragma: no cover
     raise NotImplementedError
     if __name__ == .__main__.:
-omit =
-    */tests/*
-    */__init__.py
-    util/_typing.py
-    util/_testing.py


### PR DESCRIPTION
The previous file path pattern `*/tests/*` is no longer effective and unexpectedly involved test files into the calculation. This PR fixes it as `**/tests/**`.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
