### PR TITLE
BUG: keep the mantel fallback reproducible when the GPU kernel fails

### DIFF
--- a/skbio/stats/distance/_mantel.py
+++ b/skbio/stats/distance/_mantel.py
@@ -441,8 +441,6 @@ def mantel(
     ``array_like`` because there is no notion of IDs.
 
     """
-    rng = get_rng(seed)
-
     if method in ("pearson", "spearman"):
         special = True
     elif method == "kendalltau":
@@ -490,7 +488,7 @@ def mantel(
             if gpu is not None:
                 try:
                     return _run_mantel_gpu(
-                        gpu, x.data, y.data, permutations, rng, alternative,
+                        gpu, x.data, y.data, permutations, seed, alternative,
                         spearman=(method == "spearman"),
                     )
                 except Exception:
@@ -498,7 +496,7 @@ def mantel(
                     # it and fall back to the array-API path (correct anywhere).
                     _mark_gpu_unavailable(x.data)
             return _mantel_stats_pearson_xp(
-                x.data, y.data, permutations, rng, alternative,
+                x.data, y.data, permutations, seed, alternative,
                 spearman=(method == "spearman"),
             )
 
@@ -523,11 +521,11 @@ def mantel(
     if special:
         if method == "pearson":
             orig_stat, comp_stat, permuted_stats = _mantel_stats_pearson(
-                x, y, permutations, rng, engine
+                x, y, permutations, seed, engine
             )
         else:
             orig_stat, comp_stat, permuted_stats = _mantel_stats_spearman(
-                x, y, permutations, rng, engine
+                x, y, permutations, seed, engine
             )
 
     else:
@@ -539,6 +537,9 @@ def mantel(
 
         permuted_stats = []
         if not (permutations == 0 or np.isnan(orig_stat)):
+            # This path permutes inside the loop, so it needs one generator that
+            # advances across iterations; a seed would repeat the same draw.
+            rng = get_rng(seed)
             perm_gen = (
                 corr_func(x.permute(condensed=True, seed=rng), y_flat)[0]
                 for _ in range(permutations)
@@ -590,7 +591,7 @@ def _xp_rank_average(xp, a):
     )
 
 
-def _mantel_stats_pearson_xp(x, y, permutations, rng, alternative, spearman=False):
+def _mantel_stats_pearson_xp(x, y, permutations, seed, alternative, spearman=False):
     """Mantel pearson/spearman result in the ``xp`` namespace.
 
     Backend-agnostic equivalent of ``_mantel_stats_pearson``/``_spearman`` for
@@ -600,6 +601,7 @@ def _mantel_stats_pearson_xp(x, y, permutations, rng, alternative, spearman=Fals
 
     Returns ``(orig_stat, p_value, n)``, matching ``mantel``'s return.
     """
+    rng = get_rng(seed)
     xp, X, Y = ingest_array(x, y)
     if X.shape != Y.shape:
         raise ValueError("Distance matrices must have the same shape.")

--- a/skbio/stats/distance/_mantel_gpu.py
+++ b/skbio/stats/distance/_mantel_gpu.py
@@ -29,6 +29,7 @@ from warnings import warn
 
 from scipy.stats import ConstantInputWarning, NearConstantInputWarning
 
+from skbio.util import get_rng
 from skbio.util._array import _get_backend_name
 from ._gpu import _TPB, _get_kernel
 
@@ -114,7 +115,7 @@ def _perm_order(n, permutations, rng):
     return out
 
 
-def _run_mantel_gpu(gpu, x, y, permutations, rng, alternative, spearman=False):
+def _run_mantel_gpu(gpu, x, y, permutations, seed, alternative, spearman=False):
     """Run the Mantel pearson/spearman test with the fused GPU kernel.
 
     Mirrors :func:`._mantel._mantel_stats_pearson_xp`'s preprocessing (upper
@@ -122,6 +123,12 @@ def _run_mantel_gpu(gpu, x, y, permutations, rng, alternative, spearman=False):
     per-permutation array-API loop with the fused kernel on the device-resident
     matrices. ``gpu`` is the Numba module from :func:`._gpu._numba_gpu_module_for`.
     Returns ``(orig_stat, p_value, n)`` to match :func:`._mantel.mantel`.
+
+    Takes ``seed`` rather than a live generator, as
+    :func:`._permanova_gpu._run_permanova_gpu` does. The permutations are drawn
+    before the launch that may fail, so a generator passed in from the caller
+    would come back partly consumed and the array-API fallback would then draw a
+    different set and report a different p-value than an unaccelerated run.
     """
     # Lazy import avoids a circular import (``_mantel`` imports this module).
     from ._mantel import _upper_tri_xp, _xp_rank_average, _device
@@ -186,7 +193,7 @@ def _run_mantel_gpu(gpu, x, y, permutations, rng, alternative, spearman=False):
     if Xsrc.dtype == xp.float32:
         mul, add = np.float32(mul), np.float32(add)
         ym_norm = xp.astype(ym_norm, xp.float32)
-    perm_order = _perm_order(n, permutations, rng)
+    perm_order = _perm_order(n, permutations, get_rng(seed))
 
     kernel = _get_kernel(_kernels, _build_kernel, gpu, _get_backend_name(xp))
     d_perm = gpu.to_device(perm_order)

--- a/skbio/stats/distance/tests/test_mantel.py
+++ b/skbio/stats/distance/tests/test_mantel.py
@@ -1372,7 +1372,7 @@ class MantelArrayAPITests(TestCase, ArrayAPITestMixin):
                 method=method, permutations=99, seed=0,
             )
             r, p, n = mantel_mod._mantel_stats_pearson_xp(
-                self.x, self.y, 99, get_rng(0), "two-sided", spearman=spearman,
+                self.x, self.y, 99, 0, "two-sided", spearman=spearman,
             )
             self.assertEqual(n, self.x.shape[0])
             self.assertAlmostEqual(r, r_ref, places=10)


### PR DESCRIPTION
### Description

`mantel()` creates a single generator with `get_rng(seed)` and passes that same object both to `_run_mantel_gpu` and, when the kernel raises, to `_mantel_stats_pearson_xp`. Inside `_run_mantel_gpu`, `_perm_order` draws the whole permutation batch on the host before the launch that can fail. So when the kernel does fail, the generator has already been advanced by `permutations` draws, and the fallback continues the stream instead of repeating it, producing a different p-value than an unaccelerated run for the same seed.

This is reachable on any machine where the fused kernel cannot build or launch. The array-API GPU job hit it while #2535 was in CI: `alternative="greater"` returned 0.44 where the reference is 0.48, a difference of four permutations landing on the other side of the comparison, on both the torch and CuPy jobs.

It is not limited to the non-default alternatives. Comparing a pristine generator against one that `_perm_order` has already drawn from, the two-sided p-value changes for 9 of 12 random 30x30 matrices at 99 permutations; the three that match are coincidental ties rather than a path that is safe. The two-sided test passed in that CI run only because the tests run alphabetically, so the first test to attempt the kernel marked the backend unavailable and the later ones never reached it.

The fix threads `seed` instead of a live generator and lets each callee derive its own, which is what `_run_permanova_gpu` already does and why permanova never had this problem. `_run_mantel_gpu` and `_mantel_stats_pearson_xp` both take `seed` now, and the two NumPy-path calls pass it as well; those two already declared `seed` in their signatures but were being handed the generator. `mantel()` no longer builds a generator at all, so a failed attempt cannot consume one. For a seeded run each path draws the same permutations as before, so a successful launch is unaffected.

There are only two places in the library where a GPU kernel is attempted inside a `try` and falls back to the array-API path, `mantel` and `permanova`. Permanova already passes `seed` to both branches and derives its generator inside `_permutation_batch`, so after this change the two dispatches have the same shape and the bug is not expressible in either.

The kendalltau path is the one exception and keeps its own generator. It permutes inside the loop, so it needs one that advances between iterations; a seed there would repeat the same draw every time. That branch now creates the generator locally, with a comment saying why.

### Testing

There is no new test. The bug is only reachable when the kernel is attempted and then fails, and on a runner without a GPU the dispatch returns before the attempt, so the branch cannot be entered. Reaching it in a unit test means either patching the dispatch or forcing Numba into simulator mode, and neither seemed worth it once the fix removes the parameter that made the bug possible.

The behavior was verified by reproducing it instead. Forcing the kernel to fail after it has drawn its permutations, the full `-m array_api` suite fails on `test_mantel_numba_engine_alternative_backends` with 0.44 against 0.48 on the unmodified branch point, and passes with this change, for all three `alternative` values.

Directly, comparing a run with no GPU attempt against one where the GPU path drew its permutations and then failed, the p-values are identical for all 18 combinations of three alternatives and six random matrices, which is the property the change is for.

On an RTX 4060 the fused kernels are entered with no fallback, and the GPU results match the Cython reference for both pearson and spearman across all three alternatives, with p-values equal and `r` differing by around 2e-17. The JAX GPU job is the relevant one for the array-API change, since it never uses the fused kernel, and it passes as well.

```
SKBIO_ARRAY_BACKEND=torch SKBIO_DEVICE=cpu pytest -m "array_api or numba" skbio/   # 68 passed
SKBIO_ARRAY_BACKEND=jax   SKBIO_DEVICE=cpu pytest -m "array_api or numba" skbio/   # 68 passed
```

The full unfiltered suite has the same failures before and after this change, so nothing else is affected.

The one test that calls `_mantel_stats_pearson_xp` with permutations passes the seed directly now rather than a generator, matching the new signature.
