### PR TITLE
PERF: Optimization to BPTree range-excess queries and widen its search kernel to 64-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 * Added `BPTree`, a succinct balanced-parentheses representation of trees for memory-efficient storage and fast topological queries on very large trees. Ported from [improved-octo-waddle](https://github.com/biocore/improved-octo-waddle) ([#2498](https://github.com/scikit-bio/scikit-bio/pull/2498)).
 
+### Performance enhancements
+
+* Reduced `BPTree.rmq`, `rMq`, `lca`, `height`, and `deepest_node` from O(span) to O(log n) by answering range-minimum/maximum excess queries with the rmM (min-max) tree instead of linearly scanning the queried range. For distant node pairs and deep subtrees this scales with tree size: on large trees, `lca`, `rmq`, and `rMq` on far-apart nodes drop from milliseconds to a flat sub-microsecond — hundreds- to thousands-fold, across balanced, caterpillar, and random topologies alike — with no change to construction time or memory footprint ([#2541](https://github.com/scikit-bio/scikit-bio/pull/2541)).
+
+### Bug Fixes
+
+* Widened the `BPTree` rmM (min-max) tree construction and the `fwdsearch`/`bwdsearch` search kernel from 32-bit to 64-bit indices. The parenthesis positions, block sizes, and excess deltas were C `int`s (inherited from the original improved-octo-waddle port), which silently overflowed for trees larger than 2³¹ parentheses (~537 million tips) — corrupting navigation rather than raising an error. Because the stored index arrays were already 64-bit, memory footprint and per-operation runtime are unchanged; only the loop counters and scan positions were widened ([#2541](https://github.com/scikit-bio/scikit-bio/pull/2541)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/tree/bp/_bp.pxd
+++ b/skbio/tree/bp/_bp.pxd
@@ -79,6 +79,8 @@ cdef class BPTree:
     cpdef SIZE_t edge_from_number(self, INT32_t n)
     cpdef SIZE_t rmq(self, SIZE_t i, SIZE_t j) nogil
     cpdef SIZE_t rMq(self, SIZE_t i, SIZE_t j) nogil
+    cdef SIZE_t _rmq_tree_min(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
+    cdef SIZE_t _rmq_tree_max(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
     cpdef SIZE_t postorder_select(self, SIZE_t k) nogil
     cpdef SIZE_t postorder_rank(self, SIZE_t i) nogil
     cpdef SIZE_t preorder_select(self, SIZE_t k) nogil

--- a/skbio/tree/bp/_bp.pxd
+++ b/skbio/tree/bp/_bp.pxd
@@ -14,7 +14,6 @@ cimport cython
 
 from ._ba cimport BIT_ARRAY
 
-ctypedef cnp.npy_intp SIZE_t
 ctypedef cnp.uint32_t UINT32_t
 ctypedef cnp.int32_t INT32_t
 ctypedef cnp.float64_t DOUBLE_t
@@ -22,7 +21,7 @@ ctypedef cnp.uint8_t BOOL_t
 
 
 cdef class mM:
-    cdef SIZE_t b  # block size (SIZE_t so block-index * block-size products stay 64-bit)
+    cdef Py_ssize_t b  # block size (Py_ssize_t so block-index * block-size products stay 64-bit)
     cdef int n_tip  # number of tips in the binary tree
     cdef int n_internal  # number of internal nodes in the binary tree
     cdef int n_total  # total number of nodes in the binary tree
@@ -30,10 +29,10 @@ cdef class mM:
     cdef int m_idx  # m is minimum excess
     cdef int M_idx  # M is maximum excess
     cdef int r_idx  # rank
-    cdef SIZE_t[:, ::1] mM
-    cdef SIZE_t[:] r
+    cdef Py_ssize_t[:, ::1] mM
+    cdef Py_ssize_t[:] r
 
-    cdef void rmm(self, BOOL_t[:] B, SIZE_t B_size) nogil
+    cdef void rmm(self, BOOL_t[:] B, Py_ssize_t B_size) nogil
 
 
 @cython.final
@@ -41,56 +40,56 @@ cdef class BPTree:
     cdef:
         public cnp.ndarray data
         BOOL_t* _b_ptr
-        SIZE_t[:] _e_index
-        SIZE_t[:] _k_index_0
-        SIZE_t[:] _k_index_1
+        Py_ssize_t[:] _e_index
+        Py_ssize_t[:] _k_index_0
+        Py_ssize_t[:] _k_index_1
         cnp.ndarray _names
         cnp.ndarray _lengths
         cnp.ndarray _edges
         cnp.ndarray _edge_lookup
         mM _rmm
-        SIZE_t size
+        Py_ssize_t size
 
-    cdef inline SIZE_t rank(self, SIZE_t t, SIZE_t i) nogil
-    cdef inline SIZE_t select(self, SIZE_t t, SIZE_t k) nogil
-    cdef SIZE_t _excess(self, SIZE_t i) nogil
-    cdef SIZE_t excess(self, SIZE_t i) nogil
-    cdef SIZE_t fwdsearch(self, SIZE_t i, SIZE_t d) nogil
-    cdef SIZE_t bwdsearch(self, SIZE_t i, SIZE_t d) nogil
-    cpdef inline SIZE_t close(self, SIZE_t i) nogil
-    cdef inline SIZE_t open(self, SIZE_t i) nogil
-    cpdef inline BOOL_t is_tip(self, SIZE_t i) nogil
-    cdef inline SIZE_t enclose(self, SIZE_t i) nogil
+    cdef inline Py_ssize_t rank(self, Py_ssize_t t, Py_ssize_t i) nogil
+    cdef inline Py_ssize_t select(self, Py_ssize_t t, Py_ssize_t k) nogil
+    cdef Py_ssize_t _excess(self, Py_ssize_t i) nogil
+    cdef Py_ssize_t excess(self, Py_ssize_t i) nogil
+    cdef Py_ssize_t fwdsearch(self, Py_ssize_t i, Py_ssize_t d) nogil
+    cdef Py_ssize_t bwdsearch(self, Py_ssize_t i, Py_ssize_t d) nogil
+    cpdef inline Py_ssize_t close(self, Py_ssize_t i) nogil
+    cdef inline Py_ssize_t open(self, Py_ssize_t i) nogil
+    cpdef inline BOOL_t is_tip(self, Py_ssize_t i) nogil
+    cdef inline Py_ssize_t enclose(self, Py_ssize_t i) nogil
     cdef BPTree _mask_from_self(self, BIT_ARRAY* mask, cnp.ndarray[DOUBLE_t, ndim=1] lengths)
-    cpdef SIZE_t next_sibling(self, SIZE_t i) nogil
-    cpdef SIZE_t previous_sibling(self, SIZE_t i) nogil
-    cpdef SIZE_t last_child(self, SIZE_t i) nogil
-    cpdef SIZE_t first_child(self, SIZE_t i) nogil
-    cpdef SIZE_t parent(self, SIZE_t i) nogil
-    cpdef SIZE_t depth(self, SIZE_t i) nogil
-    cpdef SIZE_t root(self) nogil
-    cdef SIZE_t scan_block_forward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil
-    cdef SIZE_t scan_block_backward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil
+    cpdef Py_ssize_t next_sibling(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t previous_sibling(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t last_child(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t first_child(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t parent(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t depth(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t root(self) nogil
+    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil
+    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil
     cdef void _set_edges(self, cnp.ndarray[INT32_t, ndim=1] edges)
 
-    cpdef inline unicode name(self, SIZE_t i)
-    cpdef inline DOUBLE_t length(self, SIZE_t i)
-    cpdef inline INT32_t edge(self, SIZE_t i)
-    cpdef SIZE_t edge_from_number(self, INT32_t n)
-    cpdef SIZE_t rmq(self, SIZE_t i, SIZE_t j) nogil
-    cpdef SIZE_t rMq(self, SIZE_t i, SIZE_t j) nogil
-    cdef SIZE_t _rmq_tree_min(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
-    cdef SIZE_t _rmq_tree_max(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
-    cpdef SIZE_t postorder_select(self, SIZE_t k) nogil
-    cpdef SIZE_t postorder_rank(self, SIZE_t i) nogil
-    cpdef SIZE_t preorder_select(self, SIZE_t k) nogil
-    cpdef SIZE_t preorder_rank(self, SIZE_t i) nogil
-    cpdef BOOL_t is_ancestor(self, SIZE_t i, SIZE_t j) nogil
-    cpdef SIZE_t level_ancestor(self, SIZE_t i, SIZE_t d) nogil
-    cpdef SIZE_t count(self, SIZE_t i=*, bint tips=*) nogil
+    cpdef inline unicode name(self, Py_ssize_t i)
+    cpdef inline DOUBLE_t length(self, Py_ssize_t i)
+    cpdef inline INT32_t edge(self, Py_ssize_t i)
+    cpdef Py_ssize_t edge_from_number(self, INT32_t n)
+    cpdef Py_ssize_t rmq(self, Py_ssize_t i, Py_ssize_t j) nogil
+    cpdef Py_ssize_t rMq(self, Py_ssize_t i, Py_ssize_t j) nogil
+    cdef Py_ssize_t _rmq_tree_min(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
+    cdef Py_ssize_t _rmq_tree_max(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
+    cpdef Py_ssize_t postorder_select(self, Py_ssize_t k) nogil
+    cpdef Py_ssize_t postorder_rank(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t preorder_select(self, Py_ssize_t k) nogil
+    cpdef Py_ssize_t preorder_rank(self, Py_ssize_t i) nogil
+    cpdef BOOL_t is_ancestor(self, Py_ssize_t i, Py_ssize_t j) nogil
+    cpdef Py_ssize_t level_ancestor(self, Py_ssize_t i, Py_ssize_t d) nogil
+    cpdef Py_ssize_t count(self, Py_ssize_t i=*, bint tips=*) nogil
     cpdef BPTree shear(self, set tips)
     cpdef BPTree collapse(self)
-    cpdef SIZE_t level_next(self, SIZE_t i) nogil
-    cpdef SIZE_t height(self, SIZE_t i) nogil
-    cpdef SIZE_t deepest_node(self, SIZE_t i) nogil
-    cpdef SIZE_t lca(self, SIZE_t i, SIZE_t j) nogil
+    cpdef Py_ssize_t level_next(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t height(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t deepest_node(self, Py_ssize_t i) nogil
+    cpdef Py_ssize_t lca(self, Py_ssize_t i, Py_ssize_t j) nogil

--- a/skbio/tree/bp/_bp.pxd
+++ b/skbio/tree/bp/_bp.pxd
@@ -22,7 +22,7 @@ ctypedef cnp.uint8_t BOOL_t
 
 
 cdef class mM:
-    cdef int b  # block size
+    cdef SIZE_t b  # block size (SIZE_t so block-index * block-size products stay 64-bit)
     cdef int n_tip  # number of tips in the binary tree
     cdef int n_internal  # number of internal nodes in the binary tree
     cdef int n_total  # total number of nodes in the binary tree
@@ -33,7 +33,7 @@ cdef class mM:
     cdef SIZE_t[:, ::1] mM
     cdef SIZE_t[:] r
 
-    cdef void rmm(self, BOOL_t[:] B, int B_size) nogil
+    cdef void rmm(self, BOOL_t[:] B, SIZE_t B_size) nogil
 
 
 @cython.final
@@ -55,8 +55,8 @@ cdef class BPTree:
     cdef inline SIZE_t select(self, SIZE_t t, SIZE_t k) nogil
     cdef SIZE_t _excess(self, SIZE_t i) nogil
     cdef SIZE_t excess(self, SIZE_t i) nogil
-    cdef SIZE_t fwdsearch(self, SIZE_t i, int d) nogil
-    cdef SIZE_t bwdsearch(self, SIZE_t i, int d) nogil
+    cdef SIZE_t fwdsearch(self, SIZE_t i, SIZE_t d) nogil
+    cdef SIZE_t bwdsearch(self, SIZE_t i, SIZE_t d) nogil
     cpdef inline SIZE_t close(self, SIZE_t i) nogil
     cdef inline SIZE_t open(self, SIZE_t i) nogil
     cpdef inline BOOL_t is_tip(self, SIZE_t i) nogil
@@ -69,8 +69,8 @@ cdef class BPTree:
     cpdef SIZE_t parent(self, SIZE_t i) nogil
     cpdef SIZE_t depth(self, SIZE_t i) nogil
     cpdef SIZE_t root(self) nogil
-    cdef int scan_block_forward(self, int i, int k, int b, int d) nogil
-    cdef int scan_block_backward(self, int i, int k, int b, int d) nogil
+    cdef SIZE_t scan_block_forward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil
+    cdef SIZE_t scan_block_backward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil
     cdef void _set_edges(self, cnp.ndarray[INT32_t, ndim=1] edges)
 
     cpdef inline unicode name(self, SIZE_t i)

--- a/skbio/tree/bp/_bp.pxd
+++ b/skbio/tree/bp/_bp.pxd
@@ -22,13 +22,13 @@ ctypedef cnp.uint8_t BOOL_t
 
 cdef class mM:
     cdef Py_ssize_t b  # block size (Py_ssize_t so block-index * block-size products stay 64-bit)
-    cdef int n_tip  # number of tips in the binary tree
-    cdef int n_internal  # number of internal nodes in the binary tree
-    cdef int n_total  # total number of nodes in the binary tree
-    cdef int height  # the height of the binary tree
-    cdef int m_idx  # m is minimum excess
-    cdef int M_idx  # M is maximum excess
-    cdef int r_idx  # rank
+    cdef Py_ssize_t n_tip  # number of tips in the binary tree
+    cdef Py_ssize_t n_internal  # number of internal nodes in the binary tree
+    cdef Py_ssize_t n_total  # total number of nodes in the binary tree
+    cdef Py_ssize_t height  # the height of the binary tree
+    cdef Py_ssize_t m_idx  # m is minimum excess
+    cdef Py_ssize_t M_idx  # M is maximum excess
+    cdef Py_ssize_t r_idx  # rank
     cdef Py_ssize_t[:, ::1] mM
     cdef Py_ssize_t[:] r
 
@@ -68,8 +68,8 @@ cdef class BPTree:
     cpdef Py_ssize_t parent(self, Py_ssize_t i) nogil
     cpdef Py_ssize_t depth(self, Py_ssize_t i) nogil
     cpdef Py_ssize_t root(self) nogil
-    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil
-    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil
+    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, Py_ssize_t k, Py_ssize_t b, Py_ssize_t d) nogil
+    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, Py_ssize_t k, Py_ssize_t b, Py_ssize_t d) nogil
     cdef void _set_edges(self, cnp.ndarray[INT32_t, ndim=1] edges)
 
     cpdef inline unicode name(self, Py_ssize_t i)
@@ -78,8 +78,8 @@ cdef class BPTree:
     cpdef Py_ssize_t edge_from_number(self, INT32_t n)
     cpdef Py_ssize_t rmq(self, Py_ssize_t i, Py_ssize_t j) nogil
     cpdef Py_ssize_t rMq(self, Py_ssize_t i, Py_ssize_t j) nogil
-    cdef Py_ssize_t _rmq_tree_min(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
-    cdef Py_ssize_t _rmq_tree_max(self, int node, int node_lo, int node_hi, int lo, int hi) nogil
+    cdef Py_ssize_t _rmq_tree_min(self, Py_ssize_t node, Py_ssize_t node_lo, Py_ssize_t node_hi, Py_ssize_t lo, Py_ssize_t hi) nogil
+    cdef Py_ssize_t _rmq_tree_max(self, Py_ssize_t node, Py_ssize_t node_lo, Py_ssize_t node_hi, Py_ssize_t lo, Py_ssize_t hi) nogil
     cpdef Py_ssize_t postorder_select(self, Py_ssize_t k) nogil
     cpdef Py_ssize_t postorder_rank(self, Py_ssize_t i) nogil
     cpdef Py_ssize_t preorder_select(self, Py_ssize_t k) nogil

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -550,35 +550,139 @@ cdef class BPTree:
             return self.bwdsearch(i - 1, -2) + 1
 
     cpdef SIZE_t rmq(self, SIZE_t i, SIZE_t j) nogil:
-        """The leftmost minimum excess in i -> j"""
-        cdef:
-            SIZE_t k, min_k
-            SIZE_t min_v, obs_v
+        """The leftmost minimum excess in i -> j.
 
-        min_k = i
-        min_v = self.excess(i)  # a value larger than what will be tested
-        for k in range(i, j + 1):
-            obs_v = self.excess(k)
-            if obs_v < min_v:
-                min_k = k
-                min_v = obs_v
-        return min_k
+        The minimum excess over [i, j] is found in O(log n): the two partial
+        end-blocks are scanned directly and the full interior blocks are
+        covered by a range query over the rmM tree. The leftmost position that
+        attains it is then recovered with a single ``fwdsearch``.
+        """
+        cdef:
+            SIZE_t d_star, p, blk_end, tree_v
+            SIZE_t bi, bj
+            int b
+
+        if i >= j:
+            return i
+
+        b = self._rmm.b
+        bi = i // b
+        bj = j // b
+
+        # smallest absolute excess over [i, j]
+        d_star = self._e_index[i]
+        if bi == bj:
+            for p in range(i + 1, j + 1):
+                if self._e_index[p] < d_star:
+                    d_star = self._e_index[p]
+        else:
+            # remainder of the block containing i (inclusive of i)
+            blk_end = min((bi + 1) * b, self.size)
+            for p in range(i + 1, blk_end):
+                if self._e_index[p] < d_star:
+                    d_star = self._e_index[p]
+            # full interior blocks (bi, bj) via the rmM tree
+            if bi + 1 <= bj - 1:
+                tree_v = self._rmq_tree_min(0, 0, self._rmm.n_internal,
+                                            <int>(bi + 1), <int>(bj - 1))
+                if tree_v < d_star:
+                    d_star = tree_v
+            # leading part of the block containing j (inclusive of j)
+            for p in range(bj * b, j + 1):
+                if self._e_index[p] < d_star:
+                    d_star = self._e_index[p]
+
+        # leftmost position in [i, j] whose excess equals the minimum
+        if self._e_index[i] == d_star:
+            return i
+        return self.fwdsearch(i, <int>(d_star - self._e_index[i]))
 
     cpdef SIZE_t rMq(self, SIZE_t i, SIZE_t j) nogil:
-        """The leftmost maximmum excess in i -> j."""
+        """The leftmost maximmum excess in i -> j.
+
+        Symmetric to :meth:`rmq`: an O(log n) range-maximum over the rmM tree
+        followed by a single ``fwdsearch`` for the leftmost attaining position.
+        """
         cdef:
-            SIZE_t k, max_k
-            SIZE_t max_v, obs_v
+            SIZE_t m_star, p, blk_end, tree_v
+            SIZE_t bi, bj
+            int b
 
-        max_k = i
-        max_v = self.excess(i)  # a value larger than what will be tested
-        for k in range(i, j + 1):
-            obs_v = self.excess(k)
-            if obs_v > max_v:
-                max_k = k
-                max_v = obs_v
+        if i >= j:
+            return i
 
-        return max_k
+        b = self._rmm.b
+        bi = i // b
+        bj = j // b
+
+        # largest absolute excess over [i, j]
+        m_star = self._e_index[i]
+        if bi == bj:
+            for p in range(i + 1, j + 1):
+                if self._e_index[p] > m_star:
+                    m_star = self._e_index[p]
+        else:
+            blk_end = min((bi + 1) * b, self.size)
+            for p in range(i + 1, blk_end):
+                if self._e_index[p] > m_star:
+                    m_star = self._e_index[p]
+            if bi + 1 <= bj - 1:
+                tree_v = self._rmq_tree_max(0, 0, self._rmm.n_internal,
+                                            <int>(bi + 1), <int>(bj - 1))
+                if tree_v > m_star:
+                    m_star = tree_v
+            for p in range(bj * b, j + 1):
+                if self._e_index[p] > m_star:
+                    m_star = self._e_index[p]
+
+        # leftmost position in [i, j] whose excess equals the maximum
+        if self._e_index[i] == m_star:
+            return i
+        return self.fwdsearch(i, <int>(m_star - self._e_index[i]))
+
+    cdef SIZE_t _rmq_tree_min(self, int node, int node_lo, int node_hi,
+                              int lo, int hi) nogil:
+        """Minimum excess over leaf-blocks [lo, hi].
+
+        Segment-tree range query over the rmM binary tree; ``node`` spans the
+        contiguous block range [node_lo, node_hi]. Only fully-covered nodes are
+        read, and a covered node satisfies ``node_hi <= hi < n_tip``, so it
+        (and its subtree) is always a real, populated block -- the partially
+        filled last level is only ever touched through the partial end-blocks,
+        which the callers scan directly.
+        """
+        cdef int mid
+        cdef SIZE_t left_v, right_v
+
+        if hi < node_lo or node_hi < lo:  # no overlap
+            return INT_MAX
+        if lo <= node_lo and node_hi <= hi:  # fully covered
+            return self._rmm.mM[node, self._rmm.m_idx]
+        mid = (node_lo + node_hi) / 2
+        left_v = self._rmq_tree_min(bt_left_child(node), node_lo, mid, lo, hi)
+        right_v = self._rmq_tree_min(bt_right_child(node), mid + 1, node_hi,
+                                     lo, hi)
+        return left_v if left_v < right_v else right_v
+
+    cdef SIZE_t _rmq_tree_max(self, int node, int node_lo, int node_hi,
+                              int lo, int hi) nogil:
+        """Maximum excess over leaf-blocks [lo, hi].
+
+        The range-maximum counterpart of :meth:`_rmq_tree_min`; see its note on
+        why every fully-covered node is a real block.
+        """
+        cdef int mid
+        cdef SIZE_t left_v, right_v
+
+        if hi < node_lo or node_hi < lo:  # no overlap
+            return -INT_MAX
+        if lo <= node_lo and node_hi <= hi:  # fully covered
+            return self._rmm.mM[node, self._rmm.M_idx]
+        mid = (node_lo + node_hi) / 2
+        left_v = self._rmq_tree_max(bt_left_child(node), node_lo, mid, lo, hi)
+        right_v = self._rmq_tree_max(bt_right_child(node), mid + 1, node_hi,
+                                     lo, hi)
+        return left_v if left_v > right_v else right_v
 
     def __len__(self):
         """The number of nodes in the tree."""

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -33,14 +33,14 @@ BOOL = np.uint8
 INT32 = np.int32
 
 
-cdef inline int min(int a, int b) nogil:
+cdef inline SIZE_t min(SIZE_t a, SIZE_t b) nogil:
     if a > b:
         return b
     else:
         return a
 
 
-cdef inline int max(int a, int b) nogil:
+cdef inline SIZE_t max(SIZE_t a, SIZE_t b) nogil:
     if a > b:
         return a
     else:
@@ -48,29 +48,32 @@ cdef inline int max(int a, int b) nogil:
 
 
 cdef class mM:
-    def __cinit__(self, BOOL_t[:] B, int B_size):
+    def __cinit__(self, BOOL_t[:] B, SIZE_t B_size):
         self.m_idx = 0
         self.M_idx = 1
 
         self.rmm(B, B_size)
 
-    cdef void rmm(self, BOOL_t[:] B, int B_size) nogil:
+    cdef void rmm(self, BOOL_t[:] B, SIZE_t B_size) nogil:
         """Construct the rmM tree based off of Navarro and Sadakane
 
         http://www.dcc.uchile.cl/~gnavarro/ps/talg12.pdf
         """
-        cdef int i, j, lvl, pos  # for loop support
-        cdef int offset  # tip offset in binary tree for a given parenthesis
-        cdef int lower_limit  # the lower limit of the bucket a parenthesis is in
-        cdef int upper_limit  # the upper limit of the bucket a parenthesis is in
-        cdef int min_ = 0 # m, absolute minimum for a blokc
-        cdef int max_ = 0 # M, absolute maximum for a block
-        cdef int excess = 0 # e, absolute excess
+        # i/j and the block bounds index into B[0, 2n), so they are SIZE_t
+        # (64-bit); lvl/pos iterate the small rmM binary tree and stay int.
+        cdef SIZE_t i, j  # parenthesis positions
+        cdef int lvl, pos  # rmM-tree level / node within a level
+        cdef SIZE_t offset  # tip offset in binary tree for a given parenthesis
+        cdef SIZE_t lower_limit  # the lower limit of the bucket a parenthesis is in
+        cdef SIZE_t upper_limit  # the upper limit of the bucket a parenthesis is in
+        cdef SIZE_t min_ = 0 # m, absolute minimum for a blokc
+        cdef SIZE_t max_ = 0 # M, absolute maximum for a block
+        cdef SIZE_t excess = 0 # e, absolute excess
         cdef int vbar
-        cdef int r = 0
+        cdef SIZE_t r = 0
 
         # build tip info
-        self.b = <int>ceil(ln(<double> B_size) * ln(ln(<double> B_size)))
+        self.b = <SIZE_t>ceil(ln(<double> B_size) * ln(ln(<double> B_size)))
 
         # determine the number of nodes and height of the binary tree
         self.n_tip = <int>ceil(B_size / <double> self.b)
@@ -480,10 +483,10 @@ cdef class BPTree:
             The rank order of the position.
         """
         cdef int k
-        cdef int r = 0
-        cdef int lower_bound
-        cdef int upper_bound
-        cdef int j
+        cdef SIZE_t r = 0
+        cdef SIZE_t lower_bound
+        cdef SIZE_t upper_bound
+        cdef SIZE_t j
         cdef int node
 
         k = i // self._rmm.b
@@ -595,7 +598,7 @@ cdef class BPTree:
         # leftmost position in [i, j] whose excess equals the minimum
         if self._e_index[i] == d_star:
             return i
-        return self.fwdsearch(i, <int>(d_star - self._e_index[i]))
+        return self.fwdsearch(i, d_star - self._e_index[i])
 
     cpdef SIZE_t rMq(self, SIZE_t i, SIZE_t j) nogil:
         """The leftmost maximmum excess in i -> j.
@@ -638,7 +641,7 @@ cdef class BPTree:
         # leftmost position in [i, j] whose excess equals the maximum
         if self._e_index[i] == m_star:
             return i
-        return self.fwdsearch(i, <int>(m_star - self._e_index[i]))
+        return self.fwdsearch(i, m_star - self._e_index[i])
 
     cdef SIZE_t _rmq_tree_min(self, int node, int node_lo, int node_hi,
                               int lo, int hi) nogil:
@@ -1384,7 +1387,7 @@ cdef class BPTree:
         bit_array_free(mask)
         return new_bp
 
-    cdef int scan_block_forward(self, int i, int k, int b, int d) nogil:
+    cdef SIZE_t scan_block_forward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil:
         """Scan a block forward from i.
 
         Parameters
@@ -1404,9 +1407,9 @@ cdef class BPTree:
             The index position of the result. -1 is returned if a result is not
             found.
         """
-        cdef int lower_bound
-        cdef int upper_bound
-        cdef int j
+        cdef SIZE_t lower_bound
+        cdef SIZE_t upper_bound
+        cdef SIZE_t j
 
         # lower_bound is block boundary or right of i
         lower_bound = max(k, 0) * b
@@ -1421,7 +1424,7 @@ cdef class BPTree:
 
         return -1
 
-    cdef int scan_block_backward(self, int i, int k, int b, int d) nogil:
+    cdef SIZE_t scan_block_backward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil:
         """Scan a block backward from i.
 
         Parameters
@@ -1441,9 +1444,9 @@ cdef class BPTree:
             The index position of the result. -1 is returned if a result is not
             found.
         """
-        cdef int lower_bound
-        cdef int upper_bound
-        cdef int j
+        cdef SIZE_t lower_bound
+        cdef SIZE_t upper_bound
+        cdef SIZE_t j
 
         # range stop is exclusive, so need to set "stop" at -1 of boundary
         lower_bound = max(k, 0) * b - 1
@@ -1467,7 +1470,7 @@ cdef class BPTree:
 
         return -1
 
-    cdef SIZE_t fwdsearch(self, SIZE_t i, int d) nogil:
+    cdef SIZE_t fwdsearch(self, SIZE_t i, SIZE_t d) nogil:
         """Search forward from i for desired excess.
 
         Parameters
@@ -1483,7 +1486,7 @@ cdef class BPTree:
             The index of the result, or -1 if no result was found
         """
         cdef int k  # the block being interrogated
-        cdef int result = -1 # the result of a scan within a block
+        cdef SIZE_t result = -1 # the result of a scan within a block
         cdef int node  # the node within the binary tree being examined
 
         # get the block of parentheses to check
@@ -1529,7 +1532,7 @@ cdef class BPTree:
 
         return result
 
-    cdef SIZE_t bwdsearch(self, SIZE_t i, int d) nogil:
+    cdef SIZE_t bwdsearch(self, SIZE_t i, SIZE_t d) nogil:
         """Search backward from i for desired excess
 
         Parameters
@@ -1545,7 +1548,7 @@ cdef class BPTree:
             The index of the result, or -1 if no result was found
         """
         cdef int k  # the block being interrogated
-        cdef int result = -1 # the result of a scan within a block
+        cdef SIZE_t result = -1 # the result of a scan within a block
         cdef int node  # the node within the binary tree being examined
 
         # get the block of parentheses to check

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -23,8 +23,9 @@ from ._ba cimport *
 
 cnp.import_array()
 
-cdef extern from "limits.h":
-    int INT_MAX
+cdef extern from "Python.h":
+    # largest value a Py_ssize_t can hold; used as a nogil "+infinity" sentinel
+    cdef Py_ssize_t PY_SSIZE_T_MAX
 
 
 DOUBLE = np.float64
@@ -59,26 +60,25 @@ cdef class mM:
 
         http://www.dcc.uchile.cl/~gnavarro/ps/talg12.pdf
         """
-        # i/j and the block bounds index into B[0, 2n), so they are Py_ssize_t
-        # (64-bit); lvl/pos iterate the small rmM binary tree and stay int.
+        # i/j index into B[0, 2n) and lvl/pos iterate the small rmM binary
+        # tree; all are non-negative indices, so they are Py_ssize_t.
         cdef Py_ssize_t i, j  # parenthesis positions
-        cdef int lvl, pos  # rmM-tree level / node within a level
+        cdef Py_ssize_t lvl, pos  # rmM-tree level / node within a level
         cdef Py_ssize_t offset  # tip offset in binary tree for a given parenthesis
         cdef Py_ssize_t lower_limit  # the lower limit of the bucket a parenthesis is in
         cdef Py_ssize_t upper_limit  # the upper limit of the bucket a parenthesis is in
         cdef Py_ssize_t min_ = 0 # m, absolute minimum for a blokc
         cdef Py_ssize_t max_ = 0 # M, absolute maximum for a block
         cdef Py_ssize_t excess = 0 # e, absolute excess
-        cdef int vbar
         cdef Py_ssize_t r = 0
 
         # build tip info
         self.b = <Py_ssize_t>ceil(ln(<double> B_size) * ln(ln(<double> B_size)))
 
         # determine the number of nodes and height of the binary tree
-        self.n_tip = <int>ceil(B_size / <double> self.b)
-        self.height = <int>ceil(log2(self.n_tip))
-        self.n_internal = <int>(pow(2, self.height)) - 1
+        self.n_tip = <Py_ssize_t>ceil(B_size / <double> self.b)
+        self.height = <Py_ssize_t>ceil(log2(self.n_tip))
+        self.n_internal = <Py_ssize_t>(pow(2, self.height)) - 1
         self.n_total = self.n_tip + self.n_internal
 
         with gil:
@@ -97,7 +97,7 @@ cdef class mM:
             offset = i // self.b
             lower_limit = i
             upper_limit = min(i + self.b, B_size)
-            min_ = INT_MAX
+            min_ = PY_SSIZE_T_MAX
             max_ = 0
 
             self.r[offset + self.n_internal] = r
@@ -123,7 +123,7 @@ cdef class mM:
         # compute for internal nodes of rmM tree in reverse level order starting
         # at the level above the tips
         for lvl in range(self.height - 1, -1, -1):
-            num_curr_nodes = <int>pow(2, lvl)
+            num_curr_nodes = <Py_ssize_t>pow(2, lvl)
 
             # for each node in the level
             for pos in range(num_curr_nodes):
@@ -431,7 +431,7 @@ cdef class BPTree:
 
     cdef void _set_edges(self, cnp.ndarray[INT32_t, ndim=1] edges):
         cdef:
-            int i, n
+            Py_ssize_t i, n
             INT32_t edge
             cnp.ndarray[Py_ssize_t, ndim=1] _edge_lookup
             cnp.ndarray[BOOL_t, ndim=1] b
@@ -482,12 +482,12 @@ cdef class BPTree:
         Py_ssize_t
             The rank order of the position.
         """
-        cdef int k
+        cdef Py_ssize_t k
         cdef Py_ssize_t r = 0
         cdef Py_ssize_t lower_bound
         cdef Py_ssize_t upper_bound
         cdef Py_ssize_t j
-        cdef int node
+        cdef Py_ssize_t node
 
         k = i // self._rmm.b
 
@@ -563,7 +563,7 @@ cdef class BPTree:
         cdef:
             Py_ssize_t d_star, p, blk_end, tree_v
             Py_ssize_t bi, bj
-            int b
+            Py_ssize_t b
 
         if i >= j:
             return i
@@ -587,7 +587,7 @@ cdef class BPTree:
             # full interior blocks (bi, bj) via the rmM tree
             if bi + 1 <= bj - 1:
                 tree_v = self._rmq_tree_min(0, 0, self._rmm.n_internal,
-                                            <int>(bi + 1), <int>(bj - 1))
+                                            bi + 1, bj - 1)
                 if tree_v < d_star:
                     d_star = tree_v
             # leading part of the block containing j (inclusive of j)
@@ -609,7 +609,7 @@ cdef class BPTree:
         cdef:
             Py_ssize_t m_star, p, blk_end, tree_v
             Py_ssize_t bi, bj
-            int b
+            Py_ssize_t b
 
         if i >= j:
             return i
@@ -631,7 +631,7 @@ cdef class BPTree:
                     m_star = self._e_index[p]
             if bi + 1 <= bj - 1:
                 tree_v = self._rmq_tree_max(0, 0, self._rmm.n_internal,
-                                            <int>(bi + 1), <int>(bj - 1))
+                                            bi + 1, bj - 1)
                 if tree_v > m_star:
                     m_star = tree_v
             for p in range(bj * b, j + 1):
@@ -643,8 +643,8 @@ cdef class BPTree:
             return i
         return self.fwdsearch(i, m_star - self._e_index[i])
 
-    cdef Py_ssize_t _rmq_tree_min(self, int node, int node_lo, int node_hi,
-                              int lo, int hi) nogil:
+    cdef Py_ssize_t _rmq_tree_min(self, Py_ssize_t node, Py_ssize_t node_lo, Py_ssize_t node_hi,
+                              Py_ssize_t lo, Py_ssize_t hi) nogil:
         """Minimum excess over leaf-blocks [lo, hi].
 
         Segment-tree range query over the rmM binary tree; ``node`` spans the
@@ -654,11 +654,11 @@ cdef class BPTree:
         filled last level is only ever touched through the partial end-blocks,
         which the callers scan directly.
         """
-        cdef int mid
+        cdef Py_ssize_t mid
         cdef Py_ssize_t left_v, right_v
 
         if hi < node_lo or node_hi < lo:  # no overlap
-            return INT_MAX
+            return PY_SSIZE_T_MAX
         if lo <= node_lo and node_hi <= hi:  # fully covered
             return self._rmm.mM[node, self._rmm.m_idx]
         mid = (node_lo + node_hi) / 2
@@ -667,18 +667,18 @@ cdef class BPTree:
                                      lo, hi)
         return left_v if left_v < right_v else right_v
 
-    cdef Py_ssize_t _rmq_tree_max(self, int node, int node_lo, int node_hi,
-                              int lo, int hi) nogil:
+    cdef Py_ssize_t _rmq_tree_max(self, Py_ssize_t node, Py_ssize_t node_lo, Py_ssize_t node_hi,
+                              Py_ssize_t lo, Py_ssize_t hi) nogil:
         """Maximum excess over leaf-blocks [lo, hi].
 
         The range-maximum counterpart of :meth:`_rmq_tree_min`; see its note on
         why every fully-covered node is a real block.
         """
-        cdef int mid
+        cdef Py_ssize_t mid
         cdef Py_ssize_t left_v, right_v
 
         if hi < node_lo or node_hi < lo:  # no overlap
-            return -INT_MAX
+            return -PY_SSIZE_T_MAX
         if lo <= node_lo and node_hi <= hi:  # fully covered
             return self._rmm.mM[node, self._rmm.M_idx]
         mid = (node_lo + node_hi) / 2
@@ -1387,7 +1387,7 @@ cdef class BPTree:
         bit_array_free(mask)
         return new_bp
 
-    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil:
+    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, Py_ssize_t k, Py_ssize_t b, Py_ssize_t d) nogil:
         """Scan a block forward from i.
 
         Parameters
@@ -1424,7 +1424,7 @@ cdef class BPTree:
 
         return -1
 
-    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil:
+    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, Py_ssize_t k, Py_ssize_t b, Py_ssize_t d) nogil:
         """Scan a block backward from i.
 
         Parameters
@@ -1485,9 +1485,9 @@ cdef class BPTree:
         int
             The index of the result, or -1 if no result was found
         """
-        cdef int k  # the block being interrogated
+        cdef Py_ssize_t k  # the block being interrogated
         cdef Py_ssize_t result = -1 # the result of a scan within a block
-        cdef int node  # the node within the binary tree being examined
+        cdef Py_ssize_t node  # the node within the binary tree being examined
 
         # get the block of parentheses to check
         k = i // self._rmm.b
@@ -1525,7 +1525,7 @@ cdef class BPTree:
 
             # we have found a block with contains our solution. convert from the
             # node index back into the block index
-            k = node - <int>(pow(2, self._rmm.height) - 1)
+            k = node - <Py_ssize_t>(pow(2, self._rmm.height) - 1)
 
             # scan for a result using the original d
             result = self.scan_block_forward(i, k, self._rmm.b, d)
@@ -1547,9 +1547,9 @@ cdef class BPTree:
         int
             The index of the result, or -1 if no result was found
         """
-        cdef int k  # the block being interrogated
+        cdef Py_ssize_t k  # the block being interrogated
         cdef Py_ssize_t result = -1 # the result of a scan within a block
-        cdef int node  # the node within the binary tree being examined
+        cdef Py_ssize_t node  # the node within the binary tree being examined
 
         # get the block of parentheses to check
         k = i // self._rmm.b
@@ -1566,7 +1566,7 @@ cdef class BPTree:
         # special case: check sibling
         if result == -1 and bt_is_right_child(node):
             node = bt_left_sibling(node)
-            k = node - <int>(pow(2, self._rmm.height) - 1)
+            k = node - <Py_ssize_t>(pow(2, self._rmm.height) - 1)
             result = self.scan_block_backward(i, k, self._rmm.b, d)
 
            # reset node and k in the event that result == -1
@@ -1600,7 +1600,7 @@ cdef class BPTree:
 
             # we have found a block with contains our solution. convert from the
             # node index back into the block index
-            k = node - <int>(pow(2, self._rmm.height) - 1)
+            k = node - <Py_ssize_t>(pow(2, self._rmm.height) - 1)
 
             # scan for a result
             result = self.scan_block_backward(i, k, self._rmm.b, d)

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -562,7 +562,7 @@ cdef class BPTree:
         """
         cdef:
             Py_ssize_t d_star, p, blk_end, tree_v
-            Py_ssize_t bi, bj
+            Py_ssize_t bi, bj, e_i
             Py_ssize_t b
 
         if i >= j:
@@ -573,7 +573,8 @@ cdef class BPTree:
         bj = j // b
 
         # smallest absolute excess over [i, j]
-        d_star = self._e_index[i]
+        e_i = self._e_index[i]
+        d_star = e_i
         if bi == bj:
             for p in range(i + 1, j + 1):
                 if self._e_index[p] < d_star:
@@ -596,9 +597,9 @@ cdef class BPTree:
                     d_star = self._e_index[p]
 
         # leftmost position in [i, j] whose excess equals the minimum
-        if self._e_index[i] == d_star:
+        if e_i == d_star:
             return i
-        return self.fwdsearch(i, d_star - self._e_index[i])
+        return self.fwdsearch(i, d_star - e_i)
 
     cpdef Py_ssize_t rMq(self, Py_ssize_t i, Py_ssize_t j) nogil:
         """The leftmost maximmum excess in i -> j.
@@ -608,7 +609,7 @@ cdef class BPTree:
         """
         cdef:
             Py_ssize_t m_star, p, blk_end, tree_v
-            Py_ssize_t bi, bj
+            Py_ssize_t bi, bj, e_i
             Py_ssize_t b
 
         if i >= j:
@@ -619,7 +620,8 @@ cdef class BPTree:
         bj = j // b
 
         # largest absolute excess over [i, j]
-        m_star = self._e_index[i]
+        e_i = self._e_index[i]
+        m_star = e_i
         if bi == bj:
             for p in range(i + 1, j + 1):
                 if self._e_index[p] > m_star:
@@ -639,9 +641,9 @@ cdef class BPTree:
                     m_star = self._e_index[p]
 
         # leftmost position in [i, j] whose excess equals the maximum
-        if self._e_index[i] == m_star:
+        if e_i == m_star:
             return i
-        return self.fwdsearch(i, m_star - self._e_index[i])
+        return self.fwdsearch(i, m_star - e_i)
 
     cdef Py_ssize_t _rmq_tree_min(self, Py_ssize_t node, Py_ssize_t node_lo, Py_ssize_t node_hi,
                               Py_ssize_t lo, Py_ssize_t hi) nogil:

--- a/skbio/tree/bp/_bp.pyx
+++ b/skbio/tree/bp/_bp.pyx
@@ -33,14 +33,14 @@ BOOL = np.uint8
 INT32 = np.int32
 
 
-cdef inline SIZE_t min(SIZE_t a, SIZE_t b) nogil:
+cdef inline Py_ssize_t min(Py_ssize_t a, Py_ssize_t b) nogil:
     if a > b:
         return b
     else:
         return a
 
 
-cdef inline SIZE_t max(SIZE_t a, SIZE_t b) nogil:
+cdef inline Py_ssize_t max(Py_ssize_t a, Py_ssize_t b) nogil:
     if a > b:
         return a
     else:
@@ -48,32 +48,32 @@ cdef inline SIZE_t max(SIZE_t a, SIZE_t b) nogil:
 
 
 cdef class mM:
-    def __cinit__(self, BOOL_t[:] B, SIZE_t B_size):
+    def __cinit__(self, BOOL_t[:] B, Py_ssize_t B_size):
         self.m_idx = 0
         self.M_idx = 1
 
         self.rmm(B, B_size)
 
-    cdef void rmm(self, BOOL_t[:] B, SIZE_t B_size) nogil:
+    cdef void rmm(self, BOOL_t[:] B, Py_ssize_t B_size) nogil:
         """Construct the rmM tree based off of Navarro and Sadakane
 
         http://www.dcc.uchile.cl/~gnavarro/ps/talg12.pdf
         """
-        # i/j and the block bounds index into B[0, 2n), so they are SIZE_t
+        # i/j and the block bounds index into B[0, 2n), so they are Py_ssize_t
         # (64-bit); lvl/pos iterate the small rmM binary tree and stay int.
-        cdef SIZE_t i, j  # parenthesis positions
+        cdef Py_ssize_t i, j  # parenthesis positions
         cdef int lvl, pos  # rmM-tree level / node within a level
-        cdef SIZE_t offset  # tip offset in binary tree for a given parenthesis
-        cdef SIZE_t lower_limit  # the lower limit of the bucket a parenthesis is in
-        cdef SIZE_t upper_limit  # the upper limit of the bucket a parenthesis is in
-        cdef SIZE_t min_ = 0 # m, absolute minimum for a blokc
-        cdef SIZE_t max_ = 0 # M, absolute maximum for a block
-        cdef SIZE_t excess = 0 # e, absolute excess
+        cdef Py_ssize_t offset  # tip offset in binary tree for a given parenthesis
+        cdef Py_ssize_t lower_limit  # the lower limit of the bucket a parenthesis is in
+        cdef Py_ssize_t upper_limit  # the upper limit of the bucket a parenthesis is in
+        cdef Py_ssize_t min_ = 0 # m, absolute minimum for a blokc
+        cdef Py_ssize_t max_ = 0 # M, absolute maximum for a block
+        cdef Py_ssize_t excess = 0 # e, absolute excess
         cdef int vbar
-        cdef SIZE_t r = 0
+        cdef Py_ssize_t r = 0
 
         # build tip info
-        self.b = <SIZE_t>ceil(ln(<double> B_size) * ln(ln(<double> B_size)))
+        self.b = <Py_ssize_t>ceil(ln(<double> B_size) * ln(ln(<double> B_size)))
 
         # determine the number of nodes and height of the binary tree
         self.n_tip = <int>ceil(B_size / <double> self.b)
@@ -187,17 +187,17 @@ cdef class BPTree:
                   cnp.ndarray[DOUBLE_t, ndim=1] lengths=None,
                   cnp.ndarray[object, ndim=1] names=None,
                   cnp.ndarray[INT32_t, ndim=1] edges=None):
-        cdef SIZE_t i
-        cdef SIZE_t size
-        cdef SIZE_t[:] _e_index
-        cdef SIZE_t[:] _k_index_0
-        cdef SIZE_t[:] _k_index_1
-        cdef SIZE_t[:] _r_index_0
-        cdef SIZE_t[:] _r_index_1
+        cdef Py_ssize_t i
+        cdef Py_ssize_t size
+        cdef Py_ssize_t[:] _e_index
+        cdef Py_ssize_t[:] _k_index_0
+        cdef Py_ssize_t[:] _k_index_1
+        cdef Py_ssize_t[:] _r_index_0
+        cdef Py_ssize_t[:] _r_index_1
         cdef cnp.ndarray[object, ndim=1] _names
         cdef cnp.ndarray[DOUBLE_t, ndim=1] _lengths
         cdef cnp.ndarray[INT32_t, ndim=1] _edges
-        cdef cnp.ndarray[SIZE_t, ndim=1] _edge_lookup
+        cdef cnp.ndarray[Py_ssize_t, ndim=1] _edge_lookup
 
         # the tree is only valid if it is balanced (equal opens and closes)
         if B.sum() * 2 != B.size:
@@ -368,7 +368,7 @@ cdef class BPTree:
         cdef:
             Py_ssize_t i, n
             Py_ssize_t chi_ptr, cur_index
-            SIZE_t node_idx, first_child, last_child, sib_idx
+            Py_ssize_t node_idx, first_child, last_child, sib_idx
             cnp.ndarray[DOUBLE_t, ndim=1] length
             cnp.ndarray[UINT32_t, ndim=1] node_ids
             cnp.ndarray[object, ndim=1] name
@@ -433,7 +433,7 @@ cdef class BPTree:
         cdef:
             int i, n
             INT32_t edge
-            cnp.ndarray[SIZE_t, ndim=1] _edge_lookup
+            cnp.ndarray[Py_ssize_t, ndim=1] _edge_lookup
             cnp.ndarray[BOOL_t, ndim=1] b
 
         b = self.data
@@ -451,19 +451,19 @@ cdef class BPTree:
     def set_edges(self, cnp.ndarray[INT32_t, ndim=1] edges):
         self._set_edges(edges)
 
-    cpdef inline unicode name(self, SIZE_t i):
+    cpdef inline unicode name(self, Py_ssize_t i):
         return self._names[i]
 
-    cpdef inline DOUBLE_t length(self, SIZE_t i):
+    cpdef inline DOUBLE_t length(self, Py_ssize_t i):
         return self._lengths[i]
 
-    cpdef inline INT32_t edge(self, SIZE_t i):
+    cpdef inline INT32_t edge(self, Py_ssize_t i):
         return self._edges[i]
 
-    cpdef SIZE_t edge_from_number(self, INT32_t n):
+    cpdef Py_ssize_t edge_from_number(self, INT32_t n):
         return self._edge_lookup[n]
 
-    cdef inline SIZE_t rank(self, SIZE_t t, SIZE_t i) nogil:
+    cdef inline Py_ssize_t rank(self, Py_ssize_t t, Py_ssize_t i) nogil:
         """Determine the rank order of the ith bit t
 
         Rank is the order of the ith bit observed, from left to right. For
@@ -471,22 +471,22 @@ cdef class BPTree:
 
         Parameters
         ----------
-        t : SIZE_t
+        t : Py_ssize_t
             The bit value, either 0 or 1 where 0 is a closing parenthesis and
             1 is an opening.
-        i : SIZE_T
+        i : Py_ssize_t
             The position to evaluate
 
         Returns
         -------
-        SIZE_t
+        Py_ssize_t
             The rank order of the position.
         """
         cdef int k
-        cdef SIZE_t r = 0
-        cdef SIZE_t lower_bound
-        cdef SIZE_t upper_bound
-        cdef SIZE_t j
+        cdef Py_ssize_t r = 0
+        cdef Py_ssize_t lower_bound
+        cdef Py_ssize_t upper_bound
+        cdef Py_ssize_t j
         cdef int node
 
         k = i // self._rmm.b
@@ -510,25 +510,25 @@ cdef class BPTree:
         else:
             return (i - r) + 1
 
-    cdef inline SIZE_t select(self, SIZE_t t, SIZE_t k) nogil:
+    cdef inline Py_ssize_t select(self, Py_ssize_t t, Py_ssize_t k) nogil:
         """The position in B of the kth occurrence of the bit t."""
         if t:
             return self._k_index_1[k]
         else:
             return self._k_index_0[k]
 
-    cdef SIZE_t _excess(self, SIZE_t i) nogil:
+    cdef Py_ssize_t _excess(self, Py_ssize_t i) nogil:
         """Actually compute excess"""
         if i < 0:
             return 0  # wasn't stated as needed but appears so given testing
         return (2 * self.rank(1, i) - i) - 1
 
-    cdef SIZE_t excess(self, SIZE_t i) nogil:
+    cdef Py_ssize_t excess(self, Py_ssize_t i) nogil:
         """the number of opening minus closing parentheses in B[1, i]"""
         # same as: self.rank(1, i) - self.rank(0, i)
         return self._e_index[i]
 
-    cpdef inline SIZE_t close(self, SIZE_t i) nogil:
+    cpdef inline Py_ssize_t close(self, Py_ssize_t i) nogil:
         """The position of the closing parenthesis that matches B[i]"""
         if not self._b_ptr[i]:
             # identity: the close of a closed parenthesis is itself
@@ -536,7 +536,7 @@ cdef class BPTree:
 
         return self.fwdsearch(i, -1)
 
-    cdef inline SIZE_t open(self, SIZE_t i) nogil:
+    cdef inline Py_ssize_t open(self, Py_ssize_t i) nogil:
         """The position of the opening parenthesis that matches B[i]"""
         if self._b_ptr[i] or i <= 0:
             # identity: the open of an open parenthesis is itself
@@ -545,14 +545,14 @@ cdef class BPTree:
 
         return self.bwdsearch(i, 0) + 1
 
-    cdef inline SIZE_t enclose(self, SIZE_t i) nogil:
+    cdef inline Py_ssize_t enclose(self, Py_ssize_t i) nogil:
         """The opening parenthesis of the smallest matching pair that contains position i"""
         if self._b_ptr[i]:
             return self.bwdsearch(i, -2) + 1
         else:
             return self.bwdsearch(i - 1, -2) + 1
 
-    cpdef SIZE_t rmq(self, SIZE_t i, SIZE_t j) nogil:
+    cpdef Py_ssize_t rmq(self, Py_ssize_t i, Py_ssize_t j) nogil:
         """The leftmost minimum excess in i -> j.
 
         The minimum excess over [i, j] is found in O(log n): the two partial
@@ -561,8 +561,8 @@ cdef class BPTree:
         attains it is then recovered with a single ``fwdsearch``.
         """
         cdef:
-            SIZE_t d_star, p, blk_end, tree_v
-            SIZE_t bi, bj
+            Py_ssize_t d_star, p, blk_end, tree_v
+            Py_ssize_t bi, bj
             int b
 
         if i >= j:
@@ -600,15 +600,15 @@ cdef class BPTree:
             return i
         return self.fwdsearch(i, d_star - self._e_index[i])
 
-    cpdef SIZE_t rMq(self, SIZE_t i, SIZE_t j) nogil:
+    cpdef Py_ssize_t rMq(self, Py_ssize_t i, Py_ssize_t j) nogil:
         """The leftmost maximmum excess in i -> j.
 
         Symmetric to :meth:`rmq`: an O(log n) range-maximum over the rmM tree
         followed by a single ``fwdsearch`` for the leftmost attaining position.
         """
         cdef:
-            SIZE_t m_star, p, blk_end, tree_v
-            SIZE_t bi, bj
+            Py_ssize_t m_star, p, blk_end, tree_v
+            Py_ssize_t bi, bj
             int b
 
         if i >= j:
@@ -643,7 +643,7 @@ cdef class BPTree:
             return i
         return self.fwdsearch(i, m_star - self._e_index[i])
 
-    cdef SIZE_t _rmq_tree_min(self, int node, int node_lo, int node_hi,
+    cdef Py_ssize_t _rmq_tree_min(self, int node, int node_lo, int node_hi,
                               int lo, int hi) nogil:
         """Minimum excess over leaf-blocks [lo, hi].
 
@@ -655,7 +655,7 @@ cdef class BPTree:
         which the callers scan directly.
         """
         cdef int mid
-        cdef SIZE_t left_v, right_v
+        cdef Py_ssize_t left_v, right_v
 
         if hi < node_lo or node_hi < lo:  # no overlap
             return INT_MAX
@@ -667,7 +667,7 @@ cdef class BPTree:
                                      lo, hi)
         return left_v if left_v < right_v else right_v
 
-    cdef SIZE_t _rmq_tree_max(self, int node, int node_lo, int node_hi,
+    cdef Py_ssize_t _rmq_tree_max(self, int node, int node_lo, int node_hi,
                               int lo, int hi) nogil:
         """Maximum excess over leaf-blocks [lo, hi].
 
@@ -675,7 +675,7 @@ cdef class BPTree:
         why every fully-covered node is a real block.
         """
         cdef int mid
-        cdef SIZE_t left_v, right_v
+        cdef Py_ssize_t left_v, right_v
 
         if hi < node_lo or node_hi < lo:  # no overlap
             return -INT_MAX
@@ -713,7 +713,7 @@ cdef class BPTree:
     def __reduce__(self):
         return (BPTree, (self.data, self._lengths, self._names))
 
-    cpdef SIZE_t depth(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t depth(self, Py_ssize_t i) nogil:
         """The depth of given node.
         
         Parameters
@@ -728,11 +728,11 @@ cdef class BPTree:
         """
         return self._e_index[i]
 
-    cpdef SIZE_t root(self) nogil:
+    cpdef Py_ssize_t root(self) nogil:
         """The index of the root node of the tree."""
         return 0
 
-    cpdef SIZE_t parent(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t parent(self, Py_ssize_t i) nogil:
         """The parent of node.
 
         Parameters
@@ -750,7 +750,7 @@ cdef class BPTree:
         else:
             return self.enclose(i)
 
-    cpdef BOOL_t is_tip(self, SIZE_t i) nogil:
+    cpdef BOOL_t is_tip(self, Py_ssize_t i) nogil:
         """Whether the node is a tip of a tree.
         
         Parameters
@@ -765,7 +765,7 @@ cdef class BPTree:
         """
         return self._b_ptr[i] and (not self._b_ptr[i + 1])
 
-    cpdef SIZE_t first_child(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t first_child(self, Py_ssize_t i) nogil:
         """Index of the first (leftmost) child of a node.
 
         Parameters
@@ -798,7 +798,7 @@ cdef class BPTree:
         else:
             return self.first_child(self.open(i))
 
-    cpdef SIZE_t last_child(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t last_child(self, Py_ssize_t i) nogil:
         """Index of the last (rightmost) child of a node.
 
         Parameters
@@ -831,12 +831,12 @@ cdef class BPTree:
         else:
             return self.last_child(self.open(i))
 
-    def mincount(self, SIZE_t i, SIZE_t j):
+    def mincount(self, Py_ssize_t i, Py_ssize_t j):
         """number of occurrences of the minimum in excess(i), excess(i + 1), . . . , excess(j)."""
         excess, counts = np.unique([self.excess(k) for k in range(i, j + 1)], return_counts=True)
         return counts[excess.argmin()]
 
-    def minselect(self, SIZE_t i, SIZE_t j, SIZE_t q):
+    def minselect(self, Py_ssize_t i, Py_ssize_t j, Py_ssize_t q):
         """position of the qth minimum in excess(i), excess(i + 1), . . . , excess(j)."""
         counts = np.array([self.excess(k) for k in range(i, j + 1)])
         index = counts == counts.min()
@@ -846,7 +846,7 @@ cdef class BPTree:
         else:
             return i + index.nonzero()[0][q - 1]
 
-    cpdef SIZE_t next_sibling(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t next_sibling(self, Py_ssize_t i) nogil:
         """Index of the next (right) sibling of a node.
 
         Parameters
@@ -871,7 +871,7 @@ cdef class BPTree:
         :meth:`~skbio.tree.TreeNode.siblings`, which returns a list of all
         sibling nodes.
         """
-        cdef SIZE_t pos
+        cdef Py_ssize_t pos
 
         if self._b_ptr[i]:
             pos = self.close(i) + 1
@@ -885,7 +885,7 @@ cdef class BPTree:
         else:
             return 0
 
-    cpdef SIZE_t previous_sibling(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t previous_sibling(self, Py_ssize_t i) nogil:
         """Index of the previous (left) sibling of a node.
 
         Parameters
@@ -910,7 +910,7 @@ cdef class BPTree:
         :meth:`~skbio.tree.TreeNode.siblings`, which returns a list of all
         sibling nodes.
         """
-        cdef SIZE_t pos
+        cdef Py_ssize_t pos
 
         if self._b_ptr[i]:
             if self._b_ptr[max(0, i - 1)]:
@@ -927,7 +927,7 @@ cdef class BPTree:
         else:
             return 0
 
-    cpdef SIZE_t preorder_rank(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t preorder_rank(self, Py_ssize_t i) nogil:
         """Preorder rank of a node.
 
         Parameters
@@ -957,7 +957,7 @@ cdef class BPTree:
         else:
             return self.preorder_rank(self.open(i))
 
-    cpdef SIZE_t preorder_select(self, SIZE_t k) nogil:
+    cpdef Py_ssize_t preorder_select(self, Py_ssize_t k) nogil:
         """Index of the node with a given preorder rank.
 
         Parameters
@@ -983,7 +983,7 @@ cdef class BPTree:
         """
         return self.select(1, k)
 
-    cpdef SIZE_t postorder_rank(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t postorder_rank(self, Py_ssize_t i) nogil:
         """Postorder rank of a node.
 
         Parameters
@@ -1013,7 +1013,7 @@ cdef class BPTree:
         else:
             return self.rank(0, i)
 
-    cpdef SIZE_t postorder_select(self, SIZE_t k) nogil:
+    cpdef Py_ssize_t postorder_select(self, Py_ssize_t k) nogil:
         """Index of the node with a given postorder rank.
 
         Parameters
@@ -1039,7 +1039,7 @@ cdef class BPTree:
         """
         return self.open(self.select(0, k))
 
-    cpdef BOOL_t is_ancestor(self, SIZE_t i, SIZE_t j) nogil:
+    cpdef BOOL_t is_ancestor(self, Py_ssize_t i, Py_ssize_t j) nogil:
         """Whether a node is an ancestor of another node.
 
         Parameters
@@ -1066,7 +1066,7 @@ cdef class BPTree:
 
         return i <= j < self.close(i)
 
-    cpdef SIZE_t count(self, SIZE_t i=0, bint tips=False) nogil:
+    cpdef Py_ssize_t count(self, Py_ssize_t i=0, bint tips=False) nogil:
         """Get the count of nodes in the subtree rooted at a node.
 
         Parameters
@@ -1094,7 +1094,7 @@ cdef class BPTree:
 
         """
         cdef:
-            SIZE_t last, j, c
+            Py_ssize_t last, j, c
 
         if not self._b_ptr[i]:
             i = self.open(i)
@@ -1115,7 +1115,7 @@ cdef class BPTree:
 
         return c
 
-    cpdef SIZE_t level_ancestor(self, SIZE_t i, SIZE_t d) nogil:
+    cpdef Py_ssize_t level_ancestor(self, Py_ssize_t i, Py_ssize_t d) nogil:
         """Index of the ancestor a given number of levels above a node.
 
         Parameters
@@ -1150,7 +1150,7 @@ cdef class BPTree:
 
         return self.bwdsearch(i, -d - 1) + 1
 
-    cpdef SIZE_t level_next(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t level_next(self, Py_ssize_t i) nogil:
         """Index of the next node at the same depth.
 
         Parameters
@@ -1177,7 +1177,7 @@ cdef class BPTree:
         """
         return self.fwdsearch(self.close(i), 1)
 
-    cpdef SIZE_t lca(self, SIZE_t i, SIZE_t j) nogil:
+    cpdef Py_ssize_t lca(self, Py_ssize_t i, Py_ssize_t j) nogil:
         """The lowest common ancestor of two nodes.
 
         Parameters
@@ -1199,7 +1199,7 @@ cdef class BPTree:
         else:
             return self.parent(self.rmq(i, j) + 1)
 
-    cpdef SIZE_t deepest_node(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t deepest_node(self, Py_ssize_t i) nogil:
         """Index of the deepest node descending from a node.
 
         Parameters
@@ -1225,7 +1225,7 @@ cdef class BPTree:
         """
         return self.rMq(self.open(i), self.close(i))
 
-    cpdef SIZE_t height(self, SIZE_t i) nogil:
+    cpdef Py_ssize_t height(self, Py_ssize_t i) nogil:
         """The height of node i with respect to its deepest descendent
 
         Parameters
@@ -1259,8 +1259,8 @@ cdef class BPTree:
             ancestors.
         """
         cdef:
-            SIZE_t i, n = len(tips)
-            SIZE_t p, t, count = 0
+            Py_ssize_t i, n = len(tips)
+            Py_ssize_t p, t, count = 0
             BIT_ARRAY* mask
             BPTree new_bp
 
@@ -1295,7 +1295,7 @@ cdef class BPTree:
     cdef BPTree _mask_from_self(self, BIT_ARRAY* mask,
                             cnp.ndarray[DOUBLE_t, ndim=1] lengths):
         cdef:
-            SIZE_t i, k, n, mask_sum
+            Py_ssize_t i, k, n, mask_sum
             cnp.ndarray[BOOL_t, ndim=1] new_b
             cnp.ndarray[object, ndim=1] new_names
             cnp.ndarray[object, ndim=1] names = self._names
@@ -1351,8 +1351,8 @@ cdef class BPTree:
 
         """
         cdef:
-            SIZE_t i, n = self.data.sum()
-            SIZE_t current, first, last
+            Py_ssize_t i, n = self.data.sum()
+            Py_ssize_t current, first, last
             cnp.ndarray[DOUBLE_t, ndim=1] new_lengths
             BIT_ARRAY* mask
             DOUBLE_t* new_lengths_ptr
@@ -1387,7 +1387,7 @@ cdef class BPTree:
         bit_array_free(mask)
         return new_bp
 
-    cdef SIZE_t scan_block_forward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil:
+    cdef Py_ssize_t scan_block_forward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil:
         """Scan a block forward from i.
 
         Parameters
@@ -1407,9 +1407,9 @@ cdef class BPTree:
             The index position of the result. -1 is returned if a result is not
             found.
         """
-        cdef SIZE_t lower_bound
-        cdef SIZE_t upper_bound
-        cdef SIZE_t j
+        cdef Py_ssize_t lower_bound
+        cdef Py_ssize_t upper_bound
+        cdef Py_ssize_t j
 
         # lower_bound is block boundary or right of i
         lower_bound = max(k, 0) * b
@@ -1424,7 +1424,7 @@ cdef class BPTree:
 
         return -1
 
-    cdef SIZE_t scan_block_backward(self, SIZE_t i, int k, SIZE_t b, SIZE_t d) nogil:
+    cdef Py_ssize_t scan_block_backward(self, Py_ssize_t i, int k, Py_ssize_t b, Py_ssize_t d) nogil:
         """Scan a block backward from i.
 
         Parameters
@@ -1444,9 +1444,9 @@ cdef class BPTree:
             The index position of the result. -1 is returned if a result is not
             found.
         """
-        cdef SIZE_t lower_bound
-        cdef SIZE_t upper_bound
-        cdef SIZE_t j
+        cdef Py_ssize_t lower_bound
+        cdef Py_ssize_t upper_bound
+        cdef Py_ssize_t j
 
         # range stop is exclusive, so need to set "stop" at -1 of boundary
         lower_bound = max(k, 0) * b - 1
@@ -1470,7 +1470,7 @@ cdef class BPTree:
 
         return -1
 
-    cdef SIZE_t fwdsearch(self, SIZE_t i, SIZE_t d) nogil:
+    cdef Py_ssize_t fwdsearch(self, Py_ssize_t i, Py_ssize_t d) nogil:
         """Search forward from i for desired excess.
 
         Parameters
@@ -1486,7 +1486,7 @@ cdef class BPTree:
             The index of the result, or -1 if no result was found
         """
         cdef int k  # the block being interrogated
-        cdef SIZE_t result = -1 # the result of a scan within a block
+        cdef Py_ssize_t result = -1 # the result of a scan within a block
         cdef int node  # the node within the binary tree being examined
 
         # get the block of parentheses to check
@@ -1532,7 +1532,7 @@ cdef class BPTree:
 
         return result
 
-    cdef SIZE_t bwdsearch(self, SIZE_t i, SIZE_t d) nogil:
+    cdef Py_ssize_t bwdsearch(self, Py_ssize_t i, Py_ssize_t d) nogil:
         """Search backward from i for desired excess
 
         Parameters
@@ -1548,7 +1548,7 @@ cdef class BPTree:
             The index of the result, or -1 if no result was found
         """
         cdef int k  # the block being interrogated
-        cdef SIZE_t result = -1 # the result of a scan within a block
+        cdef Py_ssize_t result = -1 # the result of a scan within a block
         cdef int node  # the node within the binary tree being examined
 
         # get the block of parentheses to check

--- a/skbio/tree/bp/_bp_binary_tree.pxd
+++ b/skbio/tree/bp/_bp_binary_tree.pxd
@@ -14,60 +14,59 @@
 # from https://github.com/jfuentess/sea2015/blob/master/binary_trees.h
 
 from libc.math cimport pow, log2, floor
-from ._bp cimport SIZE_t
 
 
-cdef inline SIZE_t bt_is_root(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_is_root(Py_ssize_t v) nogil:
     """Is v the root"""
     return v == 0
 
 
-cdef inline SIZE_t bt_is_left_child(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_is_left_child(Py_ssize_t v) nogil:
     """Is v a left child of some node"""
     return 0 if bt_is_root(v) else v % 2
 
 
-cdef inline SIZE_t bt_is_right_child(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_is_right_child(Py_ssize_t v) nogil:
     """Is v a right child of some node"""
     return 0 if bt_is_root(v) else 1 - (v % 2)
 
 
-cdef inline SIZE_t bt_parent(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_parent(Py_ssize_t v) nogil:
     """Get the index of the parent of v"""
     return 0 if bt_is_root(v) else (v - 1) // 2
 
 
-cdef inline SIZE_t bt_left_child(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_left_child(Py_ssize_t v) nogil:
     """Get the index of the left child of v"""
     return 2 * v + 1
 
 
-cdef inline SIZE_t bt_right_child(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_right_child(Py_ssize_t v) nogil:
     """Get the index of the right child of v"""
     return 2 * v + 2
 
 
-cdef inline SIZE_t bt_left_sibling(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_left_sibling(Py_ssize_t v) nogil:
     """Get the index of the left sibling of v"""
     return v - 1
 
 
-cdef inline SIZE_t bt_right_sibling(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_right_sibling(Py_ssize_t v) nogil:
     """Get the index of the right sibling of v"""
     return v + 1
 
 
-cdef inline SIZE_t bt_is_leaf(SIZE_t v, SIZE_t height) nogil:
+cdef inline Py_ssize_t bt_is_leaf(Py_ssize_t v, Py_ssize_t height) nogil:
     """Determine if v is a leaf"""
-    return <SIZE_t>(v >= pow(2, height) - 1)
+    return <Py_ssize_t>(v >= pow(2, height) - 1)
 
 
-cdef inline SIZE_t bt_node_from_left(SIZE_t pos, SIZE_t height) nogil:
+cdef inline Py_ssize_t bt_node_from_left(Py_ssize_t pos, Py_ssize_t height) nogil:
     """Get the index from the left of a node at a given height"""
-    return <SIZE_t>pow(2, height) - 1 + pos
+    return <Py_ssize_t>pow(2, height) - 1 + pos
 
 
-cdef inline SIZE_t bt_offset_from_left(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_offset_from_left(Py_ssize_t v) nogil:
     """Get the position from left of a node at its level
 
     This is the inverse of bt_node_from_left
@@ -81,38 +80,38 @@ cdef inline SIZE_t bt_offset_from_left(SIZE_t v) nogil:
     if leftmost_check == floor(leftmost_check):
         return 0
 
-    return v - <SIZE_t>pow(2, floor(log2(v))) + 1
+    return v - <Py_ssize_t>pow(2, floor(log2(v))) + 1
 
 
-cdef inline SIZE_t bt_offset_from_right(SIZE_t v) nogil:
+cdef inline Py_ssize_t bt_offset_from_right(Py_ssize_t v) nogil:
     """Get the position from right of a node at its level"""
-    cdef SIZE_t lvl = <SIZE_t>floor(log2(v + 1))
-    cdef SIZE_t n_nodes_at_lvl = <SIZE_t>pow(2, lvl)
+    cdef Py_ssize_t lvl = <Py_ssize_t>floor(log2(v + 1))
+    cdef Py_ssize_t n_nodes_at_lvl = <Py_ssize_t>pow(2, lvl)
 
     return n_nodes_at_lvl - bt_offset_from_left(v) - 1
 
 
-cdef inline SIZE_t bt_left_leaf(SIZE_t v, SIZE_t height) nogil:
+cdef inline Py_ssize_t bt_left_leaf(Py_ssize_t v, Py_ssize_t height) nogil:
     """Determine the index of a nodes left most leaf"""
-    cdef SIZE_t left_tip = <SIZE_t>pow(2, height) - 1
-    cdef SIZE_t block_size
+    cdef Py_ssize_t left_tip = <Py_ssize_t>pow(2, height) - 1
+    cdef Py_ssize_t block_size
 
     if bt_is_root(v):
         return left_tip
 
-    block_size = <SIZE_t>pow(2, height - floor(log2(v + 1)))
+    block_size = <Py_ssize_t>pow(2, height - floor(log2(v + 1)))
 
     return left_tip + (block_size * bt_offset_from_left(v))
 
 
-cdef inline SIZE_t bt_right_leaf(SIZE_t v, SIZE_t height) nogil:
+cdef inline Py_ssize_t bt_right_leaf(Py_ssize_t v, Py_ssize_t height) nogil:
     """Determine the index of a nodes right most leaf"""
-    cdef SIZE_t right_tip = <SIZE_t>pow(2, height + 1) - 2
-    cdef SIZE_t block_size
+    cdef Py_ssize_t right_tip = <Py_ssize_t>pow(2, height + 1) - 2
+    cdef Py_ssize_t block_size
 
     if bt_is_root(v):
         return right_tip
 
-    block_size = <SIZE_t>pow(2, height - floor(log2(v + 1)))
+    block_size = <Py_ssize_t>pow(2, height - floor(log2(v + 1)))
 
     return right_tip - (block_size * bt_offset_from_right(v))


### PR DESCRIPTION
## Summary

Two focused, **output-preserving** improvements to the balanced-parentheses `BPTree` backend introduced in #2498. Both target the `bp_tree` feature branch and leave the public API, the stored arrays, and every query result bit-for-bit identical.

1. **PERF** — answer range-minimum/maximum *excess* queries in **O(log n)** instead of O(span), speeding up `rmq`, `rMq`, and everything built on them (`lca`, `height`, `deepest_node`).
2. **MAINT** — widen the rmM-tree construction and the `fwdsearch`/`bwdsearch` search kernel from 32-bit C `int` to 64-bit indices, removing a silent overflow ceiling at ~537 M tips.

## 1. O(log n) range min/max excess queries

`rmq(i, j)` / `rMq(i, j)` find the position of the minimum / maximum *excess* in the parenthesis range `[i, j]`. The original port answered them by **linearly scanning the range**, so cost grew with the array distance `j − i`. Because `lca`, `height`, and `deepest_node` are all thin wrappers over these, a lowest-common-ancestor query between two distant nodes, or a whole-subtree height, degraded to an O(n) scan.

This rewrite instead **descends the rmM (range min-max) tree** — the block-summary structure already built at construction — to obtain the min/max excess over the range in O(log n), scanning only the two partial end-blocks. The attaining position is then recovered with a single existing `fwdsearch`, so no new "leftmost-qualifying-block” descent logic is introduced (`i` if `excess(i)` already equals the target, else `fwdsearch(i, target − excess(i))`). Segment-tree bounds are clamped so a fully-covered node never reads into the partially-filled last level of the heap.

**This is a general asymptotic win, not a deep-tree special case.** For far-separated node pairs the array distance is ~O(n) on *every* topology, so the improvement scales with tree size across balanced, caterpillar, and random shapes alike (see benchmarks). Queries between *near* nodes (small range) were already cheap and are unchanged.

## 2. 64-bit search kernel

The rmM-tree construction and the `fwdsearch`/`bwdsearch` kernel used C `int` for parenthesis positions, block sizes, block counts, and excess deltas — inherited verbatim from the [improved-octo-waddle](https://github.com/biocore/improved-octo-waddle) port. Above `2³¹` parentheses (~537 M tips) these **silently overflowed**, corrupting navigation rather than raising an error. This widens the loop counters and scan positions to 64-bit (`npy_intp`). The stored index arrays were *already* 64-bit, so the on-disk/in-memory footprint and per-operation runtime are unchanged; only the transient kernel arithmetic was widened.

## Testing

Both changes are verified bit-for-bit identical to the pre-PR backend:

- **52 `BPTree` unit tests** pass (`skbio/tree/tests/bp`), including the compiled `test_bp_cy.pyx` that exercises the `cimport`ed C vtable.
- **627,102 exhaustive equivalence checks** (`BPTree` vs `TreeNode` across 22 operations, balanced/caterpillar/random topologies × 4 seeds) — 0 failures.
- The rmM rewrite was additionally cross-checked against a brute-force O(span) oracle over millions of `(i, j)` pairs spanning varied block layouts and tail-block sizes — 0 disagreements.

## Benchmarks

Measured with the standalone `bptree-benchmarks` suite: each git ref built into an isolated `pip --target` install and timed in a fresh subprocess (`min` of repeated trials), across `balanced` / `caterpillar` / `random` topologies at 1K – 500K tips. Baseline is the pre-PR backend (`bp_tree` @ #2498).

**`lca` between far-apart nodes — old ns → new ns (speed-up):**

| topology | 1K | 100K | 500K |
|---|---|---|---|
| balanced | 7440 → 593 (**12.5×**) | 702K → 1020 (**688×**) | 3.67M → 1004 (**3650×**) |
| caterpillar | 5703 → 639 (**8.9×**) | 520K → 1055 (**493×**) | 2.72M → 1220 (**2233×**) |
| random | 7461 → 626 (**11.9×**) | 693K → 927 (**747×**) | 3.64M → 1072 (**3392×**) |

The old cost grows ~linearly with tree size on all three topologies; the new cost is a flat sub-microsecond regardless of size or shape. `rmq`/`rMq` themselves show the same pattern (up to ~5000–6700× at 500K).

**`height` / `deepest_node` (whole-tree range) — speed-up old → new:**

| topology | 1K | 100K | 500K |
|---|---|---|---|
| balanced | 1.7× | 1.9× | 1.5× |
| caterpillar | 18–21× | ~1300× | **~6000×** |
| random | 1.4–2.0× | 1.6–3.0× | 1.6× |

**Unchanged (controls), old → new ≈ 1.0× on every topology/size:**

- `lca` between *near* nodes: 0.24 µs → 0.23 µs (small range, already cheap).
- Navigation (`parent`, `first_child`, `next_sibling`, `close`, …): within noise.
- Construction (`parse_newick`, `from_treenode`): within noise.
- Memory footprint: unchanged (no stored array changed dtype; the 64-bit widening touches
  only transient kernel arithmetic).

## Scope / follow-up

- A follow-up PR rebalances the Cython/Python boundary of the same backend and stacks on top of this branch.

Please complete the following checklist:
* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.
* [x] This pull request does not include code, documentation, or other content derived from external source(s).