### PR TITLE
MAINT: cache the center_distance_matrix Numba kernels and document the symmetry requirement

### DIFF
--- a/skbio/stats/ordination/_center_distance_matrix_numba.py
+++ b/skbio/stats/ordination/_center_distance_matrix_numba.py
@@ -25,13 +25,18 @@ except ImportError:
 
 if NUMBA_AVAILABLE:
 
-    @njit(parallel=True)
+    @njit(parallel=True, cache=True)
     def e_matrix_means_nb(mat, centered, row_means):
         """Apply the E-matrix transform and collect row/global means in one pass.
 
         Writes ``-0.5 * d**2`` into ``centered`` and returns the global mean of
         that transformed matrix. Values are promoted to float64 before squaring
         to match the Cython ``double`` accumulator (matters for float32 input).
+
+        ``row_means`` is the mean of each *row* of ``centered``; it is not
+        also the column means unless ``mat`` is symmetric. This function does
+        not require symmetry on its own, but its output feeds directly into
+        ``f_matrix_inplace_nb``, which does.
         """
         n = mat.shape[0]
         global_sum = np.float64(0.0)
@@ -50,12 +55,19 @@ if NUMBA_AVAILABLE:
 
         return (global_sum / np.float64(n)) / np.float64(n)
 
-    @njit(parallel=True)
+    @njit(parallel=True, cache=True)
     def f_matrix_inplace_nb(row_means, global_mean, centered):
         """Double-center the E-matrix in-place.
 
         Uses the same 24-wide block tiling as ``f_matrix_inplace_cy`` so the
         two engines share a memory-access pattern.
+
+        ``centered`` must be symmetric. The column mean of column ``col`` is
+        approximated by ``row_means[col]`` (the *row* mean of row ``col``)
+        rather than computed separately, which only equals the true column
+        mean when ``centered`` -- and therefore the original distance matrix
+        it was derived from -- is symmetric. For a non-symmetric input this
+        does not raise; it silently returns an incorrectly centered matrix.
         """
         n = centered.shape[0]
 
@@ -78,8 +90,11 @@ if NUMBA_AVAILABLE:
 
         Parameters
         ----------
-        mat : ndarray of shape (n, n)
+        mat : ndarray of shape (n, n), must be symmetric
             Input distance matrix, C-contiguous, float32 or float64.
+            ``f_matrix_inplace_nb`` reuses row means as column means, which
+            is only correct for a symmetric matrix (as distance matrices
+            are); see its docstring for details.
         centered : ndarray of shape (n, n)
             Pre-allocated output array of the same dtype as ``mat``. May alias
             ``mat`` for in-place centering.


### PR DESCRIPTION
## Summary

`e_matrix_means_nb` and `f_matrix_inplace_nb` (added in #2508) were the only Numba kernels in the codebase without `cache=True`; every other kernel (`_permanova.py`, `_mantel.py`, `_unifrac.py`, `_permdisp.py`, `_mmvec.py`) sets it. Neither kernel closes over anything but its own array and scalar arguments, so Numba's on-disk cache applies without complication. Added `cache=True` to both.

`f_matrix_inplace_nb` also has an undocumented constraint carried over from its Cython counterpart, `f_matrix_inplace_cy`, but dropped somewhere in the port: it approximates the column mean of column `col` with `row_means[col]`, the row mean of row `col`, which only equals the true column mean when the input is symmetric. For a non-symmetric matrix this does not raise, it silently returns an incorrectly centered result. `_cutils.pyx` already documents this constraint on the Cython side; I restored the equivalent note on the Numba kernels and on the public `center_distance_matrix_nb` entry point's `mat` parameter.

## Tests

Ran `test_util.py` and `test_principal_coordinate_analysis.py` (45 passed, 10 subtests) twice, including `test_center_distance_matrix_numba_matches_cython` and `test_engine_numba_matches_cython`, to exercise the on-disk cache path introduced by `cache=True` and confirm it doesn't change results. Re-verified against the current branch tip after `development_numba_gpu` was rewritten upstream.

## Checklist
- [x] I have read the contribution guidelines.
- [ ] I have documented all public-facing changes in the changelog.
- [x] This pull request does not include code, documentation, or other content derived from external source(s).
