### PR TITLE
MAINT: run the Numba GPU kernels in array-API CI and report coverage

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -44,7 +44,15 @@ jobs:
         env:
           SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
           SKBIO_DEVICE: cpu
-        run: cd ci && pytest -m array_api --pyargs skbio
+        run: cd ci && coverage run --rcfile ../pyproject.toml -m pytest -m array_api --pyargs skbio
+
+      - name: Generate coverage reports
+        run: cd ci && coverage lcov --rcfile ../pyproject.toml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: scikit-bio/scikit-bio
 
   test-gpu:
     if: |
@@ -83,6 +91,10 @@ jobs:
             cupy)  pip install cupy-cuda12x[ctk] ;;
           esac
           pip install -r ci/requirements.txt -r ci/requirements.test.txt
+          # numba-cuda is what lets the fused GPU kernels actually run here.
+          # Without it `engine="numba"` cannot resolve and the kernel modules
+          # are never executed, so they show up as uncovered.
+          pip install "numba-cuda[cu12]"
 
       - name: Verify GPU is visible to backend
         env:
@@ -108,8 +120,28 @@ jobs:
               print("cupy:", cupy.__version__, "devices:", n)
           PY
 
+      - name: Verify Numba can target the GPU
+        # Without this the job still passes when numba-cuda is missing or cannot
+        # find NVVM: the fused kernel is simply skipped and every test takes the
+        # array-API fallback, so the GPU kernels would look tested when they were
+        # never run.
+        run: |
+          python - <<'PY'
+          from numba import cuda
+          assert cuda.is_available(), "numba.cuda cannot target this GPU"
+          print("numba.cuda devices:", cuda.gpus)
+          PY
+
       - name: Run tests
         env:
           SKBIO_ARRAY_BACKEND: ${{ matrix.backend }}
           SKBIO_DEVICE: ${{ matrix.device }}
-        run: cd ci && pytest -m array_api --pyargs skbio
+        run: cd ci && coverage run --rcfile ../pyproject.toml -m pytest -m array_api --pyargs skbio
+
+      - name: Generate coverage reports
+        run: cd ci && coverage lcov --rcfile ../pyproject.toml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: scikit-bio/scikit-bio

--- a/skbio/stats/distance/_mantel_gpu.py
+++ b/skbio/stats/distance/_mantel_gpu.py
@@ -40,7 +40,8 @@ def _build_kernel(gpu):
     from numba import float64 as nb_f64
 
     @gpu.jit
-    def _mantel_r(n_dims, mat, perm_order, ym_norm, mul, add, out):
+    def _mantel_r(n_dims, mat, perm_order, ym_norm, mul, add, out):  # pragma: no cover
+        # runs on the device; coverage.py cannot instrument compiled PTX
         p = gpu.blockIdx.x              # one block per permutation
         t = gpu.threadIdx.x
         tile = gpu.blockDim.x           # == _TPB

--- a/skbio/stats/distance/_permanova_gpu.py
+++ b/skbio/stats/distance/_permanova_gpu.py
@@ -43,7 +43,8 @@ def _build_kernel(gpu):
     from numba import float64 as nb_f64, int64 as nb_i64
 
     @gpu.jit
-    def _pmn_sW(n_dims, mat, groupings, inv_gs, out_sW):
+    def _pmn_sW(n_dims, mat, groupings, inv_gs, out_sW):  # pragma: no cover
+        # runs on the device; coverage.py cannot instrument compiled PTX
         gel = gpu.blockIdx.x            # one block per permutation
         icol = gpu.threadIdx.x
         tile = gpu.blockDim.x           # == _TPB

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -1228,6 +1228,28 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
             self.assertAlmostEqual(r, r_ref, places=10)
             self.assertAlmostEqual(p, p_ref, places=10)
 
+    @numba_code
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_mantel_numba_engine_backends(self, xp, device):
+        # `engine="numba"` on device-resident matrices is what routes to the
+        # fused GPU kernel; on NumPy it exercises the CPU numba engine. Skipped
+        # automatically where Numba or the device is unavailable.
+        for method in ("pearson", "spearman"):
+            r_ref, p_ref, _ = mantel(
+                DistanceMatrix(self.x), DistanceMatrix(self.y),
+                method=method, permutations=99, seed=0,
+            )
+            mx = DistanceMatrix(self.make_array(xp, device, self.x))
+            my = DistanceMatrix(self.make_array(xp, device, self.y))
+            r, p, _ = mantel(
+                mx, my, method=method, permutations=99, seed=0, engine="numba"
+            )
+            # Default tolerance, as in the other engine="numba" tests: the fused
+            # kernel sums in a different order than Cython, so r is not expected
+            # to agree bit for bit.
+            self.assertAlmostEqual(r, r_ref)
+            self.assertAlmostEqual(p, p_ref)
+
     @array_backends("numpy", "jax", "torch", "cupy")
     def test_spearman_ties_backends(self, xp, device):
         # integer distances with repeats -> tied ranks, exercising the

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -23,7 +23,7 @@ from skbio.stats.distance import _mantel as mantel_mod
 from skbio.stats.distance._mantel import _order_dms
 from skbio.stats.distance._mantel import _mantel_stats_pearson
 from skbio.stats.distance._mantel import _mantel_stats_spearman
-from skbio.stats.distance._mantel_gpu import _perm_order
+from skbio.stats.distance._mantel_gpu import _perm_order, _run_mantel_gpu
 from skbio.stats.distance._cutils import (mantel_perm_pearsonr_cy,
                                           mantel_perm_pearsonr_condensed_cy)
 from skbio.stats.distance._utils import distmat_reorder_condensed
@@ -1250,6 +1250,42 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
             self.assertAlmostEqual(r, r_ref)
             self.assertAlmostEqual(p, p_ref)
 
+    @numba_code
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_mantel_numba_engine_alternative_backends(self, xp, device):
+        # the fused kernel's stats feed a p-value formula with three branches
+        # on `alternative`; only "two-sided" is exercised above.
+        mx = DistanceMatrix(self.make_array(xp, device, self.x))
+        my = DistanceMatrix(self.make_array(xp, device, self.y))
+        for alternative in ("greater", "less"):
+            r_ref, p_ref, _ = mantel(
+                DistanceMatrix(self.x), DistanceMatrix(self.y),
+                permutations=99, seed=0, alternative=alternative,
+            )
+            r, p, _ = mantel(
+                mx, my, permutations=99, seed=0, alternative=alternative,
+                engine="numba",
+            )
+            self.assertAlmostEqual(r, r_ref)
+            self.assertAlmostEqual(p, p_ref)
+
+    @numba_code
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_mantel_numba_engine_float32_backends(self, xp, device):
+        # the kernel's per-element math stays in the matrix dtype; float32 is
+        # the common case on consumer GPUs and untested on this path otherwise.
+        r_ref, p_ref, _ = mantel(
+            DistanceMatrix(self.x), DistanceMatrix(self.y),
+            permutations=99, seed=0,
+        )
+        mx = DistanceMatrix(self.make_array(xp, device, self.x, dtype=xp.float32))
+        my = DistanceMatrix(self.make_array(xp, device, self.y, dtype=xp.float32))
+        r, p, _ = mantel(mx, my, permutations=99, seed=0, engine="numba")
+        # float32 input -> agreement at float32 precision, as in the CPU numba
+        # float32 test: the kernel accumulates in float64 but reads float32.
+        self.assertAlmostEqual(r, r_ref, places=5)
+        self.assertAlmostEqual(p, p_ref)
+
     @array_backends("numpy", "jax", "torch", "cupy")
     def test_spearman_ties_backends(self, xp, device):
         # integer distances with repeats -> tied ranks, exercising the
@@ -1428,6 +1464,45 @@ class MantelGpuHostTests(TestCase):
                                  permutations=perms, seed=0, engine="cython")
         self.assertAlmostEqual(comp_stat, r_ref, places=10)
         self.assertEqual(p_value, p_ref)
+
+    def test_run_mantel_gpu_validation(self):
+        # same validation as _mantel_stats_pearson_xp; a NumPy array reaches
+        # these checks before ``gpu`` is touched, so ``None`` stands in for it.
+        with self.assertRaises(ValueError):  # shape mismatch
+            _run_mantel_gpu(None, self.x.data, self.y.data[:9, :9], 0,
+                            get_rng(0), "two-sided")
+        with self.assertRaises(ValueError):  # not square
+            _run_mantel_gpu(None, np.zeros((3, 4)), np.zeros((3, 4)), 0,
+                            get_rng(0), "two-sided")
+        with self.assertRaises(ValueError):  # fewer than 3 objects
+            _run_mantel_gpu(None, np.zeros((2, 2)), np.zeros((2, 2)), 0,
+                            get_rng(0), "two-sided")
+        const = np.ones((5, 5))
+        np.fill_diagonal(const, 0.0)
+        with self.assertWarns(ConstantInputWarning):
+            r, p, _ = _run_mantel_gpu(None, const, self.x.data[:5, :5], 0,
+                                      get_rng(0), "two-sided")
+        self.assertTrue(np.isnan(r))
+        self.assertTrue(np.isnan(p))
+
+    def test_run_mantel_gpu_near_constant_and_no_permutations(self):
+        # near-constant input warns but still returns a statistic; permutations=0
+        # returns a NaN p-value. Both branches return before the kernel launch,
+        # so ``gpu=None`` is never touched.
+        rng = np.random.default_rng(0)
+        near_const = np.full((5, 5), 1.0) + rng.random((5, 5)) * 1e-14
+        near_const = (near_const + near_const.T) / 2.0
+        np.fill_diagonal(near_const, 0.0)
+        with self.assertWarns(NearConstantInputWarning):
+            r, p, _ = _run_mantel_gpu(None, near_const, self.y.data[:5, :5], 0,
+                                      get_rng(0), "two-sided")
+        self.assertFalse(np.isnan(r))
+        self.assertTrue(np.isnan(p))
+
+        r, p, _ = _run_mantel_gpu(None, self.x.data, self.y.data, 0,
+                                  get_rng(0), "two-sided")
+        self.assertFalse(np.isnan(r))
+        self.assertTrue(np.isnan(p))
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -571,6 +571,24 @@ class PermanovaArrayAPITests(TestCase, ArrayAPITestMixin):
         self.assertAlmostEqual(res['test statistic'], self.ref['test statistic'])
         self.assertAlmostEqual(res['p-value'], self.ref['p-value'])
 
+    @numba_code
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_permanova_numba_engine_float32_backends(self, xp, device):
+        # the kernel's per-element math stays in the matrix dtype; float32 is
+        # the common case on consumer GPUs and untested on this path otherwise.
+        dm = DistanceMatrix(
+            self.make_array(xp, device, self.data, dtype=xp.float32)
+        )
+        res = permanova(
+            dm, self.grouping, permutations=99, seed=0, engine="numba"
+        )
+        # float32 input -> agreement at float32 precision, as in the CPU numba
+        # float32 test: the kernel accumulates in float64 but reads float32.
+        self.assertAlmostEqual(
+            res['test statistic'], self.ref['test statistic'], places=5
+        )
+        self.assertAlmostEqual(res['p-value'], self.ref['p-value'])
+
     def test_permanova_array_api_numpy_backend(self):
         # NumPy is array-API compatible, so the array-API compute path runs on a
         # NumPy array. The dispatch routes a NumPy DistanceMatrix to the
@@ -651,6 +669,15 @@ class PermanovaGpuHostTests(TestCase):
                 gpu_mod._mark_gpu_unavailable(arr)  # must not warn again
         finally:
             gpu_mod._unavailable.discard("numpy")
+
+    def test_assemble_fp_no_permutations(self):
+        # permutations=0 -> NaN p-value rather than a count over an empty slice.
+        # pseudo-F for s_T=10, s_W=2, n=8, k=2 is (8/1) / (2/6) = 24.
+        f, p = _assemble_fp(
+            np.array([2.0]), s_T=10.0, sample_size=8, num_groups=2, permutations=0
+        )
+        self.assertAlmostEqual(f, 24.0)
+        self.assertTrue(np.isnan(p))
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permanova.py
+++ b/skbio/stats/distance/tests/test_permanova.py
@@ -555,6 +555,22 @@ class PermanovaArrayAPITests(TestCase, ArrayAPITestMixin):
         )
         self.assertAlmostEqual(res['p-value'], self.ref['p-value'], places=10)
 
+    @numba_code
+    @array_backends("numpy", "jax", "torch", "cupy")
+    def test_permanova_numba_engine_backends(self, xp, device):
+        # `engine="numba"` on a device-resident matrix is what routes to the
+        # fused GPU kernel; on NumPy it exercises the CPU numba engine. Skipped
+        # automatically where Numba or the device is unavailable.
+        dm = DistanceMatrix(self.make_array(xp, device, self.data))
+        res = permanova(
+            dm, self.grouping, permutations=99, seed=0, engine="numba"
+        )
+        # Default tolerance, as in the other engine="numba" tests above: the
+        # fused kernel sums in a different order than Cython, so the statistic
+        # is not expected to agree bit for bit.
+        self.assertAlmostEqual(res['test statistic'], self.ref['test statistic'])
+        self.assertAlmostEqual(res['p-value'], self.ref['p-value'])
+
     def test_permanova_array_api_numpy_backend(self):
         # NumPy is array-API compatible, so the array-API compute path runs on a
         # NumPy array. The dispatch routes a NumPy DistanceMatrix to the


### PR DESCRIPTION
Builds on #2530.

### Description

The array-API GPU job runs `pytest -m array_api`, and until now no test in that selection ever reached the fused Numba GPU kernels. `array_api` and `numba` are two independent markers, but nothing carried both: on `development_numba_gpu`, `pytest -m "array_api and numba"` collects 0 tests. Every numba-marked test uses NumPy inputs, and the GPU dispatch in `_permanova` and `_mantel` is gated on the buffer not being NumPy, so those tests take the CPU Numba engine regardless of which runner they land on. The result is that the fused kernels in `_permanova_gpu.py` and `_mantel_gpu.py` were never executed in CI. The pure-NumPy helpers in those files (`_permutation_batch`, `_assemble_fp`, `_perm_order`) are already covered by the unfiltered suite in `ci.yml`; it is the GPU paths that nothing reached.

This adds tests to `PermanovaArrayAPITests` and `MantelArrayAPITests` that stack `@numba_code` on top of `@array_backends(...)`, so the test is both device-resident and passes `engine="numba"`. Stacking is safe because `numba_code` applies `unittest.skip` when Numba is absent and `array_backends` already skips backend and device combinations that are not available, so the tests are inert everywhere they cannot run. The marker intersection goes from 0 to 5.

Alongside those, the host-side branches of the GPU path get tests that need no GPU at all. `_run_mantel_gpu` validates its inputs and handles constant, near-constant and zero-permutation cases before it ever touches its `gpu` argument, so those branches can be driven directly on NumPy input, as can `_assemble_fp` with no permutations. These live in the existing `MantelGpuHostTests` and `PermanovaGpuHostTests` classes, which already exist for exactly this purpose.

Every new test was checked by mutating the code it covers and confirming it fails: removing each validation branch, flipping the no-permutation p-value away from NaN, and returning a wrong result from the fused kernel on the GPU, which all five device-resident tests catch.

Running those tests needs Numba to be able to target the GPU, so the GPU job now installs `numba-cuda[cu12]`, matching the CUDA 12 stack the job already pins for torch, JAX and CuPy. It also gains an explicit check that `numba.cuda.is_available()` is true. That check is deliberate rather than decorative: without it, a missing or broken install makes `_numba_gpu_module_for` return `None`, every test quietly takes the array-API fallback, and the job stays green while the kernels it is supposed to cover never run.

Finally, both array-API jobs now run under `coverage` and upload to Codecov, mirroring `ci.yml`. `array-api.yml` had no coverage step at all, so everything it exercised was invisible in the coverage report. This is the reason the GPU support files looked untested: partly nothing ran the kernel paths, and partly this workflow measured nothing.

One behavior worth stating explicitly: `_numba_gpu_module_for` returns `None` for anything that is not CuPy or PyTorch, so the JAX GPU job exercises the array-API fallback rather than the fused kernel. That is by design. Torch and CuPy are the two backends that reach `_permanova_gpu` and `_mantel_gpu`.

The GPU job keeps its `-m array_api` selection rather than widening to `-m "array_api or numba"`. The union would add the 15 existing numba tests, but all of them use NumPy inputs and would run the CPU Numba engine on the GPU runner, duplicating what `numba.yml` already covers without touching a kernel. Carrying both markers on the new tests is what actually puts the fused kernels in the GPU job's selection.

On pull requests the GPU job only runs when the `gpu-ci` label is applied. The scheduled and manual runs are unaffected.

### Coverage

Three things were suppressing the number on these files: `array-api.yml` had no coverage step at all, the GPU code paths were never run, and the fused kernel bodies were being counted as missable statements when they can never be measured.

The last one needs explaining. The bodies of the `@gpu.jit` kernels compile to PTX and execute on the device, so CPython never runs them and `coverage.py` cannot instrument them, no matter how thoroughly the kernel is tested. They are 56 of the 98 statements in `_permanova_gpu.py` and 48 of the 123 in `_mantel_gpu.py`, which is why those files looked almost untested. I confirmed there is no way around this rather than assuming it: Numba's CUDA simulator (`NUMBA_ENABLE_CUDASIM`) swaps the `cuda` module by scanning the kernel function's `__globals__`, and these kernels reach their GPU module through a closure parameter so that the same builder can target `numba.cuda` or `numba.hip`. A closure is not a global, so the simulator cannot drive them.

Both kernels are therefore marked `# pragma: no cover`, which is already the convention here (`skbio/util/_gpu.py`, `_typing.py`). The kernels are still verified, just not by line coverage: their output is compared against the Cython and array-API results on real hardware.

With that, and with the new host-side tests, measured on this branch:

| File | on `development_numba_gpu` | `-m array_api` on an RTX 4060 | merged with the unfiltered run |
|---|---|---|---|
| `_gpu.py` | 19% | 65% | **79%** |
| `_mantel_gpu.py` | 5% | 87% | **100%** |
| `_permanova_gpu.py` | 7% | 96% | **100%** |
| total | 8% | 84% | **95%** |

The first column is the current state, on the old denominator; the pragma accounts for part of the gain on the two kernel files and the new tests for the rest. Codecov merges uploads per commit, so the last column is what the report should settle at once both workflows upload.

What is still uncovered is all in `_gpu.py`: the CuPy branch, which needs a working CuPy install, and the two `except Exception: return None` fallbacks for a failed Numba import or a raising `is_available()`. The fallbacks are reachable only by mocking the libraries under test, so I left them alone.

### Testing

Locally, per backend, as CI invokes it:

```
SKBIO_ARRAY_BACKEND=torch SKBIO_DEVICE=cpu pytest -m "array_api or numba" skbio/   # 68 passed
SKBIO_ARRAY_BACKEND=jax   SKBIO_DEVICE=cpu pytest -m "array_api or numba" skbio/   # 68 passed
```

On an NVIDIA RTX 4060, against this branch, with the fused kernel entry instrumented:

```
SKBIO_ARRAY_BACKEND=torch SKBIO_DEVICE=cuda pytest -k "numba_engine or GpuHost" skbio/stats/distance/   # 13 passed
```

With the torch backend both `_run_permanova_gpu` and `_run_mantel_gpu` are entered and complete with no fallback to the array-API path. With the JAX backend the kernels are correctly not entered, which is the intended behavior since `_numba_gpu_module_for` only maps CuPy and PyTorch.

CuPy was not verified on GPU hardware: the CuPy install on the box available to me fails inside its own NVRTC compilation for reasons unrelated to this change, and 45 pre-existing array-API tests fail there with the new tests excluded.
