### PR TITLE
BUG: pass permdisp's seed down to pcoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Bug Fixes
 
+* Fixed `permdisp` not passing its `seed` down to `pcoa`, which left `method="fsvd"` unseeded. Because the FSVD solver draws a random projection, results were not reproducible even when a seed was given; on larger matrices repeated calls with the same seed could return materially different p-values. `method="eigh"` was unaffected, being deterministic.
 * Fixed an unexpected behavior in differential abundance tests (`ancombc` and `dirmult_lme`) where string columns in the metadata that can be cast into numbers (e.g., `["1", "2", "3"]`) were treated as numerical. Now they are treated as categories ([#2539](https://github.com/scikit-bio/scikit-bio/pull/2539)).
 * Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Bug Fixes
 
-* Fixed `permdisp` not passing its `seed` down to `pcoa`, which left `method="fsvd"` unseeded. Because the FSVD solver draws a random projection, results were not reproducible even when a seed was given; on larger matrices repeated calls with the same seed could return materially different p-values. `method="eigh"` was unaffected, being deterministic.
+* Fixed `permdisp` not passing its `seed` down to `pcoa`, which left `method="fsvd"` unseeded. Because the FSVD solver draws a random projection, results were not reproducible even when a seed was given; on larger matrices repeated calls with the same seed could return materially different p-values. `method="eigh"` was unaffected, being deterministic ([#2546](https://github.com/scikit-bio/scikit-bio/pull/2546)).
 * Fixed an unexpected behavior in differential abundance tests (`ancombc` and `dirmult_lme`) where string columns in the metadata that can be cast into numbers (e.g., `["1", "2", "3"]`) were treated as numerical. Now they are treated as categories ([#2539](https://github.com/scikit-bio/scikit-bio/pull/2539)).
 * Fixed a subtle floating-point arithmetic issue in `pair_align` under a linear gap penalty. Previously it could be less tolerant than expected when `atol` was set smaller than the default (1e-5) and scores involved decimal numbers ([#2513](https://github.com/scikit-bio/scikit-bio/pull/2513)).
 * Fixed a bug in `pair_align` which raised a `TypeError` when called with `atol=None`. This should be equivalent to `atol=0` ([#2504](https://github.com/scikit-bio/scikit-bio/pull/2504)).

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -294,6 +294,7 @@ def permdisp(
             distmat,
             method=method,
             dimensions=dimensions,
+            seed=seed,
             warn_neg_eigval=warn_neg_eigval,
         )
     else:

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -282,6 +282,28 @@ class PERMDISPTests(TestCase):
 
         self.assert_series_equal(obs, exp)
 
+    def test_fsvd_seed_is_reproducible(self):
+        # fsvd draws a random projection, so permdisp has to pass its seed down
+        # to pcoa for the result to be reproducible. The matrix has to be large
+        # enough that different projections actually disagree; on a handful of
+        # samples they all converge and the difference is invisible. No
+        # permutations are needed, since the statistic alone depends on the
+        # ordination.
+        rng = np.random.default_rng(0)
+        mat = rng.random((60, 60))
+        mat = (mat + mat.T) / 2
+        np.fill_diagonal(mat, 0.0)
+        dm = DistanceMatrix(mat)
+        grouping = ['a'] * 30 + ['b'] * 30
+
+        for test in ('centroid', 'median'):
+            first = permdisp(dm, grouping, test=test, permutations=0,
+                             method='fsvd', seed=42)
+            repeat = permdisp(dm, grouping, test=test, permutations=0,
+                              method='fsvd', seed=42)
+            npt.assert_allclose(repeat['test statistic'],
+                                first['test statistic'])
+
     def test_not_distance_matrix(self):
         dm = []
         grouping = ['Control', 'Control', 'Control', 'Control', 'Control',


### PR DESCRIPTION
### Description

`permdisp` accepts a `seed` and its docstring states that the seed is there to make the output deterministic, but the internal `pcoa` call does not forward it.

With `method="eigh"` this is invisible, since that solver is deterministic and never touches the seed. With `method="fsvd"` the solver draws a random projection from an unseeded generator, so each call produces a different ordination and therefore a different statistic and p-value, even when the caller passes a seed. On a 60 by 60 matrix, repeated calls with the same seed disagree on every run. On larger inputs the movement is big enough to matter: on a 300 sample matrix I saw the p-value range from 0.01 to 0.70 across repeated calls with an identical seed.

The fix forwards the seed. I checked that this does not disturb the `eigh` path: `pcoa` only consumes the seed inside `_fsvd`, so passing a generator through leaves it untouched on the `eigh` path, and the statistic and p-value for an `eigh` call are identical before and after this change. The `fsvd` path is the only behavior that changes, and it had no reproducible behavior to preserve.

### Testing

The existing `fsvd` tests pass despite the bug because their distance matrix is nine by nine, which is small enough that every random projection recovers the same subspace, so the result looks stable. The new test uses a matrix large enough for the projections to actually disagree, and asserts that two calls with the same seed return the same statistic.

It runs with `permutations=0`, because the observed statistic alone depends on the ordination and the permutation loop only adds runtime. I confirmed the test is a real guard rather than a passing assertion: with the fix reverted it fails on all ten of ten runs, and it covers both the centroid and the median test.

```
pytest skbio/stats/distance/tests/test_permdisp.py    # 22 passed
```

The full suite shows no change against the baseline on this branch.
