### PR TITLE
MAINT: reduce warnings emitted by the test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed an unexpected behavior in differential abundance tests (`ancombc` and `dirmult_lme`) where string columns in the metadata that can be cast into numbers (e.g., `["1", "2", "3"]`) were treated as numerical. Now they are treated as categories ([#2539](https://github.com/scikit-bio/scikit-bio/pull/2539)).
 * Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
+* Fixed `TabularMSA.gap_frequencies(relative=True)` emitting a zero-division warning for alignments with no positions. Return values are unchanged.
 * Patched `rclr` such that it won't raise a zero division warning ([#2526](https://github.com/scikit-bio/scikit-bio/pull/2526)).
 * Fixed `permanova` returning an inaccurate pseudo-F for float32 distance matrices, caused by accumulating the total sum of squares in float32 rather than float64 [#2509](https://github.com/scikit-bio/scikit-bio/pull/2509).
 * `permanova` and `pcoa` now honor `engine="numba"` by not taking the scikit-bio-binaries path (the Cython-equivalent acceleration) [#2510](https://github.com/scikit-bio/scikit-bio/pull/2510).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 * Fixed an unexpected behavior in differential abundance tests (`ancombc` and `dirmult_lme`) where string columns in the metadata that can be cast into numbers (e.g., `["1", "2", "3"]`) were treated as numerical. Now they are treated as categories ([#2539](https://github.com/scikit-bio/scikit-bio/pull/2539)).
 * Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).
-* Fixed `TabularMSA.gap_frequencies(relative=True)` emitting a zero-division warning for alignments with no positions. Return values are unchanged.
+* Fixed `TabularMSA.gap_frequencies(relative=True)` emitting a zero-division warning for alignments with no positions. Return values are unchanged ([#2543](https://github.com/scikit-bio/scikit-bio/pull/2543)).
+* Fixed `Sequence.frequencies(relative=True)` emitting a zero-division warning for empty sequences. Return values are unchanged ([#2543](https://github.com/scikit-bio/scikit-bio/pull/2543)).
 * Patched `rclr` such that it won't raise a zero division warning ([#2526](https://github.com/scikit-bio/scikit-bio/pull/2526)).
 * Fixed `permanova` returning an inaccurate pseudo-F for float32 distance matrices, caused by accumulating the total sum of squares in float32 rather than float64 [#2509](https://github.com/scikit-bio/scikit-bio/pull/2509).
 * `permanova` and `pcoa` now honor `engine="numba"` by not taking the scikit-bio-binaries path (the Cython-equivalent acceleration) [#2510](https://github.com/scikit-bio/scikit-bio/pull/2510).

--- a/skbio/alignment/_tabular_msa.py
+++ b/skbio/alignment/_tabular_msa.py
@@ -1666,8 +1666,10 @@ class TabularMSA(MetadataMixin, PositionalMetadataMixin, SkbioObject):
 
         gap_freqs = np.asarray(gap_freqs, dtype=float if relative else int)
 
-        if relative:
+        if relative and length:
             gap_freqs /= length
+        elif relative:
+            gap_freqs.fill(np.nan)
 
         return gap_freqs
 

--- a/skbio/alignment/tests/test_tabular_msa.py
+++ b/skbio/alignment/tests/test_tabular_msa.py
@@ -3455,8 +3455,9 @@ class TestGapFrequencies(unittest.TestCase):
     def test_no_positions_relative(self):
         msa = TabularMSA([DNA('')])
 
-        seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
-        pos_freqs = msa.gap_frequencies(axis='position', relative=True)
+        with np.errstate(divide='raise', invalid='raise'):
+            seq_freqs = msa.gap_frequencies(axis='sequence', relative=True)
+            pos_freqs = msa.gap_frequencies(axis='position', relative=True)
 
         npt.assert_array_equal(np.array([]), seq_freqs)
         npt.assert_array_equal(np.array([np.nan]), pos_freqs)

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -422,10 +422,14 @@ class BetaDiversityTests(TestCase):
             beta_diversity('weighted_unifrac', [[0, 1, 3], [0, 3, 12]],
                            not_a_real_kwarg=42.0, tree=self.tree1,
                            taxa=['O1', 'O2', 'O3'])
-        with self.assertRaisesRegex(TypeError, error_msg):
-            beta_diversity(weighted_unifrac, [[0, 1, 3], [0, 3, 12]],
-                           not_a_real_kwarg=42.0, tree=self.tree1,
-                           taxa=['O1', 'O2', 'O3'])
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Passing `weighted_unifrac` as a callable"
+            )
+            with self.assertRaisesRegex(TypeError, error_msg):
+                beta_diversity(weighted_unifrac, [[0, 1, 3], [0, 3, 12]],
+                               not_a_real_kwarg=42.0, tree=self.tree1,
+                               taxa=['O1', 'O2', 'O3'])
 
         # non-matching id or taxon counts
         msg = "Input table has 3 samples whereas 2 sample IDs were provided."
@@ -434,16 +438,24 @@ class BetaDiversityTests(TestCase):
         self.assertEqual(str(cm.exception), msg)
 
         msg = "Input table has 2 features whereas 3 feature IDs were provided."
-        with self.assertRaises(ValueError) as cm:
-            beta_diversity(weighted_unifrac, example_table, taxa=['foo', 'bar', 'qux'],
-                           tree=self.tree1)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Passing `weighted_unifrac` as a callable"
+            )
+            with self.assertRaises(ValueError) as cm:
+                beta_diversity(weighted_unifrac, example_table,
+                               taxa=['foo', 'bar', 'qux'], tree=self.tree1)
         self.assertEqual(str(cm.exception), msg)
 
         # non-matching taxa and tree
         msg = "2 taxa are not present as tip names in the tree."
-        with self.assertRaises(MissingNodeError) as cm:
-            beta_diversity(weighted_unifrac, example_table, taxa=['foo', 'bar'],
-                           tree=self.tree1)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Passing `weighted_unifrac` as a callable"
+            )
+            with self.assertRaises(MissingNodeError) as cm:
+                beta_diversity(weighted_unifrac, example_table,
+                               taxa=['foo', 'bar'], tree=self.tree1)
         self.assertEqual(str(cm.exception), msg)
 
     def test_invalid_input_mahalanobis(self):
@@ -657,8 +669,9 @@ class BetaDiversityTests(TestCase):
         # expected values calculated by hand
         dm1 = beta_diversity('unweighted_unifrac', self.table1, self.sids1,
                              taxa=self.oids1, tree=self.tree1)
-        dm2 = beta_diversity(unweighted_unifrac, self.table1, self.sids1,
-                             taxa=self.oids1, tree=self.tree1)
+        with self.assertWarnsRegex(UserWarning, "unweighted_unifrac"):
+            dm2 = beta_diversity(unweighted_unifrac, self.table1, self.sids1,
+                                 taxa=self.oids1, tree=self.tree1)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
         expected_data = [[0.0, 0.0, 0.25],
@@ -676,8 +689,9 @@ class BetaDiversityTests(TestCase):
         # expected values calculated by hand
         dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
                              taxa=self.oids1, tree=self.tree1)
-        dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
-                             taxa=self.oids1, tree=self.tree1)
+        with self.assertWarnsRegex(UserWarning, "weighted_unifrac"):
+            dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
+                                 taxa=self.oids1, tree=self.tree1)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
         expected_data = [
@@ -697,9 +711,10 @@ class BetaDiversityTests(TestCase):
         dm1 = beta_diversity('weighted_unifrac', self.table1, self.sids1,
                              taxa=self.oids1, tree=self.tree1,
                              normalized=True)
-        dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
-                             taxa=self.oids1, tree=self.tree1,
-                             normalized=True)
+        with self.assertWarnsRegex(UserWarning, "weighted_unifrac"):
+            dm2 = beta_diversity(weighted_unifrac, self.table1, self.sids1,
+                                 taxa=self.oids1, tree=self.tree1,
+                                 normalized=True)
         self.assertEqual(dm1.shape, (3, 3))
         self.assertEqual(dm1, dm2)
         expected_data = [
@@ -740,9 +755,10 @@ class BetaDiversityTests(TestCase):
         expected = DistanceMatrix([[0.0, 42.0], [42.0, 0.0]])
         self.assertEqual(dm1, expected)
 
-        dm1 = beta_diversity(unweighted_unifrac, self.table1,
-                             taxa=self.oids1, tree=self.tree1,
-                             pairwise_func=not_a_real_pdist)
+        with self.assertWarnsRegex(UserWarning, "unweighted_unifrac"):
+            dm1 = beta_diversity(unweighted_unifrac, self.table1,
+                                 taxa=self.oids1, tree=self.tree1,
+                                 pairwise_func=not_a_real_pdist)
         expected = DistanceMatrix([[0.0, 42.0], [42.0, 0.0]])
         self.assertEqual(dm1, expected)
 

--- a/skbio/io/tests/test_descriptors.py
+++ b/skbio/io/tests/test_descriptors.py
@@ -327,17 +327,17 @@ class TestInheritanceIntegration(unittest.TestCase):
     
     def test_child_inherits_read(self):
         """Test that child class inherits parent's read capability."""
-        fh = StringIO("child data")
+        fh = StringIO("TESTDATA:child data")
         obj = self.ChildClass.read(fh, format='inheritance_test_format')
         self.assertIsInstance(obj, self.ChildClass)
-        self.assertEqual(obj.data, "child data")
+        self.assertEqual(obj.data, "TESTDATA:child data")
     
     def test_grandchild_inherits_read(self):
         """Test that grandchild class inherits parent's read capability."""
-        fh = StringIO("grandchild data")
+        fh = StringIO("TESTDATA:grandchild data")
         obj = self.GrandchildClass.read(fh, format='inheritance_test_format')
         self.assertIsInstance(obj, self.GrandchildClass)
-        self.assertEqual(obj.data, "grandchild data")
+        self.assertEqual(obj.data, "TESTDATA:grandchild data")
     
     def test_child_inherits_write(self):
         """Test that child class inherits parent's write capability."""

--- a/skbio/sequence/_sequence.py
+++ b/skbio/sequence/_sequence.py
@@ -1829,7 +1829,10 @@ fuzzy=[(True, False)], metadata={'gene': 'foo'})
 
         obs_counts = freqs[indices]
         if relative:
-            obs_counts = obs_counts / len(self)
+            if len(self):
+                obs_counts = obs_counts / len(self)
+            else:
+                obs_counts = np.full_like(obs_counts, np.nan, dtype=float)
 
         # Use tolist() for minor performance gain.
         return dict(zip(chars, obs_counts.tolist()))

--- a/skbio/sequence/tests/test_sequence.py
+++ b/skbio/sequence/tests/test_sequence.py
@@ -1432,16 +1432,16 @@ class TestSequence(TestSequenceBase, ReallyEqualMixin):
         seq = Sequence('')
 
         self.assertEqual(seq.frequencies(), {})
-        self.assertEqual(seq.frequencies(relative=True), {})
-
         self.assertEqual(seq.frequencies(chars=set()), {})
-        self.assertEqual(seq.frequencies(chars=set(), relative=True), {})
-
         self.assertEqual(seq.frequencies(chars={'a', 'b'}), {'a': 0, 'b': 0})
 
-        # use npt.assert_equal to explicitly handle nan comparisons
-        npt.assert_equal(seq.frequencies(chars={'a', 'b'}, relative=True),
-                         {'a': np.nan, 'b': np.nan})
+        with np.errstate(divide='raise', invalid='raise'):
+            self.assertEqual(seq.frequencies(relative=True), {})
+            self.assertEqual(seq.frequencies(chars=set(), relative=True), {})
+
+            # use npt.assert_equal to explicitly handle nan comparisons
+            npt.assert_equal(seq.frequencies(chars={'a', 'b'}, relative=True),
+                             {'a': np.nan, 'b': np.nan})
 
     def test_frequencies_observed_chars(self):
         seq = Sequence('x')

--- a/skbio/stats/composition/tests/test_base.py
+++ b/skbio/stats/composition/tests/test_base.py
@@ -624,7 +624,7 @@ class CompositionTests(TestCase, ArrayAPITestMixin):
             tmp = np.exp(data - np.max(data, axis=axis, keepdims=True))
             expected = tmp / np.sum(tmp, axis=axis, keepdims=True)
             arr = self.make_array(xp, device, data)
-            result = clr_inv(arr, axis)
+            result = clr_inv(arr, axis=axis, validate=False)
 
             self.assert_type_preserved(result, xp, device)
             self.assertEqual(result.shape, arr.shape)

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -171,12 +171,17 @@ def permdisp(
     ...                       ['s1', 's2', 's3', 's4', 's5', 's6'])
     >>> grouping = ['G1', 'G1', 'G1', 'G2', 'G2', 'G2']
 
+    This illustrative distance matrix is non-Euclidean. The examples below disable
+    PCoA's negative-eigenvalue warning to keep the focus on PERMDISP usage. This does
+    not alter the results.
+
     Run PERMDISP using 99 permutations to calculate the p-value. The seed is to make
     the output deterministic. You may skip it if that's not necessary.
 
     >>> from skbio.stats.distance import permdisp
     >>> permdisp(dm, grouping, permutations=99, seed=42,
-    ...          dimensions=dm.shape[0]) # doctest: +ELLIPSIS
+    ...          dimensions=dm.shape[0],
+    ...          warn_neg_eigval=False)  # doctest: +ELLIPSIS
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -192,7 +197,8 @@ def permdisp(
     To suppress calculation of the p-value and only obtain the F statistic, specify
     zero permutations:
 
-    >>> permdisp(dm, grouping, permutations=0, dimensions=dm.shape[0])
+    >>> permdisp(dm, grouping, permutations=0, dimensions=dm.shape[0],
+    ...          warn_neg_eigval=False)
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -212,7 +218,7 @@ def permdisp(
     statistics.
 
     >>> permdisp(dm, grouping, test='centroid', permutations=6, seed=42,
-    ...          dimensions=dm.shape[0])
+    ...          dimensions=dm.shape[0], warn_neg_eigval=False)
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -232,7 +238,7 @@ def permdisp(
     ...      {'Grouping': {'s1': 'G1', 's2': 'G1', 's3': 'G1', 's4': 'G2',
     ...                    's5': 'G2', 's6': 'G2'}})
     >>> permdisp(dm, df, 'Grouping', permutations=6, test='centroid', seed=42,
-    ...          dimensions=dm.shape[0])
+    ...          dimensions=dm.shape[0], warn_neg_eigval=False)
     method name               PERMDISP
     test statistic name        F-value
     sample size                      6
@@ -326,4 +332,3 @@ def _compute_groups(samples, test_type, grouping):
 
     stat, _ = f_oneway(*groups)
     return float(np.ravel(stat)[0])
-

--- a/skbio/stats/ordination/tests/test_correspondence_analysis.py
+++ b/skbio/stats/ordination/tests/test_correspondence_analysis.py
@@ -277,6 +277,8 @@ class TestCAResults_NumPy(TestCase):
             features=features,
             samples=samples,
             proportion_explained=proportion_explained,
+            feature_ids=self.feature_ids,
+            sample_ids=self.sample_ids,
         )
 
         # using global config
@@ -310,6 +312,8 @@ class TestCAResults_NumPy(TestCase):
             features=features,
             samples=samples,
             proportion_explained=proportion_explained,
+            feature_ids=self.feature_ids,
+            sample_ids=self.sample_ids,
         )
         obs = ca(self.X, 1, sample_ids=self.sample_ids, feature_ids=self.feature_ids)
 
@@ -320,7 +324,9 @@ class TestCAResults_NumPy(TestCase):
         euclidean distance between them in transformed space."""
         frequencies = self.X / self.X.sum()
         chi2_distances = chi_square_distance(frequencies)
-        transformed_sites = ca(self.X, 1).samples
+        transformed_sites = ca(
+            self.X, 1, sample_ids=self.sample_ids, feature_ids=self.feature_ids
+        ).samples
         euclidean_distances = pdist(transformed_sites, "euclidean")
         npt.assert_almost_equal(chi2_distances, euclidean_distances)
 
@@ -329,7 +335,9 @@ class TestCAResults_NumPy(TestCase):
         equal to euclidean distance between them in transformed space."""
         frequencies = self.X / self.X.sum()
         chi2_distances = chi_square_distance(frequencies, between_rows=False)
-        transformed_species = ca(self.X, 2).features
+        transformed_species = ca(
+            self.X, 2, sample_ids=self.sample_ids, feature_ids=self.feature_ids
+        ).features
         euclidean_distances = pdist(transformed_species, "euclidean")
         npt.assert_almost_equal(chi2_distances, euclidean_distances)
 

--- a/skbio/stats/ordination/tests/test_ordination_results.py
+++ b/skbio/stats/ordination/tests/test_ordination_results.py
@@ -131,6 +131,8 @@ class TestOrdinationResults(unittest.TestCase):
 @unittest.skipUnless(has_matplotlib, "Matplotlib not available.")
 class TestOrdinationResultsPlotting(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(plt.close, "all")
+
         # DataFrame for testing plot method. Has a categorical column with a
         # mix of numbers and strings. Has a numeric column with a mix of ints,
         # floats, and strings that can be converted to floats. Has a numeric
@@ -351,6 +353,8 @@ class TestOrdinationResultsPlotting(unittest.TestCase):
 @unittest.skipUnless(has_matplotlib, "Matplotlib not available.")
 class TestOrdinationResults2DPlotting(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(plt.close, "all")
+
         # DataFrame for testing plot method. Has a categorical column with a
         # mix of numbers and strings. Has a numeric column with a mix of ints,
         # floats, and strings that can be converted to floats. Has a numeric

--- a/skbio/stats/power.py
+++ b/skbio/stats/power.py
@@ -91,22 +91,22 @@ estimate for the critical value of 0.01, and a critical value of 0.001.
 
 >>> from skbio.stats.power import subsample_power
 >>> pwr_100, counts_100 = subsample_power(
-...     test=f, samples=samples, max_counts=10, min_counts=3, counts_interval=1,
+...     test=f, samples=samples, max_counts=10, min_counts=4, counts_interval=1,
 ...     draw_mode='matched', alpha_pwr=0.1, num_iter=25, seed=rng)
 >>> counts_100
-array([3, 4, 5, 6, 7, 8, 9])
+array([4, 5, 6, 7, 8, 9])
 >>> pwr_100.mean(0)
-array([ 0.512,  0.936,  0.984,  1.   ,  1.   ,  1.   ,  1.   ])
+array([ 0.94 ,  0.992,  1.   ,  1.   ,  1.   ,  1.   ])
 >>> pwr_010, counts_010 = subsample_power(
-...     test=f, samples=samples, max_counts=10, min_counts=3, counts_interval=1,
+...     test=f, samples=samples, max_counts=10, min_counts=4, counts_interval=1,
 ...     draw_mode='matched', alpha_pwr=0.01, num_iter=25, seed=rng)
 >>> pwr_010.mean(0)
-array([ 0.072,  0.416,  0.888,  0.964,  1.   ,  0.996,  1.   ])
+array([ 0.4  ,  0.844,  0.956,  0.988,  1.   ,  1.   ])
 >>> pwr_001, counts_001 = subsample_power(
-...     test=f, samples=samples, max_counts=10, min_counts=3, counts_interval=1,
+...     test=f, samples=samples, max_counts=10, min_counts=4, counts_interval=1,
 ...     draw_mode='matched', alpha_pwr=0.001, num_iter=25, seed=rng)
 >>> pwr_001.mean(0)
-array([ 0.   ,  0.044,  0.204,  0.796,  0.948,  0.996,  1.   ])
+array([ 0.044,  0.244,  0.768,  0.94 ,  0.984,  1.   ])
 
 Based on this power estimate, as we increase our confidence that we have not
 committed a type I error and identified a false positive, the number of samples

--- a/skbio/util/_testing.py
+++ b/skbio/util/_testing.py
@@ -404,7 +404,6 @@ def assert_series_almost_equal(left, right):
         check_series_type=True,
         check_names=True,
         check_exact=False,
-        check_datetimelike_compat=False,
         obj="Series",
     )
     # this check ensures that empty Series with different indices do not


### PR DESCRIPTION
PR message created by AI:

## Summary

This PR addresses 182 of the 210 warnings previously emitted by make test, while preserving existing numerical results and public return values.

The remaining known warnings are intentionally deferred or require separate design decisions, including deprecated sequence aliases planned for removal.

## Changes

- Close Matplotlib figures after ordination plotting tests.
- Remove pandas’ deprecated check_datetimelike_compat assertion argument.
- Explicitly handle expected callable-UniFrac performance warnings in tests.
- Provide sample and feature IDs in NumPy correspondence-analysis fixtures.
- Use data matching the registered sniffer in inherited I/O reader tests.
- Suppress PCoA negative-eigenvalue warnings in PERMDISP examples while documenting that their illustrative matrix is non-Euclidean.

- Disable redundant clr_inv validation in its backend behavior test.
- Prevent the power-analysis doctest from drawing constant Pearson inputs.
- Avoid zero division in:
  - TabularMSA.gap_frequencies(relative=True) for alignments without positions.
  - Sequence.frequencies(relative=True) for empty sequences.
- Add regression coverage and changelog entries for both public warning-removal fixes.

The two production fixes preserve the existing documented results: NaN relative frequencies are now constructed explicitly instead of being produced through invalid division.

## Validation

Focused validation included:

- 402 TabularMSA tests.
- 264 Sequence tests.
- 331 pandas-helper consumers.
- 63 composition tests and configured Array API variants.
- 53 I/O descriptor tests.
- 42 diversity driver tests.
- 38 plotting tests.
- 16 correspondence-analysis tests.
- PERMDISP and power doctests.
- Ruff and git diff --check.

Relevant warnings were promoted to errors during focused testing.

A full warning-audit run reached 3,821 passed and 58 skipped tests. One unrelated Numba centering test failed an exact equality assertion by approximately 5.55e-17 and passed immediately when rerun alone, indicating existing test flakiness. That run reported 30 warnings before the final two zero-division fixes were applied; 28 known warnings remain.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
