### PR TITLE
ENH: add a Numba engine for permdisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `TreeNode.prune` and `TreeNode.bifurcate` now accept an `inplace` parameter (default `True`, preserving the previous in-place behavior) and return the resulting tree. This makes them consistent with other whole-tree methods such as `shear` and `root_at_midpoint`. Set `inplace=False` to leave the original tree unchanged and operate on a copy ([#2495](https://github.com/scikit-bio/scikit-bio/pull/2495)).
 * Transition probability matrix computation has been introduced ([#2496](https://github.com/scikit-bio/scikit-bio/pull/2496)).
 * `pcoa` and `center_distance_matrix` can now use the Numba backend for distance-matrix centering via `engine="numba"` [#2508](https://github.com/scikit-bio/scikit-bio/pull/2508).
+* `permdisp` now accepts `engine="numba"`, which evaluates the permutation loop in batched Numba calls for both the centroid and the median test. The geometric median used by the median test was ported to Numba alongside it. Permutations are drawn in the same order as the Cython path, so p-values are unchanged.
 * Added a Numba GPU backend for `permanova` and `mantel`. With `engine="numba"` and a GPU-resident `DistanceMatrix`, a fused single-source kernel runs on the device (`numba.cuda` on NVIDIA, `numba.hip` on AMD), falling back to the array-API path when the kernel is unavailable [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Performance enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * `TreeNode.prune` and `TreeNode.bifurcate` now accept an `inplace` parameter (default `True`, preserving the previous in-place behavior) and return the resulting tree. This makes them consistent with other whole-tree methods such as `shear` and `root_at_midpoint`. Set `inplace=False` to leave the original tree unchanged and operate on a copy ([#2495](https://github.com/scikit-bio/scikit-bio/pull/2495)).
 * Transition probability matrix computation has been introduced ([#2496](https://github.com/scikit-bio/scikit-bio/pull/2496)).
 * `pcoa` and `center_distance_matrix` can now use the Numba backend for distance-matrix centering via `engine="numba"` [#2508](https://github.com/scikit-bio/scikit-bio/pull/2508).
-* `permdisp` now accepts `engine="numba"`, which evaluates the permutation loop in batched Numba calls for both the centroid and the median test. The geometric median used by the median test was ported to Numba alongside it. Permutations are drawn in the same order as the Cython path, so p-values are unchanged.
+* `permdisp` now accepts `engine="numba"`, which evaluates the permutation loop in batched Numba calls for both the centroid and the median test. The geometric median used by the median test was ported to Numba alongside it. Permutations are drawn in the same order as the Cython path, so p-values are unchanged ([#2547](https://github.com/scikit-bio/scikit-bio/pull/2547)).
 * Added a Numba GPU backend for `permanova` and `mantel`. With `engine="numba"` and a GPU-resident `DistanceMatrix`, a fused single-source kernel runs on the device (`numba.cuda` on NVIDIA, `numba.hip` on AMD), falling back to the array-API path when the kernel is unavailable [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Performance enhancements

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -22,12 +22,264 @@ from ._base import (
     DistanceMatrix,
 )
 from skbio.stats.ordination import pcoa, OrdinationResults
+from skbio.util import get_rng
 from skbio.util._decorator import params_aliased
+from skbio._config import _resolve_engine
+
+try:
+    from numba import njit, prange, get_num_threads
+    NUMBA_AVAILABLE = True
+except ImportError:
+    NUMBA_AVAILABLE = False
 
 if TYPE_CHECKING:  # pragma: no cover
     from numpy.typing import ArrayLike
     import pandas as pd
     from skbio.util._typing import SeedLike
+
+
+if NUMBA_AVAILABLE:
+
+    @njit
+    def _anova_f_nb(dists, codes, counts, group_sums, num_groups):
+        """One-way ANOVA F over per-sample distances to their group center.
+
+        Shared by both center definitions: only the distances differ, the test
+        around them does not. ``counts`` and ``group_sums`` are the per-group
+        sample count and distance total, already accumulated by the caller
+        while it walked the samples.
+        """
+        n = dists.shape[0]
+
+        total = 0
+        grand = 0.0
+        for g in range(num_groups):
+            total += counts[g]
+            grand += group_sums[g]
+        grand /= total
+
+        ss_between = 0.0
+        for g in range(num_groups):
+            diff = group_sums[g] / counts[g] - grand
+            ss_between += counts[g] * diff * diff
+
+        ss_within = 0.0
+        for i in range(n):
+            g = codes[i]
+            resid = dists[i] - group_sums[g] / counts[g]
+            ss_within += resid * resid
+
+        ms_between = ss_between / (num_groups - 1)
+        ms_within = ss_within / (total - num_groups)
+        if ms_within == 0.0:
+            if ms_between == 0.0:
+                return np.nan
+            return np.inf
+        return ms_between / ms_within
+
+    @njit
+    def _permdisp_f_stat_centroid_nb(samples, codes, num_groups):
+        """Levene-style F statistic on distances to each group's centroid.
+
+        Reproduces one call of ``_compute_groups(samples, "centroid", codes)``:
+        the group centroids, the Euclidean distance of every sample to its own
+        centroid, and the one-way ANOVA F over those distances. ``codes`` holds
+        the group index of each sample (0 to ``num_groups`` - 1).
+        """
+        n, d = samples.shape
+
+        counts = np.zeros(num_groups, np.int64)
+        centroids = np.zeros((num_groups, d), np.float64)
+        for i in range(n):
+            g = codes[i]
+            counts[g] += 1
+            for j in range(d):
+                centroids[g, j] += samples[i, j]
+        for g in range(num_groups):
+            for j in range(d):
+                centroids[g, j] /= counts[g]
+
+        # distance of each sample to its own centroid, plus the per-group sum
+        # needed for the group means below
+        dists = np.empty(n, np.float64)
+        group_sums = np.zeros(num_groups, np.float64)
+        for i in range(n):
+            g = codes[i]
+            acc = 0.0
+            for j in range(d):
+                diff = samples[i, j] - centroids[g, j]
+                acc += diff * diff
+            val = np.sqrt(acc)
+            dists[i] = val
+            group_sums[g] += val
+
+        # one-way ANOVA on the distances
+        return _anova_f_nb(dists, codes, counts, group_sums, num_groups)
+
+    @njit(parallel=True)
+    def _permdisp_perm_stats_centroid_nb(samples, perm_codes, num_groups):
+        """F statistic for a batch of groupings, one per row of ``perm_codes``.
+
+        The whole permutation loop is batched into a single call because the
+        per-permutation work is O(n * d) with ``d`` the retained dimensions
+        (10 by default), small enough that Python-level call overhead would
+        otherwise dominate. Permutations are independent, so the parallel axis
+        is the permutation rather than anything inside a single statistic.
+        """
+        n_perm = perm_codes.shape[0]
+        out = np.empty(n_perm, np.float64)
+        for p in prange(n_perm):
+            out[p] = _permdisp_f_stat_centroid_nb(samples, perm_codes[p], num_groups)
+        return out
+
+    @njit
+    def _geomedian_nb(X, eps=1e-7, maxiters=500):
+        """Geometric median of the columns of ``X``, shaped (dims, samples).
+
+        Numba port of ``._cutils.geomedian_axis_one``, which is itself a port of
+        hdmedians v0.14.2. Same modified Weiszfeld iteration, same convergence
+        test and the same handling of samples that coincide with the current
+        estimate, so both engines return the same center.
+        """
+        p, n = X.shape
+
+        y = np.zeros(p, np.float64)
+        for j in range(p):
+            acc = 0.0
+            for i in range(n):
+                acc += X[j, i]
+            y[j] = acc / n
+
+        if n == 1:
+            return y
+
+        D = np.empty(n, np.float64)
+        Dinv = np.empty(n, np.float64)
+        W = np.empty(n, np.float64)
+        T = np.empty(p, np.float64)
+        y1 = np.empty(p, np.float64)
+        R = np.empty(p, np.float64)
+
+        for _ in range(maxiters):
+            for i in range(n):
+                acc = 0.0
+                for j in range(p):
+                    diff = X[j, i] - y[j]
+                    acc += diff * diff
+                Di = np.sqrt(acc)
+                D[i] = Di
+                # A sample sitting on the current estimate contributes no
+                # direction, so it is dropped from the weights and added back
+                # through the nzeros correction below.
+                Dinv[i] = 1.0 / Di if abs(Di) > eps else 0.0
+
+            nzeros = n
+            for i in range(n):
+                if abs(D[i]) > eps:
+                    nzeros -= 1
+
+            # Every sample sits on the estimate, so there is no direction left
+            # to move in and the estimate is the median. Checked before the
+            # weights because the inverse distances are then all zero and their
+            # total would divide by zero just below; the Cython original tests
+            # this after dividing and raises instead.
+            if nzeros == n:
+                break
+
+            Dinvs = 0.0
+            for i in range(n):
+                Dinvs += Dinv[i]
+            for i in range(n):
+                W[i] = Dinv[i] / Dinvs
+
+            for j in range(p):
+                total = 0.0
+                for i in range(n):
+                    if abs(D[i]) > eps:
+                        total += W[i] * X[j, i]
+                T[j] = total
+
+            if nzeros == 0:
+                for j in range(p):
+                    y1[j] = T[j]
+            else:
+                for j in range(p):
+                    R[j] = (T[j] - y[j]) * Dinvs
+                r = 0.0
+                for j in range(p):
+                    r += R[j] * R[j]
+                r = np.sqrt(r)
+                rinv = nzeros / r if r > eps else 0.0
+                for j in range(p):
+                    y1[j] = max(0.0, 1 - rinv) * T[j] + min(1.0, rinv) * y[j]
+
+            dist = 0.0
+            for j in range(p):
+                diff = y[j] - y1[j]
+                dist += diff * diff
+            if np.sqrt(dist) < eps:
+                break
+
+            for j in range(p):
+                y[j] = y1[j]
+
+        return y
+
+    @njit
+    def _permdisp_f_stat_median_nb(samples, codes, num_groups):
+        """As :func:`_permdisp_f_stat_centroid_nb`, but around group medians.
+
+        The center of each group is its geometric median rather than its mean,
+        which is what ``test="median"`` selects.
+        """
+        n, d = samples.shape
+
+        counts = np.zeros(num_groups, np.int64)
+        for i in range(n):
+            counts[codes[i]] += 1
+
+        dists = np.empty(n, np.float64)
+        group_sums = np.zeros(num_groups, np.float64)
+        for g in range(num_groups):
+            size = counts[g]
+            # geomedian_axis_one takes (dims, samples), so the group is gathered
+            # transposed.
+            grp = np.empty((d, size), np.float64)
+            idx = np.empty(size, np.int64)
+            k = 0
+            for i in range(n):
+                if codes[i] == g:
+                    idx[k] = i
+                    for j in range(d):
+                        grp[j, k] = samples[i, j]
+                    k += 1
+            center = _geomedian_nb(grp)
+            for m in range(size):
+                acc = 0.0
+                for j in range(d):
+                    diff = samples[idx[m], j] - center[j]
+                    acc += diff * diff
+                val = np.sqrt(acc)
+                dists[idx[m]] = val
+                group_sums[g] += val
+
+        return _anova_f_nb(dists, codes, counts, group_sums, num_groups)
+
+    @njit(parallel=True)
+    def _permdisp_perm_stats_median_nb(samples, perm_codes, num_groups):
+        """F statistic for a batch of groupings, around group medians."""
+        n_perm = perm_codes.shape[0]
+        out = np.empty(n_perm, np.float64)
+        for p in prange(n_perm):
+            out[p] = _permdisp_f_stat_median_nb(samples, perm_codes[p], num_groups)
+        return out
+
+
+# Permutations processed per batched kernel call, per thread. The permutation is
+# the parallel axis here, so this is what keeps every worker supplied; it is
+# deliberately a few dozen per thread rather than one so the kernel launch is
+# amortised, and it bounds the grouping buffer to (CHUNK x n).
+_PERM_CHUNK_PER_THREAD = 32
 
 
 @params_aliased(
@@ -46,6 +298,7 @@ def permdisp(
     dimensions: int = 10,
     seed: SeedLike | None = None,
     warn_neg_eigval: bool | float = 0.01,
+    engine: str | None = None,
 ) -> pd.Series:
     r"""Test for Homogeneity of Multivariate Groups Disperisons.
 
@@ -102,6 +355,14 @@ def permdisp(
         during PCoA. See :func:`skbio.stats.ordination.pcoa <pcoa>` for details.
 
         .. versionadded:: 0.6.3
+
+    engine : {"cython", "numba"}, optional
+        Compute engine to use for the permutation test. ``"cython"`` (default)
+        uses the existing implementation. ``"numba"`` uses the optional Numba
+        implementation and requires Numba to be installed. If not provided, the
+        global default is used (see :func:`skbio.set_config`).
+
+        .. versionadded:: 0.7.4
 
     Returns
     -------
@@ -304,15 +565,78 @@ def permdisp(
 
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 
-    test_stat_function = partial(_compute_groups, sample_data, test)
+    engine = _resolve_engine(engine, ("cython", "numba"))
 
-    stat, p_value = _run_monte_carlo_stats(
-        test_stat_function, grouping, permutations, seed
-    )
+    # The Numba engine batches the permutation loop, for both center
+    # definitions.
+    if engine == "numba":
+        stat, p_value = _run_permdisp_numba(
+            sample_data, grouping, num_groups, permutations, seed, test
+        )
+    else:
+        test_stat_function = partial(_compute_groups, sample_data, test)
+
+        stat, p_value = _run_monte_carlo_stats(
+            test_stat_function, grouping, permutations, seed
+        )
 
     return _build_results(
         "PERMDISP", "F-value", sample_size, num_groups, stat, p_value, permutations
     )
+
+
+def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, test):
+    """Observed statistic and p-value via the Numba engine.
+
+    Draws the permutations on the host in the same order as
+    :func:`._base._run_monte_carlo_stats` (observed grouping first, then one
+    ``rng.permutation`` per replicate) so the p-value matches the Cython engine
+    exactly, then evaluates them in a single batched kernel call per chunk.
+    """
+    if permutations < 0:
+        raise ValueError(
+            "Number of permutations must be greater than or equal to zero."
+        )
+
+    samples = np.ascontiguousarray(sample_data, dtype=np.float64)
+    codes = np.ascontiguousarray(grouping, dtype=np.int32)
+    sample_size = codes.shape[0]
+
+    if test == "centroid":
+        batch = _permdisp_perm_stats_centroid_nb
+    else:
+        batch = _permdisp_perm_stats_median_nb
+
+    rng = get_rng(seed)
+    n_total = permutations + 1
+    stats = np.empty(n_total, np.float64)
+
+    # Each permutation is only O(n * d) work with d the retained dimensions (10
+    # by default), so the parallel axis is the permutation itself rather than
+    # anything inside a single statistic. Groupings are generated in fixed-size
+    # chunks so peak memory stays at (CHUNK x n) instead of growing with the
+    # permutation count; unlike the permanova row-tile kernel, here the chunk is
+    # the amount of parallel work per kernel call, so it scales with the thread
+    # count to keep every worker busy.
+    CHUNK = _PERM_CHUNK_PER_THREAD * get_num_threads()
+    width = min(CHUNK, n_total)
+    # Permutation-major buffer, allocated once and reused across chunks;
+    # rng.permutation fills a row, so the writes are sequential.
+    buf = np.empty((width, sample_size), dtype=np.int32)
+    for start in range(0, n_total, CHUNK):
+        end = min(start + CHUNK, n_total)
+        for i in range(start, end):
+            if i == 0:
+                buf[0] = codes
+            else:
+                buf[i - start] = rng.permutation(codes)
+        stats[start:end] = batch(samples, buf[: end - start], num_groups)
+
+    stat = float(stats[0])
+    if permutations == 0:
+        return stat, np.nan
+    p_value = (1.0 + np.sum(stats[1:] >= stats[0])) / (1.0 + permutations)
+    return stat, float(p_value)
 
 
 def _compute_groups(samples, test_type, grouping):

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -599,14 +599,19 @@ def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, t
             "Number of permutations must be greater than or equal to zero."
         )
 
-    # The Cython path reaches geomedian_axis_one, a fused-type function that
-    # accepts only single or double precision, so anything else raises there.
-    # Match that rather than silently widening whatever comes in.
+    # geomedian_axis_one is fused over float32 and float64, so Cython's median
+    # path raises on any other dtype, and this rejects the same set so the two
+    # engines agree there. The check is not conditioned on the test, so it also
+    # covers test="centroid", which never reaches that kernel and which Cython
+    # computes for any numeric dtype; the Numba path is stricter in that case.
     if np.asarray(sample_data).dtype not in (np.float32, np.float64):
         raise TypeError(
             "Ordination coordinates must be of type np.float32 or np.float64."
         )
 
+    # An accepted float32 ordination is accumulated in float64, for the same
+    # reason as #2509. Cython computes in the input dtype instead, so the two
+    # engines differ by float32 precision on such an input.
     samples = np.ascontiguousarray(sample_data, dtype=np.float64)
     codes = np.ascontiguousarray(grouping, dtype=np.int32)
     sample_size = codes.shape[0]

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -598,6 +598,14 @@ def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, t
             "Number of permutations must be greater than or equal to zero."
         )
 
+    # The Cython path reaches geomedian_axis_one, a fused-type function that
+    # accepts only single or double precision, so anything else raises there.
+    # Match that rather than silently widening whatever comes in.
+    if np.asarray(sample_data).dtype not in (np.float32, np.float64):
+        raise TypeError(
+            "Ordination coordinates must be of type np.float32 or np.float64."
+        )
+
     samples = np.ascontiguousarray(sample_data, dtype=np.float64)
     codes = np.ascontiguousarray(grouping, dtype=np.int32)
     sample_size = codes.shape[0]
@@ -636,7 +644,7 @@ def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, t
     if permutations == 0:
         return stat, np.nan
     p_value = (1.0 + np.sum(stats[1:] >= stats[0])) / (1.0 + permutations)
-    return stat, float(p_value)
+    return stat, p_value
 
 
 def _compute_groups(samples, test_type, grouping):

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -120,7 +120,7 @@ if NUMBA_AVAILABLE:
     def _permdisp_perm_stats_centroid_nb(samples, perm_codes, num_groups):
         """F statistic for a batch of groupings, one per row of ``perm_codes``.
 
-        The whole permutation loop is batched into a single call because the
+        The permutation loop is batched, one call per chunk, because the
         per-permutation work is O(n * d) with ``d`` the retained dimensions
         (10 by default), small enough that Python-level call overhead would
         otherwise dominate. Permutations are independent, so the parallel axis
@@ -137,9 +137,10 @@ if NUMBA_AVAILABLE:
         """Geometric median of the columns of ``X``, shaped (dims, samples).
 
         Numba port of ``._cutils.geomedian_axis_one``, which is itself a port of
-        hdmedians v0.14.2. Same modified Weiszfeld iteration, same convergence
-        test and the same handling of samples that coincide with the current
-        estimate, so both engines return the same center.
+        hdmedians v0.14.2. Same modified Weiszfeld iteration and same convergence
+        test, and it agrees with the Cython kernel to 1e-12 or better. The one
+        deliberate difference is the placement of the test for every sample
+        coinciding with the estimate, described where it is applied below.
         """
         p, n = X.shape
 
@@ -278,7 +279,7 @@ if NUMBA_AVAILABLE:
 # Permutations processed per batched kernel call, per thread. The permutation is
 # the parallel axis here, so this is what keeps every worker supplied; it is
 # deliberately a few dozen per thread rather than one so the kernel launch is
-# amortised, and it bounds the grouping buffer to (CHUNK x n).
+# amortized, and it bounds the grouping buffer to (CHUNK x n).
 _PERM_CHUNK_PER_THREAD = 32
 
 
@@ -590,8 +591,8 @@ def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, t
 
     Draws the permutations on the host in the same order as
     :func:`._base._run_monte_carlo_stats` (observed grouping first, then one
-    ``rng.permutation`` per replicate) so the p-value matches the Cython engine
-    exactly, then evaluates them in a single batched kernel call per chunk.
+    ``rng.permutation`` per replicate) so the two engines see the same groupings
+    in the same order, then evaluates them in one batched kernel call per chunk.
     """
     if permutations < 0:
         raise ValueError(

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -21,7 +21,7 @@ from skbio.stats.ordination import pcoa
 from skbio.stats.distance import permdisp
 from skbio.stats.distance._permdisp import _compute_groups
 from skbio.stats.distance._cutils import geomedian_axis_one
-from skbio.util import get_data_path
+from skbio.util import get_data_path, numba_code
 
 IS_INTEL_MAC = platform.system() == "Darwin" and platform.machine() == "x86_64"
 
@@ -439,6 +439,189 @@ class PERMDISPTests(TestCase):
             "permdisp must surface pcoa's EIGH warning when the caller "
             "explicitly passes dimensions=0 on a large matrix",
         )
+
+
+class PERMDISPEngineTests(TestCase):
+    """The numba engine must agree with cython, statistic and p-value alike."""
+
+    def setUp(self):
+        # A few well separated groups over a random matrix, large enough that
+        # the pcoa retains the default ten dimensions.
+        rng = np.random.default_rng(0)
+        mat = rng.random((30, 30))
+        mat = (mat + mat.T) / 2
+        np.fill_diagonal(mat, 0.0)
+        self.dm = DistanceMatrix(mat)
+        self.grouping = ['a'] * 10 + ['b'] * 10 + ['c'] * 10
+
+    def _assert_engines_agree(self, test, **kwargs):
+        obs = permdisp(self.dm, self.grouping, test=test, seed=42,
+                       engine="numba", **kwargs)
+        exp = permdisp(self.dm, self.grouping, test=test, seed=42,
+                       engine="cython", **kwargs)
+        npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+        # The p-value is the real check: it only matches if the numba driver
+        # draws permutations in the same order as the cython path.
+        self.assertEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_centroid_matches_cython(self):
+        self._assert_engines_agree("centroid", permutations=99)
+
+    @numba_code
+    def test_median_matches_cython(self):
+        self._assert_engines_agree("median", permutations=99)
+
+    @numba_code
+    def test_p_value_matches_cython_across_seeds(self):
+        # The p-value only matches if the numba driver consumes the random
+        # stream exactly as the cython path does. A desynchronized stream
+        # still agrees on most seeds, so one seed is not enough to catch it.
+        for seed in range(10):
+            obs = permdisp(self.dm, self.grouping, test="median",
+                           permutations=99, seed=seed, engine="numba")
+            exp = permdisp(self.dm, self.grouping, test="median",
+                           permutations=99, seed=seed, engine="cython")
+            self.assertEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_uneven_groups_match_cython(self):
+        self.grouping = ['a'] * 4 + ['b'] * 6 + ['c'] * 20
+        self._assert_engines_agree("median", permutations=99)
+
+    @numba_code
+    def test_dimensions_passed_through(self):
+        self._assert_engines_agree("median", permutations=99, dimensions=3)
+
+    @numba_code
+    def test_ordination_input_matches_cython(self):
+        # permdisp also accepts an OrdinationResults directly, which skips the
+        # internal pcoa call. The engine dispatch happens after that branch, so
+        # both input forms have to agree.
+        ordination = pcoa(self.dm, method="eigh", dimensions=10)
+        for test in ("centroid", "median"):
+            obs = permdisp(ordination, self.grouping, test=test,
+                           permutations=99, seed=42, engine="numba")
+            exp = permdisp(ordination, self.grouping, test=test,
+                           permutations=99, seed=42, engine="cython")
+            npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+            self.assertEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_no_permutations(self):
+        # permutations=0 skips the batch entirely and returns a NaN p-value.
+        obs = permdisp(self.dm, self.grouping, permutations=0, engine="numba")
+        exp = permdisp(self.dm, self.grouping, permutations=0, engine="cython")
+        npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+        self.assertTrue(np.isnan(obs['p-value']))
+
+    @numba_code
+    def test_geomedian_matches_cython_kernel(self):
+        # The numba geomedian is a port of geomedian_axis_one and has to
+        # return the same center, including for the degenerate single-column
+        # case that returns the mean without iterating.
+        from skbio.stats.distance._permdisp import _geomedian_nb
+
+        rng = np.random.default_rng(1)
+        for shape in [(10, 30), (3, 50), (10, 1), (10, 2)]:
+            X = np.ascontiguousarray(rng.random(shape))
+            npt.assert_allclose(_geomedian_nb(X.copy()),
+                                np.asarray(geomedian_axis_one(X.copy())))
+
+        # Layouts where the iteration lands exactly on one of the samples.
+        # That is the one path needing the zero-distance correction, and these
+        # particular ones move to a different center without it, so they pin
+        # the correction down rather than merely reaching it.
+        degenerate = [np.array([[2.0, 1.0, -2.0, 2.0, -3.0, 0.0]]),
+                      np.array([[0.0, 3.0, -2.0, -1.0, 2.0, -2.0]]),
+                      np.array([[-2.0, -1.0, -1.0, 0.0, -1.0, 1.0]]),
+                      np.array([[-1.0, 1.0, 0.0, 0.0, 0.0],
+                                [0.0, 0.0, -1.0, 1.0, 0.0]])]
+        for X in degenerate:
+            X = np.ascontiguousarray(X)
+            npt.assert_allclose(_geomedian_nb(X.copy()),
+                                np.asarray(geomedian_axis_one(X.copy())))
+
+    @numba_code
+    def test_geomedian_all_points_coincide(self):
+        # Every sample sitting on the same spot leaves the iteration with no
+        # direction to move in, and the median is that spot. Not compared
+        # against geomedian_axis_one here because the Cython kernel divides by
+        # a zero weight total before reaching that test and raises instead.
+        from skbio.stats.distance._permdisp import _geomedian_nb
+
+        X = np.ascontiguousarray(np.tile(np.array([[1.5], [-2.0]]), (1, 6)))
+        npt.assert_allclose(_geomedian_nb(X), np.array([1.5, -2.0]))
+
+    @numba_code
+    def test_degenerate_anova_matches_f_oneway(self):
+        # The numba kernels inline the one-way ANOVA instead of calling
+        # scipy.stats.f_oneway, so the two have to agree where the ratio stops
+        # being finite. Putting each group on a shell of constant radius about
+        # its own center makes every within-group distance identical, which
+        # zeroes the within-group term: differing radii then leave the groups
+        # apart and give inf, equal radii give nan.
+        from skbio.stats.distance._permdisp import _permdisp_f_stat_centroid_nb
+
+        def shell(cx, cy, r, k):
+            th = np.linspace(0, 2 * np.pi, k, endpoint=False)
+            return np.stack([cx + r * np.cos(th), cy + r * np.sin(th)], axis=1)
+
+        codes = np.array([0] * 4 + [1] * 4)
+        for radius in (2.0, 1.0):
+            samples = np.vstack([shell(0.0, 0.0, 1.0, 4),
+                                 shell(10.0, 10.0, radius, 4)])
+            exp = _compute_groups(samples, "centroid", codes)
+            obs = _permdisp_f_stat_centroid_nb(
+                np.ascontiguousarray(samples),
+                np.ascontiguousarray(codes, dtype=np.int32), 2)
+            npt.assert_array_equal(obs, exp)
+
+    @numba_code
+    def test_tied_statistics_match_cython(self):
+        # With few samples per group many permutations reproduce the observed
+        # partition under a different labelling, which gives a statistic that
+        # is exactly equal to the observed one rather than merely close. Those
+        # ties count towards the p-value, so this pins the comparison down to
+        # the same ">=" the cython path uses.
+        rng = np.random.default_rng(0)
+        mat = rng.random((6, 6))
+        mat = (mat + mat.T) / 2
+        np.fill_diagonal(mat, 0.0)
+        dm = DistanceMatrix(mat)
+        grouping = ['a'] * 3 + ['b'] * 3
+        for test in ("centroid", "median"):
+            obs = permdisp(dm, grouping, test=test, permutations=999, seed=42,
+                           engine="numba", dimensions=5, warn_neg_eigval=False)
+            exp = permdisp(dm, grouping, test=test, permutations=999, seed=42,
+                           engine="cython", dimensions=5, warn_neg_eigval=False)
+            npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+            self.assertEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_negative_permutations_raises(self):
+        with self.assertRaisesRegex(ValueError, "greater than or equal to zero"):
+            permdisp(self.dm, self.grouping, permutations=-1, engine="numba")
+
+    @numba_code
+    def test_crosses_chunk_boundary(self):
+        # The driver batches the permutations, so more than one chunk's worth
+        # exercises the multi-batch path. The RNG has to stay in step across
+        # chunks for the p-value to still match the cython engine.
+        from numba import get_num_threads
+        from skbio.stats.distance._permdisp import _PERM_CHUNK_PER_THREAD
+
+        permutations = _PERM_CHUNK_PER_THREAD * get_num_threads() + 5
+        obs = permdisp(self.dm, self.grouping, permutations=permutations,
+                       seed=42, engine="numba")
+        exp = permdisp(self.dm, self.grouping, permutations=permutations,
+                       seed=42, engine="cython")
+        npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+        self.assertEqual(obs['p-value'], exp['p-value'])
+
+    def test_bad_engine_raises(self):
+        with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):
+            permdisp(self.dm, self.grouping, permutations=0, engine="julia")
 
 
 if __name__ == '__main__':

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -17,7 +17,7 @@ from pandas.testing import assert_series_equal
 from scipy.stats import f_oneway, ConstantInputWarning
 
 from skbio import DistanceMatrix
-from skbio.stats.ordination import pcoa
+from skbio.stats.ordination import pcoa, OrdinationResults
 from skbio.stats.distance import permdisp
 from skbio.stats.distance._permdisp import _compute_groups
 from skbio.stats.distance._cutils import geomedian_axis_one
@@ -622,6 +622,45 @@ class PERMDISPEngineTests(TestCase):
                        seed=42, engine="cython")
         npt.assert_allclose(obs['test statistic'], exp['test statistic'])
         self.assertEqual(obs['p-value'], exp['p-value'])
+
+    @numba_code
+    def test_non_float_ordination_raises_like_cython(self):
+        # geomedian_axis_one only has single and double precision signatures,
+        # so the cython path raises on anything else. The numba kernels would
+        # happily widen an integer array and return a number instead, which is
+        # worse than the error, so the engine refuses the same inputs.
+        ordination = pcoa(self.dm, method="eigh", dimensions=10)
+
+        def recast(dtype):
+            return OrdinationResults(
+                short_method_name=ordination.short_method_name,
+                long_method_name=ordination.long_method_name,
+                eigvals=ordination.eigvals,
+                samples=ordination.samples.astype(dtype),
+                proportion_explained=ordination.proportion_explained)
+
+        for dtype in ("float16", "int64"):
+            for engine in ("cython", "numba"):
+                with self.assertRaises(TypeError):
+                    permdisp(recast(dtype), self.grouping, test="median",
+                             permutations=0, engine=engine)
+        # single and double precision stay accepted by both
+        for dtype in ("float32", "float64"):
+            for engine in ("cython", "numba"):
+                permdisp(recast(dtype), self.grouping, test="median",
+                         permutations=0, engine=engine)
+
+    @numba_code
+    def test_result_types_match_cython(self):
+        # permdisp returns an object-dtype Series, so the type of each entry is
+        # visible to the caller and must not depend on the engine.
+        for permutations in (0, 99):
+            obs = permdisp(self.dm, self.grouping, permutations=permutations,
+                           seed=42, engine="numba")
+            exp = permdisp(self.dm, self.grouping, permutations=permutations,
+                           seed=42, engine="cython")
+            for key in ("test statistic", "p-value"):
+                self.assertIs(type(obs[key]), type(exp[key]))
 
     def test_bad_engine_raises(self):
         with self.assertRaisesRegex(ValueError, "engine='julia' is not supported"):

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -580,23 +580,27 @@ class PERMDISPEngineTests(TestCase):
     @numba_code
     def test_tied_statistics_match_cython(self):
         # With few samples per group many permutations reproduce the observed
-        # partition under a different labelling, which gives a statistic that
+        # partition under a different labeling, which gives a statistic that
         # is exactly equal to the observed one rather than merely close. Those
         # ties count towards the p-value, so this pins the comparison down to
-        # the same ">=" the cython path uses.
+        # the same ">=" the cython path uses. Only the centroid test is checked
+        # this way. _compute_groups builds its group list in np.unique label
+        # order and hands it to scipy.stats.f_oneway, which is not invariant to
+        # the order of its arguments; on the median distances that costs a last
+        # bit, so a relabeled partition does not always reproduce the statistic
+        # and the tie counts legitimately differ between the engines.
         rng = np.random.default_rng(0)
         mat = rng.random((6, 6))
         mat = (mat + mat.T) / 2
         np.fill_diagonal(mat, 0.0)
         dm = DistanceMatrix(mat)
         grouping = ['a'] * 3 + ['b'] * 3
-        for test in ("centroid", "median"):
-            obs = permdisp(dm, grouping, test=test, permutations=999, seed=42,
-                           engine="numba", dimensions=5, warn_neg_eigval=False)
-            exp = permdisp(dm, grouping, test=test, permutations=999, seed=42,
-                           engine="cython", dimensions=5, warn_neg_eigval=False)
-            npt.assert_allclose(obs['test statistic'], exp['test statistic'])
-            self.assertEqual(obs['p-value'], exp['p-value'])
+        obs = permdisp(dm, grouping, test="centroid", permutations=999, seed=42,
+                       engine="numba", dimensions=5, warn_neg_eigval=False)
+        exp = permdisp(dm, grouping, test="centroid", permutations=999, seed=42,
+                       engine="cython", dimensions=5, warn_neg_eigval=False)
+        npt.assert_allclose(obs['test statistic'], exp['test statistic'])
+        self.assertEqual(obs['p-value'], exp['p-value'])
 
     @numba_code
     def test_negative_permutations_raises(self):


### PR DESCRIPTION
### Description

This adds `engine="numba"` to `permdisp`, resolved through `_resolve_engine` exactly as `permanova` and `mantel` do. The Cython path is untouched and remains the default, so nothing changes for existing callers.

The Numba path batches the permutation loop instead of evaluating one grouping at a time. A single replicate here is only O(n * d) work, with `d` the retained ordination dimensions (ten by default), so unlike `permanova` there is no large matrix to stream and the parallel axis is the permutation itself. Groupings are generated in chunks of 32 per thread, which is enough to keep every worker supplied and bounds the grouping buffer to CHUNK x n rather than letting it grow with the permutation count.

`test="median"` is the default, and it needs the geometric median, so `geomedian_axis_one` is ported to Numba alongside the F statistic. Without that port the new argument would be a no-op for the test most people actually run. The port keeps the same modified Weiszfeld iteration and the same convergence test as the Cython original, which is itself a port of hdmedians v0.14.2, with one deliberate difference described below.

There are two inputs where the two do not agree, and both are pre-existing properties of the Cython side rather than things this PR introduces.

The first is exact coincidence. If every sample in a group sits on the same point, every inverse distance is zero and `geomedian_axis_one` divides by their sum before it gets to the test that would have stopped it, so the Cython path raises `ZeroDivisionError`. This is reachable from `permdisp` with a distance matrix containing mutually identical samples, which is not exotic for technical replicates. The Numba port runs that same test one block earlier, before the division rather than after it, and so returns the shared point, which is the median. The iteration is otherwise unchanged and agrees with the Cython kernel to 1e-12 or better across a few hundred random shapes.

The second showed up in CI and is worth reporting even though it is not mine to fix here. `_compute_groups` builds its group list in `np.unique` label order and hands it to `scipy.stats.f_oneway`, which is not invariant to the order of its arguments. Renaming the groups therefore swaps the arguments and can change the last bit of the statistic. I measured each stage on x86-64: the group centers and the per-sample distances are bit-identical across the swap, and only `f_oneway` differs, by 1.332e-15 on the median distances and not at all on the centroid ones.

The visible effect is that on a six sample matrix, where 98 of 999 permutations reproduce the observed partition under a different labeling, the Cython median statistic matches for all 98 on arm64 but for only 61 of 98 on x86-64, taking the p-value from 0.099 to 0.062. Renaming the two groups from `a`/`b` to `b`/`a` moves the Cython p-value on the same data and seed. The Numba kernels compute the ANOVA inline over a fixed sample order instead of calling SciPy per group, so they are order-invariant and give 0.099 either way. Exact ties disappear once groups reach about six samples each, so this only reaches very small inputs, which is presumably why it has gone unnoticed. The centroid path is unaffected on both architectures.

I have deliberately not touched `_cutils.pyx` for either of these, since they are separate from this PR; happy to open an issue.

One asymmetry is worth calling out, since it is the only place the two engines are not doing literally the same arithmetic. The Cython path finishes with `scipy.stats.f_oneway`, while the kernels compute the one-way ANOVA inline, because calling back into SciPy from inside a `prange` loop is not possible. The two definitions agree to about 4e-15 relative on the statistic at a hundred samples and 2e-13 at five thousand, the drift being accumulated summation error rather than a difference in definition, and they return the same `inf` and the same `nan` in the degenerate cases where the within-group term vanishes; there is a test pinning both of those down. Permutations are drawn in the same order as `_run_monte_carlo_stats`, so on data without exact ties the p-values are unaffected by that drift and come out bit-identical rather than merely close; that held on all four benchmark matrices at both permutation counts. Where statistics do tie exactly a last-bit difference decides a `>=` comparison, but the deciding difference there is the Cython path's own sensitivity to argument order described above, not the drift between the engines.

This is a conversion PR, so the kernels stay close to what the Cython does.

### Benchmark

AMD EPYC 7V13, 128 cores, Linux, gcc 12.2, Python 3.12.12, NumPy 2.2.6, SciPy 1.18.0, Numba 0.61.2. All four of the EMP distance matrices, three balanced groups assigned round robin by index. Timings are the permutation phase, with the ordination computed once and passed to both engines so the shared PCoA is not smeared across the comparison. PCoA itself (`eigh`, `dimensions=10`) is 1.92s and 2.13s at 5116, and 283.69s and 251.68s at 25145.

The Cython extension is built with OpenMP (`libgomp` linked, `GOMP_parallel` present), but permdisp's Cython path has no parallel section to begin with: `geomedian_axis_one` is the only `_cutils` function it reaches and it is `nogil` without a `prange`, and the rest is `scipy.stats.f_oneway` inside a Python loop. The last two columns therefore give Numba restricted to a single thread, which is the like-for-like number.

5116 samples, minimum of three runs:

| matrix | test | permutations | cython | numba | speedup | numba, 1 thread | speedup |
|---|---|---|---|---|---|---|---|
| unweighted | centroid | 999 | 1.00s | 0.10s | 10.2x | 0.15s | 6.6x |
| unweighted | centroid | 9999 | 9.88s | 0.96s | 10.3x | 1.52s | 6.5x |
| unweighted | median | 999 | 5.16s | 0.12s | 44.4x | 1.27s | 4.0x |
| unweighted | median | 9999 | 51.56s | 1.12s | 46.2x | 12.77s | 4.0x |
| weighted normalized | centroid | 999 | 0.99s | 0.10s | 10.1x | 0.15s | 6.5x |
| weighted normalized | centroid | 9999 | 9.82s | 0.91s | 10.7x | 1.50s | 6.5x |
| weighted normalized | median | 999 | 4.60s | 0.10s | 44.7x | 1.08s | 4.2x |
| weighted normalized | median | 9999 | 45.96s | 1.05s | 43.6x | 10.82s | 4.2x |

25145 samples, single run:

| matrix | test | permutations | cython | numba | speedup | numba, 1 thread | speedup |
|---|---|---|---|---|---|---|---|
| unweighted | centroid | 999 | 3.44s | 0.50s | 6.9x | 0.75s | 4.6x |
| unweighted | centroid | 9999 | 34.32s | 4.42s | 7.8x | 7.34s | 4.7x |
| unweighted | median | 999 | 29.38s | 0.56s | 52.2x | 6.39s | 4.6x |
| unweighted | median | 9999 | 293.17s | 5.14s | 57.0x | 63.43s | 4.6x |
| weighted normalized | centroid | 999 | 3.45s | 0.49s | 7.0x | 0.74s | 4.6x |
| weighted normalized | centroid | 9999 | 34.36s | 4.40s | 7.8x | 7.29s | 4.7x |
| weighted normalized | median | 999 | 24.92s | 0.56s | 44.8x | 5.37s | 4.6x |
| weighted normalized | median | 9999 | 248.73s | 4.99s | 49.9x | 53.44s | 4.7x |

Every p-value is identical across all three columns, on all four matrices, at both permutation counts. The largest difference in the statistic is 1e-12, which is the inline ANOVA against `scipy.stats.f_oneway`. These are continuous distances with no exact ties between permutation statistics.

Three things are worth reading off these rather than leaving implicit. Most of the gain is not parallelism: restricted to one thread the Numba engine is still 4x to 6.6x faster, because batching the loop removes the per-permutation Python and SciPy call overhead. Thread scaling saturates early for the centroid test, where a replicate at ten dimensions is only about fifty thousand operations and is bound by allocation and memory rather than compute, while the median test scales better because the geometric median is real work. And the median speedup is matrix dependent, 49.9x against 57.0x at 25145, because the two inputs need different numbers of Weiszfeld iterations to converge; the centroid speedup is stable at 7-8x because there is no iteration in it.

The same 5116 run on a 16 core allocation gives 11.2x for centroid/9999 and 33.6x for median/9999, so these are not an artifact of a large core count.

At 25145 with the default median test and 9999 permutations, the permutation phase drops from four to five minutes down to about five seconds, which moves essentially the whole cost of the call onto the PCoA.

### Testing

New `PERMDISPEngineTests` class, sixteen tests, fifteen of them marked with `@numba_code` so they are skipped when Numba is absent and picked up by `pytest -m numba`.

The tests compare the two engines rather than asserting stored values: statistic and p-value for both center definitions, a ten-seed sweep on the p-value (a desynchronized random stream still agrees on most single seeds, so one is not enough to catch it), uneven group sizes, an explicit `dimensions`, `OrdinationResults` passed in directly, `permutations=0`, a negative `permutations`, and a permutation count past one chunk so the multi-batch path is exercised.

Three tests cover the parts that are not just "same as Cython" on random input. The geometric median is checked against `geomedian_axis_one` itself, including layouts where the iteration lands exactly on a sample, which is the one path that needs the zero-distance correction. A six-sample fixture produces permutations that reproduce the observed partition under a different labeling, giving statistics that are exactly equal to the observed one, which pins the p-value comparison to the same `>=` the Cython path uses; that one is centroid only, for the `f_oneway` ordering reason given above. And the degenerate ANOVA cases are compared against `f_oneway` directly.

Two more cover the places the engines could drift apart without anyone noticing: that a non float32 or float64 ordination raises `TypeError` on both engines rather than being quietly widened by the Numba path, and that the types in the returned Series do not depend on the engine.

`pytest skbio/stats/distance/tests/test_permdisp.py` passes, with and without `NUMBA_DISABLE_JIT=1`. The rest of the suite is unchanged. `ruff check .` is clean.
