### PR TITLE
BUG: preserve non-zero diagonal in SymmetricMatrix.filter/permute on condensed matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
 * Patched `rclr` such that it won't raise a zero division warning ([#2526](https://github.com/scikit-bio/scikit-bio/pull/2526)).
+* Fixed `SymmetricMatrix.filter` and `SymmetricMatrix.permute` silently resetting a non-zero diagonal to `0` when the matrix was stored in condensed form. Both methods reconstructed the result from its condensed representation, which only carries off-diagonal values, without passing the diagonal through. The diagonal is now subset and reordered along with the rows and columns. `DistanceMatrix` is unaffected because it is always hollow ([#2516](https://github.com/scikit-bio/scikit-bio/issues/2516)). Thank @LarytheLord for reporting and diagnosing the root cause.
 
 
 ## Version 0.7.3

--- a/skbio/stats/distance/_base.py
+++ b/skbio/stats/distance/_base.py
@@ -471,6 +471,28 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
             new_ids = tuple(mapper(x) for x in self.ids)
         self.ids = new_ids
 
+    def _diagonal_kwargs(self, idxs=None):
+        """Return constructor keyword arguments that preserve the diagonal.
+
+        Reconstructing a matrix from its condensed form loses the diagonal,
+        because the condensed representation only stores off-diagonal values.
+        Subclasses that carry a meaningful diagonal override this to thread it
+        through. The base matrix has no explicit diagonal, so nothing is added.
+
+        Parameters
+        ----------
+        idxs : sequence of int, optional
+            Row/column indices selecting and ordering the retained entries. If
+            ``None``, the full diagonal is used.
+
+        Returns
+        -------
+        dict
+            Keyword arguments to pass to ``self.__class__``.
+
+        """
+        return {}
+
     def filter(
         self,
         ids: Sequence[str],
@@ -508,7 +530,12 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         """
         if tuple(self._ids) == tuple(ids):
             if self._flags["CONDENSED"]:
-                return self.__class__(self._data, self._ids, condensed=True)
+                return self.__class__(
+                    self._data,
+                    self._ids,
+                    condensed=True,
+                    **self._diagonal_kwargs(),
+                )
             else:
                 return self.__class__(self._data, self._ids)
 
@@ -532,7 +559,13 @@ class PairwiseMatrix(SkbioObject, PlottableMixin):
         if self._flags["CONDENSED"]:
             filtered_data = distmat_reorder_condensed_py(self.condensed_form(), idxs)
             self._validate_ids(filtered_data, ids)
-            return self.__class__(filtered_data, ids, validate=False, condensed=True)
+            return self.__class__(
+                filtered_data,
+                ids,
+                validate=False,
+                condensed=True,
+                **self._diagonal_kwargs(idxs),
+            )
         else:
             filtered_data = distmat_reorder(self.redundant_form(), idxs)
             self._validate_ids(filtered_data, ids)
@@ -1427,6 +1460,34 @@ class SymmetricMatrix(PairwiseMatrix):
         """
         return self._diagonal
 
+    def _diagonal_kwargs(self, idxs=None):
+        """Return ``diagonal=`` keyword arguments to preserve the diagonal.
+
+        A condensed symmetric matrix stores only its off-diagonal values, so
+        the diagonal must be threaded through explicitly when reconstructing
+        via ``self.__class__(..., condensed=True)``. A scalar (uniform)
+        diagonal applies to every position and is passed through unchanged; an
+        array diagonal is subset and reordered by ``idxs`` so it follows the new
+        row/column order (or kept whole when ``idxs`` is ``None``).
+
+        Parameters
+        ----------
+        idxs : sequence of int, optional
+            Row/column indices selecting and ordering the retained entries.
+
+        Returns
+        -------
+        dict
+            ``{"diagonal": ...}``, or an empty dict when no diagonal is set.
+
+        """
+        diag = self._diagonal
+        if diag is None:
+            return {}
+        if idxs is not None and not np.isscalar(diag):
+            diag = np.asarray(diag)[idxs]
+        return {"diagonal": diag}
+
     @classonlymethod
     def from_iterable(
         cls,
@@ -1764,7 +1825,11 @@ class SymmetricMatrix(PairwiseMatrix):
             if self._flags["CONDENSED"]:
                 permuted = distmat_reorder_condensed_py(self._data, order)
                 return self.__class__(
-                    permuted, self.ids, validate=False, condensed=True
+                    permuted,
+                    self.ids,
+                    validate=False,
+                    condensed=True,
+                    **self._diagonal_kwargs(order),
                 )
             else:
                 permuted = distmat_reorder(self._data, order)
@@ -1987,6 +2052,15 @@ class DistanceMatrix(SymmetricMatrix):
         self._diagonal = 0.0
         self._data = self._init_data(data, condensed)
         self._flags = self._init_flags(condensed)
+
+    def _diagonal_kwargs(self, idxs=None):
+        """Distance matrices are always hollow, so no diagonal is threaded.
+
+        Overrides :meth:`SymmetricMatrix._diagonal_kwargs` because
+        ``DistanceMatrix.__init__`` does not accept a ``diagonal`` argument.
+
+        """
+        return {}
 
     def _normalize_input(self, data, ids):
         """Get input into standard numpy array format."""

--- a/skbio/stats/distance/tests/test_base.py
+++ b/skbio/stats/distance/tests/test_base.py
@@ -1219,6 +1219,48 @@ class SymmetricMatrixTestBase(PairwiseMatrixTestData):
             self.dm_3x3_cond.filter([])
         self.assertEqual(str(e.exception), "IDs must be at least 1 in size.")
 
+    # Regression tests for #2516: filter()/permute() must not silently reset a
+    # non-zero diagonal to 0 when the matrix is stored condensed. Note that
+    # __eq__ ignores the diagonal (it only compares the off-diagonal data), so
+    # these assertions read the diagonal explicitly.
+    def test_filter_subset_preserves_diagonal(self):
+        obs = self.dm_5x5_cond_diag.filter(["a", "c", "e"])
+        npt.assert_array_equal(obs.diagonal, [90, 70, 50])
+
+        # subset combined with reordering
+        obs = self.dm_5x5_cond_diag.filter(["c", "a"])
+        npt.assert_array_equal(obs.diagonal, [70, 90])
+
+    def test_filter_reorder_preserves_diagonal(self):
+        obs = self.dm_5x5_cond_diag.filter(["e", "d", "c", "b", "a"])
+        npt.assert_array_equal(obs.diagonal, [50, 60, 70, 80, 90])
+
+    def test_filter_same_ids_preserves_diagonal(self):
+        # exercises the same-ids fast path
+        obs = self.dm_5x5_cond_diag.filter(list("abcde"))
+        npt.assert_array_equal(obs.diagonal, [90, 80, 70, 60, 50])
+
+    def test_filter_scalar_uniform_diagonal_preserved(self):
+        sm = self.matobj([1, 2, 3], ["a", "b", "c"], diagonal=8, condensed=True)
+        obs = sm.filter(["a", "c"])
+        self.assertEqual(obs.diagonal, 8.0)
+
+    def test_permute_preserves_diagonal(self):
+        # seed=2 yields the permutation order [2, 0, 1] for a 3x3 matrix, so the
+        # diagonal and off-diagonal values follow that same reordering.
+        sm = self.matobj(
+            [0.01, 4.2, 12], ["a", "b", "c"], diagonal=[10, 20, 30], condensed=True
+        )
+        obs = sm.permute(seed=2)
+        npt.assert_array_equal(obs.diagonal, [30, 10, 20])
+        npt.assert_array_equal(obs.condensed_form(), [4.2, 12, 0.01])
+
+        # the diagonal of a larger permuted matrix is a permutation of the
+        # original diagonal, never all zeros
+        obs = self.dm_5x5_cond_diag.permute(seed=7)
+        self.assertCountEqual(np.asarray(obs.diagonal).tolist(), [90, 80, 70, 60, 50])
+        self.assertFalse(np.allclose(np.asarray(obs.diagonal), 0.0))
+
     def test_getslice(self):
         # Slice of first dimension only. Test that __getslice__ defers to
         # __getitem__.
@@ -1854,6 +1896,19 @@ class DistanceMatrixTestBase(PairwiseMatrixTestData):
         )
         obs = self.dm_3x3_cond.permute(seed=2)
         self.assertEqual(obs, exp)
+
+    # Regression tests for #2516: DistanceMatrix is always hollow, so filter()
+    # and permute() must keep the diagonal at 0 (and must not raise while the
+    # SymmetricMatrix diagonal fix threads a diagonal through its subclass).
+    def test_filter_preserves_hollow_diagonal(self):
+        obs = self.dm_3x3_cond.filter(["c", "a"])
+        self.assertEqual(obs.diagonal, 0.0)
+        npt.assert_array_equal(np.diag(obs.redundant_form()), [0.0, 0.0])
+
+    def test_permute_preserves_hollow_diagonal(self):
+        obs = self.dm_3x3_cond.permute(seed=2)
+        self.assertEqual(obs.diagonal, 0.0)
+        npt.assert_array_equal(np.diag(obs.redundant_form()), [0.0, 0.0, 0.0])
 
     # TODO: need to test this with SymmetricMatrix vs DistanceMatrix for condensed form
     def test_eq(self):


### PR DESCRIPTION
Fixes #2516.

## Root cause
`SymmetricMatrix.filter()` and `.permute()` reconstruct their result from the condensed form via `self.__class__(..., condensed=True)` without passing `diagonal=`. The condensed representation stores only off-diagonal values, so the constructor defaults the diagonal to 0. A `SymmetricMatrix` stored condensed with a non-zero diagonal therefore has it silently reset to 0 by filter/permute. `DistanceMatrix` never surfaces this because it is always hollow. The failure is silent because `__eq__` compares only the off-diagonal data, not the diagonal.

## Fix
Introduce an overridable helper `_diagonal_kwargs(idxs=None)`:
- `PairwiseMatrix` returns `{}` (no explicit diagonal).
- `SymmetricMatrix` returns `{"diagonal": ...}`, subsetting/reordering an array diagonal by `idxs` and passing a scalar (uniform) diagonal through unchanged (full diagonal when `idxs is None`).
- `DistanceMatrix` overrides back to `{}` (it stays hollow, and its constructor does not accept `diagonal=`). Note `DistanceMatrix` subclasses `SymmetricMatrix`, so this explicit override is required to avoid inheriting the diagonal-threading version.

The helper is threaded through the three condensed reconstruction sites (filter same-ids fast path, filter subset, permute), so `SymmetricMatrix` preserves its diagonal while `DistanceMatrix` is unaffected.

## Tests
Added regression tests: SymmetricMatrix filter (subset, reorder, same-ids, scalar-uniform) and permute preserve the diagonal; DistanceMatrix filter/permute remain hollow. Verified red (assertions fail with diagonal == 0 before the fix) and green (full `test_base.py`: 169 passed) in a clean `python:3.12` container.

## Changelog
Added a Bug Fixes entry referencing #2516.

Credit to @LarytheLord for reporting and diagnosing the root cause.

---
This contribution was prepared with AI assistance and reviewed by me before submission.