### PR TITLE
MAINT: Rename two PCA tests that shadowed the ones above them

### DIFF
--- a/skbio/stats/ordination/tests/test_principal_component_analysis.py
+++ b/skbio/stats/ordination/tests/test_principal_component_analysis.py
@@ -196,7 +196,7 @@ class TestPCA(TestCase):
         assert_ordination_results_equal(results, self.reduced_dim_expected_results,
                                         ignore_directionality=True)
         
-    def test_eigh_full_dim(self):
+    def test_eigh_full_dim_iterative(self):
         results = pca(self.X, 
                       method="eigh",
                       iterative=True,
@@ -206,7 +206,7 @@ class TestPCA(TestCase):
         assert_ordination_results_equal(results, self.full_dim_expected_results,
                                         ignore_directionality=True)
         
-    def test_eigh_reduced_dim(self):
+    def test_eigh_reduced_dim_iterative(self):
         results = pca(self.X, 
                       method="eigh",
                       dimensions=2,


### PR DESCRIPTION
`TestPCA` in `skbio/stats/ordination/tests/test_principal_component_analysis.py` defines `test_eigh_full_dim` and `test_eigh_reduced_dim` twice each. The second pair are the `iterative=True` variants; they look like copies of the pair above that were never renamed. Being class attributes, they replace the earlier definitions, so the first two never run:

```
$ pytest skbio/stats/ordination/tests/test_principal_component_analysis.py
10 passed
```

12 test methods are written in the file, 10 are collected.

The `svd` tests directly above already distinguish the two cases with an `_iterative` suffix:

```
test_svd_full_dim              test_eigh_full_dim
test_svd_reduced_dim           test_eigh_reduced_dim
test_svd_full_dim_iterative    test_eigh_full_dim        <- shadows
test_svd_reduced_dim_iterative test_eigh_reduced_dim     <- shadows
```

This renames the `eigh` pair the same way, which makes the block symmetric with the `svd` one and lets all 12 run:

```
$ pytest skbio/stats/ordination/tests/test_principal_component_analysis.py
12 passed
```

### Scope

To be clear about what this does and does not do: it does **not** close a coverage gap. `test_simple` and `test_dimensionality_reduction` call `pca` with the defaults, and those defaults are `method="eigh"` and `iterative=False` — the exact combinations the shadowed tests assert. I measured line and branch coverage of `_principal_component_analysis.py` before and after and it is 100% either way.

So this is a test-suite correctness fix rather than a behavioural one: two tests that were written to run were silently not running, and the file no longer says what it means.

### Notes

I did not add a changelog entry, since the PR template asks for those on public-facing changes and this one is test-only. Happy to add one under Miscellaneous if you would prefer.

I could not run the full suite locally — `biom-format` has no Python 3.14 wheel here and the compiled `_cutils` extensions fail to load on this machine — so I ran this test module against an installed scikit-bio with those two pieces stubbed out. CI will be the real check.
