### PR TITLE
[Don't merge] Remove deprecated sequence aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # scikit-bio changelog
 
+## Version 0.8.0-dev
+
+### Backward-incompatible changes
+
+* Removed the deprecated `skbio.sequence.GrammaredSequence.nondegenerate_chars`, `skbio.sequence.GrammaredSequence.nondegenerates`, and `skbio.sequence.GrammaredSequence.has_nondegenerates` aliases. Use `definite_chars`, `definites`, and `has_definites`, respectively. These aliases had been deprecated since version 0.5.0.
+
 ## Version 0.7.4-dev
 
 ### Features

--- a/skbio/alignment/tests/test_pairwise.py
+++ b/skbio/alignment/tests/test_pairwise.py
@@ -70,29 +70,6 @@ class PairwiseAlignmentTests(TestCase):
         """Clear the list of warning filters, so that no filters are active."""
         warnings.resetwarnings()
 
-    # TODO: duplicate of test_global_pairwise_align_custom_alphabet, remove
-    # when nondegenerate_chars is removed
-    def test_global_pairwise_align_custom_alphabet_nondegenerate_chars(self):
-        custom_substitution_matrix = SubstitutionMatrix.identity(
-            sorted(CustomSequence.nondegenerate_chars), 1, -1
-        ).to_dict()
-
-        custom_msa, custom_score, custom_start_end = global_pairwise_align(
-            CustomSequence("WXYZ"), CustomSequence("WXYYZZ"),
-            10.0, 5.0, custom_substitution_matrix)
-
-        # Expected values computed by running an equivalent alignment using the
-        # DNA alphabet with the following mapping:
-        #
-        #     W X Y Z
-        #     | | | |
-        #     A C G T
-        #
-        self.assertEqual(custom_msa, TabularMSA([CustomSequence('WXYZ^^'),
-                                                 CustomSequence('WXYYZZ')]))
-        self.assertEqual(custom_score, 2.0)
-        self.assertEqual(custom_start_end, [(0, 3), (0, 5)])
-
     def test_global_pairwise_align_custom_alphabet(self):
         custom_substitution_matrix = SubstitutionMatrix.identity(
             sorted(CustomSequence.definite_chars), 1, -1
@@ -113,32 +90,6 @@ class PairwiseAlignmentTests(TestCase):
                                                  CustomSequence('WXYYZZ')]))
         self.assertEqual(custom_score, 2.0)
         self.assertEqual(custom_start_end, [(0, 3), (0, 5)])
-
-    # TODO: duplicate of test_local_pairwise_align_custom_alphabet, remove
-    # when nondegenerate_chars is removed.
-    def test_local_pairwise_align_custom_alphabet_nondegenerate_chars(self):
-        custom_substitution_matrix = SubstitutionMatrix.identity(
-            sorted(CustomSequence.nondegenerate_chars), 5, -4
-        ).to_dict()
-
-        custom_msa, custom_score, custom_start_end = local_pairwise_align(
-            CustomSequence("YWXXZZYWXXWYYZWXX"),
-            CustomSequence("YWWXZZZYWXYZWWX"), 5.0, 0.5,
-            custom_substitution_matrix)
-
-        # Expected values computed by running an equivalent alignment using the
-        # DNA alphabet with the following mapping:
-        #
-        #     W X Y Z
-        #     | | | |
-        #     A C G T
-        #
-        self.assertEqual(
-            custom_msa,
-            TabularMSA([CustomSequence('WXXZZYWXXWYYZWXX'),
-                        CustomSequence('WXZZZYWX^^^YZWWX')]))
-        self.assertEqual(custom_score, 41.0)
-        self.assertEqual(custom_start_end, [(1, 16), (2, 14)])
 
     def test_local_pairwise_align_custom_alphabet(self):
         custom_substitution_matrix = SubstitutionMatrix.identity(

--- a/skbio/sequence/_grammared_sequence.py
+++ b/skbio/sequence/_grammared_sequence.py
@@ -6,7 +6,6 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from warnings import warn
 from abc import ABCMeta, abstractmethod
 from itertools import product
 import re
@@ -321,30 +320,6 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         return set(cls.degenerate_map)
 
     @classproperty
-    def nondegenerate_chars(cls):
-        """Return non-degenerate characters.
-
-        Returns
-        -------
-        set
-            Non-degenerate characters.
-
-        Warnings
-        --------
-        ``nondegenerate_chars`` is deprecated as of ``0.5.0``. It has been renamed to
-        ``definite_chars``.
-
-        See Also
-        --------
-        definite_chars
-
-        """  # noqa: D416
-        # @deprecated
-        warn("nondegenerate_chars is deprecated as of 0.5.0", DeprecationWarning)
-
-        return cls.definite_chars
-
-    @classproperty
     @abstractmethod
     def definite_chars(cls):
         """Return definite characters.
@@ -574,39 +549,6 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         return self._definite_hash[self._bytes]
 
-    def nondegenerates(self):
-        """Find positions containing non-degenerate characters in the sequence.
-
-        Returns
-        -------
-        1D np.ndarray (bool)
-            Boolean vector where ``True`` indicates a non-degenerate character
-            is present at that position in the biological sequence.
-
-        Warnings
-        --------
-        ``nondegenerates`` is deprecated as of ``0.5.0``. It has been renamed to
-        ``definites``.
-
-        See Also
-        --------
-        definites
-        has_definites
-        degenerates
-
-        Examples
-        --------
-        >>> from skbio import DNA
-        >>> s = DNA('ACWGN')
-        >>> s.nondegenerates()
-        array([ True,  True, False,  True, False], dtype=bool)
-
-        """  # noqa: D416
-        # @deprecated
-        warn("nondenengerates is deprecated as of 0.5.0.", DeprecationWarning)
-
-        return self.definites()
-
     def has_definites(self):
         """Determine if sequence contains one or more definite characters.
 
@@ -635,44 +577,6 @@ class GrammaredSequence(Sequence, metaclass=GrammaredSequenceMeta):
         """
         # TODO: cache results
         return bool(self.definites().any())
-
-    def has_nondegenerates(self):
-        """Determine if sequence contains one or more non-degenerate characters.
-
-        Returns
-        -------
-        bool
-            Indicates whether there are one or more occurrences of
-            non-degenerate characters in the biological sequence.
-
-        Warnings
-        --------
-        ``has_nondegenerates`` is deprecated as of ``0.5.0``. It has been renamed to
-        ``has_definites``.
-
-        See Also
-        --------
-        definites
-        has_definites
-        degenerates
-        has_degenerates
-
-        Examples
-        --------
-        >>> from skbio import DNA
-        >>> s = DNA('NWNNNNNN')
-        >>> s.has_nondegenerates()
-        False
-        >>> t = DNA('ANCACWWGACGTT')
-        >>> t.has_nondegenerates()
-        True
-
-        """  # noqa: D416
-        # TODO: cache results
-        # @deprecated
-        warn("has_nondegenerates is deprecated as of 0.5.0", DeprecationWarning)
-
-        return self.has_definites()
 
     def degap(self):
         """Return a new sequence with gap characters removed.

--- a/skbio/sequence/tests/test_grammared_sequence.py
+++ b/skbio/sequence/tests/test_grammared_sequence.py
@@ -298,23 +298,6 @@ class TestGrammaredSequence(TestCase):
         with self.assertRaises(AttributeError):
             ExampleGrammaredSequence('').degenerate_chars = set("BAR")
 
-    # TODO: duplicate of test_definite_chars, remove when nondegenerate_chars,
-    # is removed
-    def test_nondegenerate_chars(self):
-        expected = set("ABCQ")
-        self.assertEqual(ExampleGrammaredSequence.nondegenerate_chars,
-                         expected)
-
-        ExampleGrammaredSequence.degenerate_chars.add("D")
-        self.assertEqual(ExampleGrammaredSequence.nondegenerate_chars,
-                         expected)
-
-        self.assertEqual(ExampleGrammaredSequence('').nondegenerate_chars,
-                         expected)
-
-        with self.assertRaises(AttributeError):
-            ExampleGrammaredSequence('').nondegenerate_chars = set("BAR")
-
     def test_definite_chars(self):
         expected = set("ABCQ")
         self.assertEqual(ExampleGrammaredSequence.definite_chars,
@@ -439,31 +422,6 @@ class TestGrammaredSequence(TestCase):
         self.assertTrue(ExampleGrammaredSequence("Z").has_degenerates())
         self.assertTrue(ExampleGrammaredSequence("ABC.XYZ-").has_degenerates())
 
-    # TODO: duplicate of test_definites; remove when nondegenerates is removed
-    def test_nondegenerates(self):
-        self.assertIs(type(ExampleGrammaredSequence("").nondegenerates()),
-                      np.ndarray)
-        self.assertIs(ExampleGrammaredSequence("").nondegenerates().dtype,
-                      np.dtype('bool'))
-
-        npt.assert_equal(
-            ExampleGrammaredSequence("XYZYZ-.XY.").nondegenerates(),
-            np.zeros(10).astype(bool))
-
-        npt.assert_equal(ExampleGrammaredSequence("ABABA").nondegenerates(),
-                         np.ones(5).astype(bool))
-
-        npt.assert_equal(
-            ExampleGrammaredSequence("XA.B-AZCXA").nondegenerates(),
-            np.array([0, 1] * 5, dtype=bool))
-
-        npt.assert_equal(
-            ExampleGrammaredSequence("XXAZZB.-C").nondegenerates(),
-            np.array([0, 0, 1] * 3, dtype=bool))
-
-        npt.assert_equal(ExampleGrammaredSequence("YB.-AC").nondegenerates(),
-                         np.array([0, 1, 0, 0, 1, 1], dtype=bool))
-
     def test_definites(self):
         self.assertIs(type(ExampleGrammaredSequence("").definites()),
                       np.ndarray)
@@ -487,22 +445,6 @@ class TestGrammaredSequence(TestCase):
 
         npt.assert_equal(ExampleGrammaredSequence("YB.-AC").definites(),
                          np.array([0, 1, 0, 0, 1, 1], dtype=bool))
-
-    # TODO: duplicate of test_has_definites; remove when has_nondegenerates is
-    # removed.
-    def test_has_nondegenerates(self):
-        self.assertIs(type(ExampleGrammaredSequence("").has_nondegenerates()),
-                      bool)
-        self.assertIs(type(ExampleGrammaredSequence("A").has_nondegenerates()),
-                      bool)
-
-        self.assertFalse(ExampleGrammaredSequence("").has_nondegenerates())
-        self.assertFalse(
-            ExampleGrammaredSequence("X-.YZ").has_nondegenerates())
-
-        self.assertTrue(ExampleGrammaredSequence("C").has_nondegenerates())
-        self.assertTrue(
-            ExampleGrammaredSequence(".XYZ-ABC").has_nondegenerates())
 
     def test_has_definites(self):
         self.assertIs(type(ExampleGrammaredSequence("").has_definites()),

--- a/skbio/sequence/tests/test_nucleotide_sequences.py
+++ b/skbio/sequence/tests/test_nucleotide_sequences.py
@@ -66,15 +66,6 @@ class TestNucleotideSequence(unittest.TestCase):
         self.assertIn("abstract class", str(cm.exception))
         self.assertIn("complement_map", str(cm.exception))
 
-    # TODO: remove when nondegenerate_chars is removed
-    def test_nondegenerate_chars(self):
-        dna = (DNA, "ACGT")
-        rna = (RNA, "ACGU")
-        for constructor, nondegenerate in (dna, rna):
-            exp = set(nondegenerate)
-            self.assertEqual(constructor('').nondegenerate_chars, exp)
-            self.assertEqual(constructor.nondegenerate_chars, exp)
-
     def test_definite_chars(self):
         dna = (DNA, "ACGT")
         rna = (RNA, "ACGU")

--- a/skbio/sequence/tests/test_protein.py
+++ b/skbio/sequence/tests/test_protein.py
@@ -27,13 +27,6 @@ class TestProtein(unittest.TestCase):
         with self.assertRaises(AttributeError):
             Protein('').alphabet = set("ABCD")
 
-    # TODO: duplicate of test_definite_chars, remove when nondegenerate_chars,
-    # is removed
-    def test_nondegenerate_chars(self):
-        exp = set("ACDEFGHIKLMNOPQRSTUVWY")
-        self.assertEqual(Protein("").nondegenerate_chars, exp)
-        self.assertEqual(Protein.nondegenerate_chars, exp)
-
     def test_definite_chars(self):
         exp = set("ACDEFGHIKLMNOPQRSTUVWY")
         self.assertEqual(Protein("").definite_chars, exp)


### PR DESCRIPTION
This PR drops the `nondegenerate` characters of sequences, which has been deprecated since 0.5.0 and replaced with `definite` characters. We should merge it before the 0.8.0 release.

***

Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.
