### PR TITLE
DOC: document the symmetry requirement of the center_distance_matrix Numba kernels

### DIFF
--- a/skbio/stats/ordination/_center_distance_matrix_numba.py
+++ b/skbio/stats/ordination/_center_distance_matrix_numba.py
@@ -32,6 +32,11 @@ if NUMBA_AVAILABLE:
         Writes ``-0.5 * d**2`` into ``centered`` and returns the global mean of
         that transformed matrix. Values are promoted to float64 before squaring
         to match the Cython ``double`` accumulator (matters for float32 input).
+
+        ``row_means`` is the mean of each *row* of ``centered``; it is not
+        also the column means unless ``mat`` is symmetric. This function does
+        not require symmetry on its own, but its output feeds directly into
+        ``f_matrix_inplace_nb``, which does.
         """
         n = mat.shape[0]
         global_sum = np.float64(0.0)
@@ -56,6 +61,13 @@ if NUMBA_AVAILABLE:
 
         Uses the same 24-wide block tiling as ``f_matrix_inplace_cy`` so the
         two engines share a memory-access pattern.
+
+        ``centered`` must be symmetric. The column mean of column ``col`` is
+        approximated by ``row_means[col]`` (the *row* mean of row ``col``)
+        rather than computed separately, which only equals the true column
+        mean when ``centered`` -- and therefore the original distance matrix
+        it was derived from -- is symmetric. For a non-symmetric input this
+        does not raise; it silently returns an incorrectly centered matrix.
         """
         n = centered.shape[0]
 
@@ -78,8 +90,11 @@ if NUMBA_AVAILABLE:
 
         Parameters
         ----------
-        mat : ndarray of shape (n, n)
+        mat : ndarray of shape (n, n), must be symmetric
             Input distance matrix, C-contiguous, float32 or float64.
+            ``f_matrix_inplace_nb`` reuses row means as column means, which
+            is only correct for a symmetric matrix (as distance matrices
+            are); see its docstring for details.
         centered : ndarray of shape (n, n)
             Pre-allocated output array of the same dtype as ``mat``. May alias
             ``mat`` for in-place centering.


### PR DESCRIPTION
## Summary

f_matrix_inplace_nb approximates the column mean of column col with row_means[col], the row mean of row col, rather than computing it separately. That only equals the true column mean when the input is symmetric. For a non-symmetric matrix this does not raise, it silently returns an incorrectly centered result. The Cython counterpart, f_matrix_inplace_cy, already documents this constraint; the Numba port dropped it. This restores the equivalent note on both Numba kernels and on the public center_distance_matrix_nb entry point's mat parameter.

## Tests

Docstring change only, no test changes needed.

## Checklist
- [x] I have read the contribution guidelines.
- [ ] I have documented all public-facing changes in the changelog. (docstring-only, no public API or behavior change)
- [x] This pull request does not include code, documentation, or other content derived from external source(s).

@sfiligoi
