### PR TITLE
BUG: raise ValueError for non-positive max_iter in optspace

### DIFF
--- a/skbio/stats/ordination/_optspace.py
+++ b/skbio/stats/ordination/_optspace.py
@@ -458,7 +458,7 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
     elif method not in ("GN", "GD"):
         raise ValueError("Method must be 'GN' or 'GD'")
 
-    elif max_iter < 1:
+    elif type(max_iter) is not int or max_iter < 1:
         raise ValueError("Max_iter must be a positive integer")
 
     # Create observed mask

--- a/skbio/stats/ordination/_optspace.py
+++ b/skbio/stats/ordination/_optspace.py
@@ -369,6 +369,10 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
         The rank of the matrix to recover. Default is 3.
     max_iter : int, optional
         Maximum number of iterations. Default is 10000.
+
+        .. versionchanged:: 0.7.4
+            A non-positive or non-integer value now raises ``ValueError``
+            instead of failing with an unrelated error partway through.
     tol : float, optional
         Convergence tolerance. Default is 1e-5.
     method : {'GD', 'GN'}, optional

--- a/skbio/stats/ordination/_optspace.py
+++ b/skbio/stats/ordination/_optspace.py
@@ -458,7 +458,7 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
     elif method not in ("GN", "GD"):
         raise ValueError("Method must be 'GN' or 'GD'")
 
-    elif type(max_iter) is not int or max_iter < 1:
+    elif not np.issubdtype(type(max_iter), np.integer) or max_iter < 1:
         raise ValueError("Max_iter must be a positive integer")
 
     # Create observed mask

--- a/skbio/stats/ordination/_optspace.py
+++ b/skbio/stats/ordination/_optspace.py
@@ -390,6 +390,8 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
     ValueError
         If ``method`` is not one of "GN" or "GD".
     ValueError
+        If ``max_iter`` is not a positive integer.
+    ValueError
         If input is fully unobserved.
 
     See Also
@@ -455,6 +457,9 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
 
     elif method not in ("GN", "GD"):
         raise ValueError("Method must be 'GN' or 'GD'")
+
+    elif max_iter < 1:
+        raise ValueError("Max_iter must be a positive integer")
 
     # Create observed mask
     observed_mask = ~np.isnan(X)

--- a/skbio/stats/ordination/_rpca.py
+++ b/skbio/stats/ordination/_rpca.py
@@ -73,6 +73,8 @@ def rpca(
         If ``dimensions`` is not a positive integer less than or equal to
         min(n_samples, n_features)
     ValueError
+        If ``max_iter`` is not a positive integer.
+    ValueError
         If any row or column is fully unobserved.
 
     See Also

--- a/skbio/stats/ordination/_rpca.py
+++ b/skbio/stats/ordination/_rpca.py
@@ -58,6 +58,10 @@ def rpca(
         than or equal to min(n, p). Default is 3.
     max_iter : int, optional
         Maximum iterations for OptSpace algorithm. Default is 10000.
+
+        .. versionchanged:: 0.7.4
+            A non-positive or non-integer value now raises ``ValueError``
+            instead of failing with an unrelated error partway through.
     sample_ids, feature_ids, output_format : optional
         Standard table parameters. See :ref:`table_params` for details.
 

--- a/skbio/stats/ordination/tests/test_optspace.py
+++ b/skbio/stats/ordination/tests/test_optspace.py
@@ -116,6 +116,18 @@ class TestOptSpace(unittest.TestCase):
 
         self.assertIn("did not converge", str(context.warning))
 
+    def test_zero_max_iter_error(self):
+        """Test error for max_iter of zero."""
+        with self.assertRaises(ValueError) as context:
+            _ = optspace(self.M_obs, self.r, max_iter=0)
+        self.assertIn("positive", str(context.exception))
+
+    def test_negative_max_iter_error(self):
+        """Test error for negative max_iter."""
+        with self.assertRaises(ValueError) as context:
+            _ = optspace(self.M_obs, self.r, max_iter=-1)
+        self.assertIn("positive", str(context.exception))
+
     def test_max_ls_exception(self):
         """Test line search warning when convergence is not achieved."""
         with patch(

--- a/skbio/stats/ordination/tests/test_optspace.py
+++ b/skbio/stats/ordination/tests/test_optspace.py
@@ -128,6 +128,11 @@ class TestOptSpace(unittest.TestCase):
             _ = optspace(self.M_obs, self.r, max_iter=-1)
         self.assertIn("positive", str(context.exception))
 
+    def test_numpy_integer_max_iter_accepted(self):
+        """Test that a NumPy integer type is accepted for max_iter."""
+        with self.assertWarns(RuntimeWarning):
+            _ = optspace(self.M_obs, self.r, max_iter=np.int64(1))
+
     def test_non_integer_max_iter_error(self):
         """Test error for non-integer max_iter."""
         with self.assertRaises(ValueError) as context:

--- a/skbio/stats/ordination/tests/test_optspace.py
+++ b/skbio/stats/ordination/tests/test_optspace.py
@@ -128,6 +128,12 @@ class TestOptSpace(unittest.TestCase):
             _ = optspace(self.M_obs, self.r, max_iter=-1)
         self.assertIn("positive", str(context.exception))
 
+    def test_non_integer_max_iter_error(self):
+        """Test error for non-integer max_iter."""
+        with self.assertRaises(ValueError) as context:
+            _ = optspace(self.M_obs, self.r, max_iter=2.5)
+        self.assertIn("integer", str(context.exception))
+
     def test_max_ls_exception(self):
         """Test line search warning when convergence is not achieved."""
         with patch(

--- a/skbio/stats/ordination/tests/test_rpca.py
+++ b/skbio/stats/ordination/tests/test_rpca.py
@@ -108,6 +108,17 @@ class TestRPCA(unittest.TestCase):
             _ = rpca(nan_table, dimensions=3)
         self.assertIn("must not contain", str(context.exception))
 
+    def test_zero_max_iter_error(self):
+        """Test error for max_iter of zero."""
+        with self.assertRaises(ValueError) as context:
+            _ = rpca(self.table, dimensions=3, max_iter=0)
+        self.assertIn("positive", str(context.exception))
+
+    def test_negative_max_iter_error(self):
+        """Test error for negative max_iter."""
+        with self.assertRaises(ValueError) as context:
+            _ = rpca(self.table, dimensions=3, max_iter=-1)
+        self.assertIn("positive", str(context.exception))
 
 
 class TestRPCAReproducibility(unittest.TestCase):


### PR DESCRIPTION
## Summary

Calling `optspace` with `max_iter=0` (or a negative value) raised `UnboundLocalError: cannot access local variable 'S' where it is not associated with a value` instead of a clear error. `S` is first assigned inside the main iteration loop, so a `max_iter` that produces zero iterations leaves it unbound by the time the function builds `X_hat` from `U @ S @ V.T`. `rpca` passes `max_iter` straight through to `optspace`, so the same crash was reachable from the public entry point. This was flagged during review of an earlier version of this branch and had survived a few rounds of revision.

`optspace` now validates `max_iter` alongside its other parameter checks (`method`, `dimensions`) and raises `ValueError` for `max_iter < 1`, with a matching docstring `Raises` entry added to both `optspace` and `rpca`.

## Tests

- `test_zero_max_iter_error` and `test_negative_max_iter_error` in `test_optspace.py`, asserting `ValueError` for `max_iter=0` and `max_iter=-1`.
- The same two cases added to `test_rpca.py` for the pass-through path.

## Checklist
- [x] I have read the contribution guidelines.
- [ ] I have documented all public-facing changes in the changelog.
- [x] This pull request does not include code, documentation, or other content derived from external source(s).
