### PR TITLE
TST: Replace deprecated NumPy assert_warns

### DIFF
--- a/skbio/io/format/tests/test_base.py
+++ b/skbio/io/format/tests/test_base.py
@@ -144,8 +144,8 @@ class PhredEncoderTests(unittest.TestCase):
         self.assertIn('-1', str(cm.exception))
         self.assertIn('[0, 93]', str(cm.exception))
 
-        obs = npt.assert_warns(UserWarning, _encode_phred_to_qual,
-                               [42, 94, 33], variant='sanger')
+        with self.assertWarns(UserWarning):
+            obs = _encode_phred_to_qual([42, 94, 33], variant='sanger')
         self.assertEqual(obs, 'K~B')
 
     def test_illumina13_variant(self):
@@ -160,8 +160,8 @@ class PhredEncoderTests(unittest.TestCase):
         self.assertIn('-1', str(cm.exception))
         self.assertIn('[0, 62]', str(cm.exception))
 
-        obs = npt.assert_warns(UserWarning, _encode_phred_to_qual,
-                               [42, 63, 33], variant='illumina1.3')
+        with self.assertWarns(UserWarning):
+            obs = _encode_phred_to_qual([42, 63, 33], variant='illumina1.3')
         self.assertEqual(obs, 'j~a')
 
     def test_illumina18_variant(self):
@@ -176,8 +176,8 @@ class PhredEncoderTests(unittest.TestCase):
         self.assertIn('-1', str(cm.exception))
         self.assertIn('[0, 62]', str(cm.exception))
 
-        obs = npt.assert_warns(UserWarning, _encode_phred_to_qual,
-                               [42, 63, 33], variant='illumina1.8')
+        with self.assertWarns(UserWarning):
+            obs = _encode_phred_to_qual([42, 63, 33], variant='illumina1.8')
         self.assertEqual(obs, 'K_B')
 
     def test_custom_phred_offset(self):
@@ -190,8 +190,8 @@ class PhredEncoderTests(unittest.TestCase):
         self.assertIn('-1', str(cm.exception))
         self.assertIn('[0, 84]', str(cm.exception))
 
-        obs = npt.assert_warns(UserWarning, _encode_phred_to_qual,
-                               [42, 255, 33], phred_offset=42)
+        with self.assertWarns(UserWarning):
+            obs = _encode_phred_to_qual([42, 255, 33], phred_offset=42)
         self.assertEqual(obs, 'T~K')
 
 


### PR DESCRIPTION
Please complete the following checklist:

* [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).

* [ ] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).

* [ ] **This pull request includes code, documentation, or other content derived from external source(s).** If this is the case, ensure the external source's license is compatible with scikit-bio's [license](https://github.com/scikit-bio/scikit-bio/blob/main/LICENSE.txt). Include the license in the `licenses` directory and add a comment in the code giving proper attribution. Ensure any other requirements set forth by the license and/or author are satisfied.

  - **It is your responsibility to disclose** code, documentation, or other content derived from external source(s). If you have questions about whether something can be included in the project or how to give proper attribution, include those questions in your pull request and a reviewer will assist you.

* [x] This pull request does not include code, documentation, or other content derived from external source(s).

Note: [This document](https://scikit.bio/devdoc/review.html) may also be helpful to see some of the things code reviewers will be verifying when reviewing your pull request.

### Summary

Replaces four uses of the deprecated `numpy.testing.assert_warns` utility in `skbio/io/format/tests/test_base.py` with `unittest.TestCase.assertWarns`.

NumPy 2.4 deprecates its warning assertion utilities. Using the existing `unittest` warning context manager removes these deprecation warnings while preserving both the warning checks and return-value assertions.

### Testing

- `python -m pytest skbio/io/format/tests/test_base.py -W error::DeprecationWarning -q`
  - 32 passed
- `pre-commit run --files skbio/io/format/tests/test_base.py`
  - Ruff passed
  - Ruff format passed
- Full test suite:
  - 3791 passed
  - 99 skipped
  - 28 warnings
