### PR TITLE
BUG: make the Gauss-Newton Jacobian entry-indexed and its adjoint exact

### DIFF
--- a/skbio/stats/ordination/_optspace.py
+++ b/skbio/stats/ordination/_optspace.py
@@ -35,7 +35,7 @@ References
 from warnings import warn
 
 import numpy as np
-from scipy.linalg import svd
+from scipy.linalg import svd, qr, solve_triangular
 from scipy.sparse.linalg import svds, lsmr, LinearOperator
 
 
@@ -116,7 +116,83 @@ def _svd_init(X_trimmed, r):
     return U, V
 
 
-def jacobian_S(U, V, S, rows, cols):
+def _obs_basis(Ui, Vj, tol=1e-12):
+    """Factorize the S-Jacobian restricted to the observed entries.
+
+    ``J_S`` is the linear map ``dS -> P_\\Omega(U dS V^T)``. Written as a matrix
+    acting on ``dS.ravel()`` it has one row per observed entry ``k = (i, j)``,
+
+    A[k, a * r + b] = U[i, a] * V[j, b],
+
+    i.e. ``A[k] = kron(U[i], V[j])``, which matches the row-major
+    ``s.reshape(r, r)`` convention used throughout this module. ``A`` is
+    ``(n_observed, r ** 2)``, so it is thin (only 9 columns at the default rank
+    of 3) and can be factorized once per outer iteration and reused by every
+    matrix-vector product.
+
+    The economy QR factorization ``A[:, perm] = Q R`` yields both operations
+    needed downstream: ``Q`` is an orthonormal basis of ``range(J_S)``, and
+    ``R`` back-substitutes the least-squares solve for ``S``.
+
+    Column pivoting is used so that rank deficiency (possible when the observed
+    entries do not determine all ``r ** 2`` degrees of freedom of ``S``) is
+    detected from the magnitudes of the diagonal of ``R``, which pivoting orders
+    non-increasingly. Trailing columns whose pivot falls below ``tol`` relative
+    to the leading pivot are dropped, giving the basic (minimum-column-support)
+    least-squares solution rather than a division by a near-zero pivot.
+
+    Parameters
+    ----------
+    Ui : ndarray of shape (n_observed, r)
+        Rows of ``U`` gathered at the observed row indices.
+    Vj : ndarray of shape (n_observed, r)
+        Rows of ``V`` gathered at the observed column indices.
+    tol : float, optional
+        Relative pivot threshold for rank detection.
+
+    Returns
+    -------
+    Q : ndarray of shape (n_observed, rank)
+        Orthonormal basis of ``range(J_S)``.
+    R : ndarray of shape (rank, rank)
+        Upper triangular factor of the retained columns.
+    perm : ndarray of shape (rank,)
+        Indices of the retained columns of ``A``.
+    """
+
+    r = Ui.shape[1]
+
+    # A[k, a * r + b] = Ui[k, a] * Vj[k, b]
+    A = (Ui[:, :, None] * Vj[:, None, :]).reshape(-1, r**2)
+
+    Q, R, perm = qr(A, mode="economic", pivoting=True)
+
+    # Pivoting orders |diag(R)| non-increasingly, so the numerical rank is the
+    # length of the leading run of pivots above the relative threshold.
+    pivots = np.abs(np.diag(R))
+    if pivots.size == 0 or pivots[0] == 0.0:
+        rank = 0
+    else:
+        rank = int(np.count_nonzero(pivots > tol * pivots[0]))
+
+    return Q[:, :rank], R[:rank, :rank], perm[:rank]
+
+
+def _project_S_complement(Q, w):
+    """Project w onto the orthogonal complement of the S tangent space.
+
+    ``Q`` is an orthonormal basis of ``range(J_S)`` as returned by
+    :func:`_obs_basis`, so the projector onto the complement is
+
+    P_\\perp w = w - Q (Q^T w).
+
+    This is exact and costs ``O(n_observed * r ** 2)``.
+    """
+
+    return w - Q @ (Q.T @ w)
+
+
+def jacobian_S(Ui, Vj, S):
     """Compute J_S(dS).
 
     The Jacobian is
@@ -127,13 +203,18 @@ def jacobian_S(U, V, S, rows, cols):
     the reconstruction error over the observed entries.
 
     J_S(dS) = P_\\Omega(U dS V^T).
+
+    Evaluated only at the observed entries, this is
+
+    J_S(dS)[k] = U[i] dS V[j]^T,
+
+    which avoids forming the dense ``(m, n)`` product.
     """
 
-    W = U @ S @ V.T
-    return W[rows, cols]
+    return (Ui @ S * Vj).sum(axis=1)
 
 
-def jacobian_S_adj(U, V, w, observed_mask):
+def jacobian_S_adj(Ui, Vj, w):
     """Compute J_S*(W).
 
     The Jacobian adjoint is defined with respect to the inner product by
@@ -142,16 +223,15 @@ def jacobian_S_adj(U, V, w, observed_mask):
 
     Thus,
 
-    J_S*(W) = U^T P_\\Omega(W) V.
+    J_S*(W) = U^T P_\\Omega(W) V = sum_k w[k] outer(U[i], V[j]),
+
+    where the sum runs over the observed entries ``k = (i, j)``.
     """
 
-    W = np.zeros_like(observed_mask, dtype=U.dtype)
-    W[observed_mask] = w
-    ds = U.T @ W @ V
-    return ds.ravel()
+    return np.einsum("k,ka,kb->ab", w, Ui, Vj).ravel()
 
 
-def _solve_S(U, V, b, observed_mask, tol):
+def _solve_S(Q, R, perm, b, r):
     """Compute optimal S given U and V.
 
     Solves the least squares problem to find the optimal S that
@@ -164,32 +244,22 @@ def _solve_S(U, V, b, observed_mask, tol):
 
     J_S(dS) = -R
 
-    This is solved via lsmr.
+    Given the pivoted QR factorization ``A[:, perm] = Q R`` of the S-Jacobian
+    (see :func:`_obs_basis`), the solution follows from a single triangular
+    back-substitution, ``R s[perm] = Q^T b``, with the dropped (rank-deficient)
+    coefficients left at zero. This is exact, unlike the iterative solve it
+    replaces.
     """
 
-    r = U.shape[1]
-    n_observed = np.sum(observed_mask)
-    rows, cols = np.where(observed_mask)
+    s = np.zeros(r**2, dtype=b.dtype)
 
-    def matvec(s):
-        return jacobian_S(U, V, s.reshape(r, r), rows, cols)
-
-    def rmatvec(w):
-        return jacobian_S_adj(U, V, w, observed_mask)
-
-    J_S = LinearOperator(
-        shape=(n_observed, r**2),
-        matvec=matvec,
-        rmatvec=rmatvec,
-        dtype=U.dtype,
-    )
-
-    s = lsmr(J_S, b, atol=tol, btol=tol)[0]
+    if perm.size:
+        s[perm] = solve_triangular(R, Q.T @ b)
 
     return s.reshape(r, r)
 
 
-def jacobian_UV(U, V, S, dU, dV, observed_mask, tol):
+def jacobian_UV(U, V, dU, dV, rows, cols, US, VST, Q):
     """Compute J_UV(dU, dV).
 
     The Jacobian is
@@ -202,29 +272,31 @@ def jacobian_UV(U, V, S, dU, dV, observed_mask, tol):
 
     J_UV(dU, dV) = P_\\Omega(dU S V^T + U S dV^T)
 
-    This is pre-composed with projection of the pair (dU, dV) onto the tangent
-    space of (U, V).
-    """
+    Evaluated only at the observed entries ``k = (i, j)``, this is
 
-    rows, cols = np.where(observed_mask)
+    J_UV(dU, dV)[k] = dU[i] . (V S^T)[j] + (U S)[i] . dV[j],
+
+    so ``US = U @ S`` and ``VST = V @ S.T`` are precomputed once per outer
+    iteration and no dense ``(m, n)`` array is ever formed.
+
+    This is pre-composed with projection of the pair (dU, dV) onto the tangent
+    space of (U, V), and post-composed with projection onto the orthogonal
+    complement of the S tangent space.
+    """
 
     # Project input onto (U, V) tangent space
     dU_t = dU - U @ (U.T @ dU)
     dV_t = dV - V @ (V.T @ dV)
 
-    # Compute Jacobian
-    W = dU_t @ S @ V.T
-    W += U @ S @ dV_t.T
+    # Compute Jacobian over the observed entries only
+    w = (dU_t[rows] * VST[cols]).sum(axis=1)
+    w += (US[rows] * dV_t[cols]).sum(axis=1)
 
     # Project output onto complement of S tangent space
-    w = W[rows, cols]
-    s = _solve_S(U, V, w, observed_mask, tol)
-    w -= jacobian_S(U, V, s, rows, cols)
-
-    return w
+    return _project_S_complement(Q, w)
 
 
-def jacobian_UV_adj(U, V, S, w, observed_mask, tol):
+def jacobian_UV_adj(U, V, w, rows, cols, US, VST, Q):
     """Compute J*(W).
 
     The Jacobian adjoint is defined with respect to the inner product by
@@ -235,19 +307,28 @@ def jacobian_UV_adj(U, V, S, w, observed_mask, tol):
 
     J_UV*(W) = (P_\\Omega(W) V S^T, P_\\Omega(W)^T U S)
 
-    This is projected back to the tangent space of (U, V).
+    which over the observed entries ``k = (i, j)`` is the scatter-accumulation
+
+    dU[i] += w[k] * (V S^T)[j],   dV[j] += w[k] * (U S)[i].
+
+    The input is first projected onto the orthogonal complement of the S tangent
+    space and the output is projected back to the tangent space of (U, V). Both
+    projections are self-adjoint, so this is the exact adjoint of
+    :func:`jacobian_UV`.
     """
 
-    rows, cols = np.where(observed_mask)
+    m, r = U.shape
+    n = V.shape[0]
 
     # Project input onto complement of S tangent space
-    W = np.zeros_like(observed_mask, dtype=U.dtype)
-    s = _solve_S(U, V, w, observed_mask, tol)
-    W[observed_mask] = w - jacobian_S(U, V, s, rows, cols)
+    w = _project_S_complement(Q, w)
 
-    # Compute Jacobian adjoint
-    dU = W @ V @ S.T
-    dV = W.T @ U @ S
+    # Compute Jacobian adjoint by scattering into the factor rows
+    dU = np.empty((m, r), dtype=U.dtype)
+    dV = np.empty((n, r), dtype=V.dtype)
+    for q in range(r):
+        dU[:, q] = np.bincount(rows, weights=w * VST[cols, q], minlength=m)
+        dV[:, q] = np.bincount(cols, weights=w * US[rows, q], minlength=n)
 
     # Project output onto (U, V) tangent space
     dU -= U @ (U.T @ dU)
@@ -271,33 +352,38 @@ def unpack(x, U_shape, V_shape):
     return dU, dV
 
 
-def solve_gauss_newton_step(U, V, S, observed_mask, R, tol, damp):
-    """Solve (J_UV* J_UV)dx = -J_UV* R.
+def solve_gauss_newton_step(U, V, rows, cols, US, VST, Q_S, residual, tol, damp):
+    """Solve (J_UV* J_UV)dx = -J_UV* residual.
 
     The Gauss-Newton step is the vector dx = (dU, dV), where dU and dV are
     tangent vectors in their respective Grassmann manifolds. The step is the
-    least-squares solution of the system J_UV dx = -R, and it is computed using
-    the LSMR algorithm.
+    least-squares solution of the system J_UV dx = -residual, and it is
+    computed using the LSMR algorithm.
+
+    ``US``, ``VST`` and ``Q_S`` depend only on the current ``(U, V, S)``, which
+    are fixed for the duration of this call, so they are computed once by the
+    caller and closed over by the matrix-vector products rather than being
+    rebuilt on every LSMR iteration.
     """
 
     nvars = U.size + V.size
 
     def matvec(x):
         dU, dV = unpack(x, U.shape, V.shape)
-        return jacobian_UV(U, V, S, dU, dV, observed_mask, tol)
+        return jacobian_UV(U, V, dU, dV, rows, cols, US, VST, Q_S)
 
     def rmatvec(y):
-        dU, dV = jacobian_UV_adj(U, V, S, y, observed_mask, tol)
+        dU, dV = jacobian_UV_adj(U, V, y, rows, cols, US, VST, Q_S)
         return pack(dU, dV)
 
     J_UV = LinearOperator(
-        shape=(np.sum(observed_mask), nvars),
+        shape=(rows.size, nvars),
         matvec=matvec,
         rmatvec=rmatvec,
         dtype=U.dtype,
     )
 
-    step = lsmr(J_UV, -R.ravel(), atol=tol, btol=tol, damp=damp)[0]
+    step = lsmr(J_UV, -residual.ravel(), atol=tol, btol=tol, damp=damp)[0]
 
     return unpack(step, U.shape, V.shape)
 
@@ -505,23 +591,37 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
 
     # Objective function
     def _compute_obj(U, V):
+        # Gather the factor rows at the observed entries and factorize J_S
+        Ui_curr, Vj_curr = U[rows], V[cols]
+        Q_curr, R_curr, perm_curr = _obs_basis(Ui_curr, Vj_curr)
+
         # Compute optimal S given current U, V
-        S_curr = _solve_S(U, V, b, observed_mask, tol)
+        S_curr = _solve_S(Q_curr, R_curr, perm_curr, b, r)
 
         # Compute current error
-        R_curr = jacobian_S(U, V, S_curr, rows, cols) - b
+        E_curr = jacobian_S(Ui_curr, Vj_curr, S_curr) - b
 
         # Current objective (Frobenius norm of error over observed entries)
-        obj_curr = np.sum(R_curr**2)
+        obj_curr = np.sum(E_curr**2)
 
         return obj_curr
 
     for _ in range(max_iter):
+        # Gather the factor rows at the observed entries. The basis Q of
+        # range(J_S) and its triangular factor depend only on (U, V), so they
+        # are built once per iteration and reused by every Jacobian product.
+        Ui, Vj = U[rows], V[cols]
+        Q_S, R_S, perm_S = _obs_basis(Ui, Vj)
+
         # Compute optimal S given current U, V
-        S = _solve_S(U, V, b, observed_mask, tol)
+        S = _solve_S(Q_S, R_S, perm_S, b, r)
+
+        # Precompute the S-scaled factors used by the Jacobian products
+        US = U @ S
+        VST = V @ S.T
 
         # Compute current error
-        R = jacobian_S(U, V, S, rows, cols) - b
+        R = jacobian_S(Ui, Vj, S) - b
 
         # Current objective (Frobenius norm of error over observed entries)
         obj = np.sum(R**2)
@@ -547,7 +647,7 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
         # Update via gradient descent with line search
         if method == "GD":
             # Compute gradient directions
-            dU, dV = jacobian_UV_adj(U, V, S, -R, observed_mask, tol)
+            dU, dV = jacobian_UV_adj(U, V, -R, rows, cols, US, VST, Q_S)
 
             # Perform backtracking line search
             U, V, obj, alpha = line_search(
@@ -557,7 +657,9 @@ def optspace(X, dimensions=3, max_iter=10000, tol=1e-5, method="GD"):
         # Update via Gauss-Newton
         if method == "GN":
             # Compute Gauss-Newton step
-            dU, dV = solve_gauss_newton_step(U, V, S, observed_mask, R, tol, damp)
+            dU, dV = solve_gauss_newton_step(
+                U, V, rows, cols, US, VST, Q_S, R, tol, damp
+            )
 
             # Retract updates back to Grassmann manifold
             U = retract_grassmann(U, dU)

--- a/skbio/stats/ordination/tests/test_optspace.py
+++ b/skbio/stats/ordination/tests/test_optspace.py
@@ -7,11 +7,21 @@
 # ----------------------------------------------------------------------------
 
 import unittest
+import warnings
 from unittest.mock import patch
 
 import numpy as np
 
-from skbio.stats.ordination._optspace import optspace
+from skbio.stats.ordination._optspace import (
+    optspace,
+    _obs_basis,
+    _project_S_complement,
+    _solve_S,
+    jacobian_S,
+    jacobian_S_adj,
+    jacobian_UV,
+    jacobian_UV_adj,
+)
 
 
 class TestOptSpace(unittest.TestCase):
@@ -180,6 +190,258 @@ class TestOptSpace(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             _ = optspace(M_obs, dimensions=self.r)
         self.assertIn("requires at least", str(context.exception))
+
+
+class TestJacobian(unittest.TestCase):
+    """Tests for the entry-indexed Jacobian operators used by OptSpace.
+
+    The Jacobians are evaluated only at the observed entries. These tests check
+    them against the equivalent dense formulation, which materializes the full
+    (m, n) reconstruction and is therefore obviously correct but far slower.
+    """
+
+    def setUp(self):
+        """Set up a small, well-conditioned factorization."""
+        rng = np.random.default_rng(3)
+        self.m, self.n, self.r = 23, 17, 3
+
+        self.U = np.linalg.qr(rng.normal(size=(self.m, self.r)))[0]
+        self.V = np.linalg.qr(rng.normal(size=(self.n, self.r)))[0]
+        self.S = rng.normal(size=(self.r, self.r))
+
+        self.mask = rng.random((self.m, self.n)) < 0.5
+        self.rows, self.cols = np.where(self.mask)
+        self.n_observed = self.rows.size
+
+        self.Ui = self.U[self.rows]
+        self.Vj = self.V[self.cols]
+        self.US = self.U @ self.S
+        self.VST = self.V @ self.S.T
+        self.Q, self.R, self.perm = _obs_basis(self.Ui, self.Vj)
+
+        self.rng = rng
+
+    def dense_basis(self):
+        """Dense (n_observed, r ** 2) matrix form of J_S."""
+        return np.einsum("ka,kb->kab", self.Ui, self.Vj).reshape(
+            self.n_observed, self.r**2
+        )
+
+    def dense_project(self, w):
+        """Exact projection onto the complement of range(J_S), densely."""
+        A = self.dense_basis()
+        s = np.linalg.lstsq(A, w, rcond=None)[0]
+        return w - A @ s
+
+    def dense_jacobian_UV(self, dU, dV):
+        """Dense reference for jacobian_UV (forms the full (m, n) product)."""
+        dU_t = dU - self.U @ (self.U.T @ dU)
+        dV_t = dV - self.V @ (self.V.T @ dV)
+        W = dU_t @ self.S @ self.V.T + self.U @ self.S @ dV_t.T
+        return self.dense_project(W[self.rows, self.cols])
+
+    def dense_jacobian_UV_adj(self, w):
+        """Dense reference for jacobian_UV_adj."""
+        W = np.zeros((self.m, self.n))
+        W[self.mask] = self.dense_project(w)
+        dU = W @ self.V @ self.S.T
+        dV = W.T @ self.U @ self.S
+        dU -= self.U @ (self.U.T @ dU)
+        dV -= self.V @ (self.V.T @ dV)
+        return dU, dV
+
+    def test_jacobian_S_matches_dense(self):
+        """Entry-indexed J_S agrees with the dense reconstruction."""
+        expected = (self.U @ self.S @ self.V.T)[self.rows, self.cols]
+        observed = jacobian_S(self.Ui, self.Vj, self.S)
+        np.testing.assert_allclose(observed, expected, atol=1e-12)
+
+    def test_jacobian_S_adj_matches_dense(self):
+        """Entry-indexed J_S* agrees with the dense scatter form."""
+        w = self.rng.normal(size=self.n_observed)
+        W = np.zeros((self.m, self.n))
+        W[self.mask] = w
+        expected = (self.U.T @ W @ self.V).ravel()
+        observed = jacobian_S_adj(self.Ui, self.Vj, w)
+        np.testing.assert_allclose(observed, expected, atol=1e-12)
+
+    def test_obs_basis_reshape_convention(self):
+        """The QR basis is built from the same s.reshape(r, r) ordering."""
+        A = self.dense_basis()
+        np.testing.assert_allclose(
+            A @ self.S.ravel(), jacobian_S(self.Ui, self.Vj, self.S), atol=1e-12
+        )
+
+        # A[:, perm] == Q @ R for the retained columns
+        np.testing.assert_allclose(A[:, self.perm], self.Q @ self.R, atol=1e-12)
+
+    def test_solve_S_is_exact(self):
+        """The triangular solve for S attains the least-squares minimum."""
+        b = self.rng.normal(size=self.n_observed)
+        A = self.dense_basis()
+
+        S_solved = _solve_S(self.Q, self.R, self.perm, b, self.r)
+        S_lstsq = np.linalg.lstsq(A, b, rcond=None)[0].reshape(self.r, self.r)
+
+        np.testing.assert_allclose(S_solved, S_lstsq, atol=1e-10)
+
+        # The residual must not exceed the reference least-squares residual.
+        residual = np.linalg.norm(A @ S_solved.ravel() - b)
+        reference = np.linalg.norm(A @ S_lstsq.ravel() - b)
+        self.assertLessEqual(residual, reference * (1 + 1e-10))
+
+    def test_project_S_complement(self):
+        """P_perp is idempotent and annihilates the range of J_S."""
+        w = self.rng.normal(size=self.n_observed)
+        Pw = _project_S_complement(self.Q, w)
+
+        # Idempotence
+        np.testing.assert_allclose(
+            _project_S_complement(self.Q, Pw), Pw, atol=1e-12
+        )
+
+        # Orthogonality: the projected vector has no J_S component left
+        np.testing.assert_allclose(
+            jacobian_S_adj(self.Ui, self.Vj, Pw),
+            np.zeros(self.r**2),
+            atol=1e-12,
+        )
+
+        # Agrees with the dense least-squares projection
+        np.testing.assert_allclose(Pw, self.dense_project(w), atol=1e-9)
+
+    def test_jacobian_UV_matches_dense(self):
+        """Entry-indexed J_UV agrees with the dense formulation."""
+        dU = self.rng.normal(size=(self.m, self.r))
+        dV = self.rng.normal(size=(self.n, self.r))
+
+        observed = jacobian_UV(
+            self.U, self.V, dU, dV, self.rows, self.cols, self.US, self.VST, self.Q
+        )
+        np.testing.assert_allclose(
+            observed, self.dense_jacobian_UV(dU, dV), atol=1e-9
+        )
+
+    def test_jacobian_UV_adj_matches_dense(self):
+        """Entry-indexed J_UV* agrees with the dense formulation."""
+        w = self.rng.normal(size=self.n_observed)
+
+        dU, dV = jacobian_UV_adj(
+            self.U, self.V, w, self.rows, self.cols, self.US, self.VST, self.Q
+        )
+        dU_dense, dV_dense = self.dense_jacobian_UV_adj(w)
+
+        np.testing.assert_allclose(dU, dU_dense, atol=1e-9)
+        np.testing.assert_allclose(dV, dV_dense, atol=1e-9)
+
+    def test_jacobian_UV_adjoint_identity(self):
+        """<J x, y> == <x, J* y> for random x and y.
+
+        LSMR assumes matvec and rmatvec form an exact adjoint pair, so this is
+        the defining property of the operator used by the Gauss-Newton step.
+        """
+        for seed in range(5):
+            rng = np.random.default_rng(100 + seed)
+            dU = rng.normal(size=(self.m, self.r))
+            dV = rng.normal(size=(self.n, self.r))
+            y = rng.normal(size=self.n_observed)
+
+            Jx = jacobian_UV(
+                self.U,
+                self.V,
+                dU,
+                dV,
+                self.rows,
+                self.cols,
+                self.US,
+                self.VST,
+                self.Q,
+            )
+            JtY_U, JtY_V = jacobian_UV_adj(
+                self.U, self.V, y, self.rows, self.cols, self.US, self.VST, self.Q
+            )
+
+            lhs = Jx @ y
+            rhs = np.sum(dU * JtY_U) + np.sum(dV * JtY_V)
+            self.assertAlmostEqual(lhs, rhs, delta=1e-12 * max(1.0, abs(lhs)))
+
+
+class TestRankDeficient(unittest.TestCase):
+    """Tests for the rank-deficient fallback in the S-Jacobian factorization."""
+
+    def test_fewer_observations_than_unknowns(self):
+        """A is rank deficient when n_observed < r ** 2."""
+        rng = np.random.default_rng(1)
+        r = 3
+
+        # 6 observed entries but 9 unknowns in S
+        M = np.full((4, 4), np.nan)
+        for i, j in [(0, 0), (1, 1), (2, 2), (3, 3), (0, 1), (2, 3)]:
+            M[i, j] = rng.normal()
+
+        rows, cols = np.where(~np.isnan(M))
+        U = np.linalg.qr(rng.normal(size=(4, r)))[0]
+        V = np.linalg.qr(rng.normal(size=(4, r)))[0]
+
+        Q, R, perm = _obs_basis(U[rows], V[cols])
+        self.assertLess(Q.shape[1], r**2)
+        self.assertEqual(Q.shape[1], R.shape[0])
+        self.assertEqual(Q.shape[1], perm.size)
+
+        S = _solve_S(Q, R, perm, M[rows, cols], r)
+        self.assertTrue(np.all(np.isfinite(S)))
+
+        # The dropped coefficients are exactly zero, not garbage.
+        dropped = np.setdiff1d(np.arange(r**2), perm)
+        np.testing.assert_array_equal(S.ravel()[dropped], 0.0)
+
+    def test_degenerate_factors(self):
+        """A is rank deficient when the factor rows are degenerate."""
+        rng = np.random.default_rng(1)
+        r = 3
+
+        rows, cols = np.where(np.ones((6, 6), dtype=bool))
+        U = np.tile(np.linalg.qr(rng.normal(size=(6, r)))[0][:1], (6, 1))
+        V = np.linalg.qr(rng.normal(size=(6, r)))[0]
+
+        Q, R, perm = _obs_basis(U[rows], V[cols])
+        self.assertEqual(Q.shape[1], r)
+
+        S = _solve_S(Q, R, perm, rng.normal(size=rows.size), r)
+        self.assertTrue(np.all(np.isfinite(S)))
+
+    def test_completion_of_degenerate_input(self):
+        """Matrix completion of a rank-deficient problem does not blow up."""
+        rng = np.random.default_rng(1)
+
+        M = np.full((4, 4), np.nan)
+        for i, j in [(0, 0), (1, 1), (2, 2), (3, 3), (0, 1), (2, 3)]:
+            M[i, j] = rng.normal()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            M_hat = optspace(M, dimensions=3, max_iter=50)
+
+        self.assertTrue(np.all(np.isfinite(M_hat)))
+
+
+class TestSolverAgreement(unittest.TestCase):
+    """Gradient descent and Gauss-Newton share the exact S solve."""
+
+    def test_gd_and_gn_agree(self):
+        """Both methods converge to the same completed matrix."""
+        rng = np.random.default_rng(0)
+        m, n, r = 100, 100, 3
+        M_true = rng.normal(size=(m, r)) @ rng.normal(size=(n, r)).T
+        M_obs = M_true + 0.01 * rng.normal(size=M_true.shape)
+        M_obs[~(rng.random((m, n)) < 0.4)] = np.nan
+
+        M_gd = optspace(M_obs, r, method="GD", tol=1e-5)
+        M_gn = optspace(M_obs, r, method="GN", tol=1e-5)
+
+        rel_diff = np.linalg.norm(M_gd - M_gn) / np.linalg.norm(M_gn)
+        self.assertLess(rel_diff, 1e-3)
+
 
 # TODO: More varied sizes, shapes, and missingness among matrices
 # Vary total size (m*n), ratio (m/n), portion p of observed entries,


### PR DESCRIPTION
## Summary

#2512 added a projection onto the complement of the S tangent space by calling `_solve_S` from inside `jacobian_UV` and `jacobian_UV_adj`. `_solve_S` runs its own `scipy.sparse.linalg.lsmr` call whose matvec, `jacobian_S`, builds the dense m x n product `U @ S @ V.T`. So every outer-loop LSMR matvec in the Gauss-Newton step now triggers a nested LSMR solve, and each iteration of that nested solve reconstructs a dense array from a handful of observed entries. `np.where(observed_mask)` is also recomputed separately in `jacobian_UV`, `jacobian_UV_adj`, and `_solve_S`, three times per matvec.

The S-projection doesn't need an iterative solve. It's a projection onto `range(J_S)` complement, and `J_S` is only N x r^2 (N the number of observed entries, 9 columns at rank 3), so a one-time economy QR of `J_S` per outer Gauss-Newton iteration replaces the nested LSMR entirely: the projection becomes `w - Q @ (Q.T @ w)` and the solve becomes back-substitution against `R`. `jacobian_S`, `jacobian_S_adj`, `jacobian_UV`, and `jacobian_UV_adj` are rewritten to index directly into the observed rows and columns instead of materializing dense products, and `rows`, `cols`, `U @ S`, `S @ V.T`, and the QR factors are hoisted out of the per-matvec closures into `solve_gauss_newton_step` and `optspace`, computed once per outer iteration instead of once per matvec.

The rewrite also turned up a real correctness gap in the current code, not just a performance one: the outer LSMR call assumes `matvec` and `rmatvec` are an exact adjoint pair, and the nested-LSMR projection was breaking that assumption. On a random test pair the old code is off by 1.7e-4; the new exact projection is off by 3.6e-15. On a converged fixture the two solvers still agree (max abs difference 1.76e-6, relative Frobenius 1.04e-7), but on a non-converged HDLSS case (50 samples x 398 features, 10% observed, max_iter=20) they diverge by O(1), and the new trajectory is the one that doesn't diverge (masked SSE 4.30e3 vs 6.13e3, ||X_hat||_F 43 vs 329 for the old code).

A, the N x r^2 basis for the S-projection, can be rank-deficient. I used a pivoted economy QR and drop columns where |R_ii| is below 1e-12 times |R_00| before back-substituting, rather than falling back to a separate least-squares solve, since it reuses the same Q the projection already needs.

## Benchmarks

Rank 3, 5 outer iterations, before vs after, same machine:

| case | method | before | after | speedup |
|---|---|---|---|---|
| 50 x 200 @ 10% | GN | 2.26 s | 0.54 s | 4.2x |
| 50 x 1000 @ 5% | GN | 9.24 s | 1.82 s | 5.1x |
| 50 x 1000 @ 10% | GN | 5.08 s | 1.66 s | 3.1x |
| 100 x 2000 @ 5% | GN | 29.32 s | 3.01 s | 9.7x |
| 100 x 2000 @ 5% | GD | 0.15 s | 0.05 s | 3.0x |

GD benefits too, because `_compute_obj` calls `_solve_S` inside the line search, up to 16 times per call.

## Tests

- `TestJacobian`: `jacobian_S`/`jacobian_S_adj` against the dense reference (5.6e-17 / 3.3e-16), the adjoint dot-product identity for `jacobian_UV`/`jacobian_UV_adj` (new pair 3.6e-15, old pair 1.7e-4), and idempotence/orthogonality of the S-complement projection.
- `TestRankDeficient`: three cases that trigger the pivoted-QR fallback.
- `TestSolverAgreement`: end-to-end `method="GN"` before/after on the existing fixture.
- `test_gauss_newton`, `test_basic_completion`, and `test_gradient_descent` pass unchanged, no tolerances loosened.
- Full `skbio/stats/ordination/` suite: 193 passed, 5 skipped.

Based directly on the current tip of #2512 (`rpca_dev` at ea757faa), re-verified unchanged as of this PR.

## Checklist
- [x] I have read the contribution guidelines.
- [ ] I have documented all public-facing changes in the changelog.
- [x] This pull request does not include code, documentation, or other content derived from external source(s).
