### PR TITLE
ENH: add engine= selector with Numba geometric-median to permdisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `TreeNode.prune` and `TreeNode.bifurcate` now accept an `inplace` parameter (default `True`, preserving the previous in-place behavior) and return the resulting tree. This makes them consistent with other whole-tree methods such as `shear` and `root_at_midpoint`. Set `inplace=False` to leave the original tree unchanged and operate on a copy ([#2495](https://github.com/scikit-bio/scikit-bio/pull/2495)).
 * Transition probability matrix computation has been introduced ([#2496](https://github.com/scikit-bio/scikit-bio/pull/2496)).
 * `pcoa` and `center_distance_matrix` can now use the Numba backend for distance-matrix centering via `engine="numba"` [#2508](https://github.com/scikit-bio/scikit-bio/pull/2508).
+* `permdisp` now supports the optional Numba backend via an `engine` parameter, providing a JIT-compiled alternative to the Cython geometric-median (`test="median"`) computation.
 * Added a Numba GPU backend for `permanova` and `mantel`. With `engine="numba"` and a GPU-resident `DistanceMatrix`, a fused single-source kernel runs on the device (`numba.cuda` on NVIDIA, `numba.hip` on AMD), falling back to the array-API path when the kernel is unavailable [#2511](https://github.com/scikit-bio/scikit-bio/pull/2511).
 
 ### Performance enhancements

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -26,7 +26,7 @@ from skbio.util._decorator import params_aliased
 from skbio._config import _resolve_engine
 
 try:
-    from numba import njit, prange
+    from numba import njit
 
     NUMBA_AVAILABLE = True
 except ImportError:
@@ -40,17 +40,19 @@ if TYPE_CHECKING:  # pragma: no cover
 
 if NUMBA_AVAILABLE:
 
-    @njit(parallel=True, cache=True)
+    @njit(cache=True)
     def _geomedian_axis_one_nb(X, eps, maxiters):
         """Compute geometric median along axis 1 using Numba.
 
         This is a Numba port of the Weiszfeld algorithm implemented by the
         Cython ``geomedian_axis_one`` (see ``_cutils.pyx``). It always
-        operates in float64. The outer iteration is inherently sequential
-        (each iteration depends on the previous ``y``), so it cannot be
-        parallelized; only the inner per-point and per-dimension loops
-        (independent writes, no cross-iteration reduction) are wrapped in
-        ``prange``.
+        operates in float64. All loops run sequentially (no ``prange``):
+        profiling showed that at the problem sizes involved here (tens to
+        low hundreds of points per group, called thousands of times per
+        ``permdisp`` call for the Monte Carlo permutations), the fixed
+        per-entry dispatch overhead of Numba's parallel regions dominates
+        the actual compute time, making ``parallel=True`` several times
+        *slower* than a plain sequential ``@njit`` function.
         """
         p = X.shape[0]
         n = X.shape[1]
@@ -73,8 +75,7 @@ if NUMBA_AVAILABLE:
         y1 = np.empty(p, dtype=np.float64)
 
         for _ in range(maxiters):
-            # independent per-point writes: safe to parallelize
-            for i in prange(n):
+            for i in range(n):
                 d = 0.0
                 for j in range(p):
                     tmp = X[j, i] - y[j]
@@ -94,8 +95,7 @@ if NUMBA_AVAILABLE:
             for i in range(n):
                 W[i] = Dinv[i] / Dinvs
 
-            # independent per-dimension writes: safe to parallelize
-            for j in prange(p):
+            for j in range(p):
                 total = 0.0
                 for i in range(n):
                     if abs(D[i]) > eps:

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -23,11 +23,143 @@ from ._base import (
 )
 from skbio.stats.ordination import pcoa, OrdinationResults
 from skbio.util._decorator import params_aliased
+from skbio._config import _resolve_engine
+
+try:
+    from numba import njit, prange
+
+    NUMBA_AVAILABLE = True
+except ImportError:
+    NUMBA_AVAILABLE = False
 
 if TYPE_CHECKING:  # pragma: no cover
     from numpy.typing import ArrayLike
     import pandas as pd
     from skbio.util._typing import SeedLike
+
+
+if NUMBA_AVAILABLE:
+
+    @njit(parallel=True, cache=True)
+    def _geomedian_axis_one_nb(X, eps, maxiters):
+        """Compute geometric median along axis 1 using Numba.
+
+        This is a Numba port of the Weiszfeld algorithm implemented by the
+        Cython ``geomedian_axis_one`` (see ``_cutils.pyx``). It always
+        operates in float64. The outer iteration is inherently sequential
+        (each iteration depends on the previous ``y``), so it cannot be
+        parallelized; only the inner per-point and per-dimension loops
+        (independent writes, no cross-iteration reduction) are wrapped in
+        ``prange``.
+        """
+        p = X.shape[0]
+        n = X.shape[1]
+
+        # initial guess = row means (mean along axis 1)
+        y = np.empty(p, dtype=np.float64)
+        for j in range(p):
+            s = 0.0
+            for i in range(n):
+                s += X[j, i]
+            y[j] = s / n
+
+        if n == 1:
+            return y
+
+        D = np.empty(n, dtype=np.float64)
+        Dinv = np.empty(n, dtype=np.float64)
+        W = np.empty(n, dtype=np.float64)
+        T = np.empty(p, dtype=np.float64)
+        y1 = np.empty(p, dtype=np.float64)
+
+        for _ in range(maxiters):
+            # independent per-point writes: safe to parallelize
+            for i in prange(n):
+                d = 0.0
+                for j in range(p):
+                    tmp = X[j, i] - y[j]
+                    d += tmp * tmp
+                Di = np.sqrt(d)
+                D[i] = Di
+                if abs(Di) > eps:
+                    Dinv[i] = 1.0 / Di
+                else:
+                    Dinv[i] = 0.0
+
+            # sequential reduction, same order as Cython's _sum
+            Dinvs = 0.0
+            for i in range(n):
+                Dinvs += Dinv[i]
+
+            for i in range(n):
+                W[i] = Dinv[i] / Dinvs
+
+            # independent per-dimension writes: safe to parallelize
+            for j in prange(p):
+                total = 0.0
+                for i in range(n):
+                    if abs(D[i]) > eps:
+                        total += W[i] * X[j, i]
+                T[j] = total
+
+            nzeros = n
+            for i in range(n):
+                if abs(D[i]) > eps:
+                    nzeros -= 1
+
+            if nzeros == 0:
+                for j in range(p):
+                    y1[j] = T[j]
+            elif nzeros == n:
+                break
+            else:
+                r = 0.0
+                for j in range(p):
+                    Rj = (T[j] - y[j]) * Dinvs
+                    r += Rj * Rj
+                r = np.sqrt(r)
+                if r > eps:
+                    rinv = nzeros / r
+                else:
+                    rinv = 0.0
+                a = max(0.0, 1.0 - rinv)
+                b = min(1.0, rinv)
+                for j in range(p):
+                    y1[j] = a * T[j] + b * y[j]
+
+            dist = 0.0
+            for j in range(p):
+                tmp = y[j] - y1[j]
+                dist += tmp * tmp
+            dist = np.sqrt(dist)
+            if dist < eps:
+                break
+
+            for j in range(p):
+                y[j] = y1[j]
+
+        return y
+
+
+def _geomedian_axis_one(X, engine):
+    """Compute the geometric median along axis 1 using the given engine.
+
+    Parameters
+    ----------
+    X : array_like
+        Array of shape ``(p, n)`` (``p`` dimensions, ``n`` points).
+    engine : str
+        Already-resolved compute engine, either ``"cython"`` or ``"numba"``.
+
+    Returns
+    -------
+    numpy.ndarray
+        The length-``p`` geometric median.
+    """
+    if engine == "numba":
+        Xc = np.ascontiguousarray(X, dtype=np.float64)
+        return np.asarray(_geomedian_axis_one_nb(Xc, 1e-7, 500))
+    return np.asarray(geomedian_axis_one(X))
 
 
 @params_aliased(
@@ -46,6 +178,7 @@ def permdisp(
     dimensions: int = 10,
     seed: SeedLike | None = None,
     warn_neg_eigval: bool | float = 0.01,
+    engine: str | None = None,
 ) -> pd.Series:
     r"""Test for Homogeneity of Multivariate Groups Disperisons.
 
@@ -103,6 +236,13 @@ def permdisp(
 
         .. versionadded:: 0.6.3
 
+    engine : {"cython", "numba"}, optional
+        Compute engine to use for the geometric median (``test="median"``).
+        ``"cython"`` (default) uses the Cython implementation. ``"numba"``
+        uses the optional Numba implementation and requires Numba to be
+        installed. If not provided, the global default is used (see
+        :func:`skbio.set_config`). Ignored when ``test="centroid"``.
+
     Returns
     -------
     pandas.Series
@@ -129,6 +269,10 @@ def permdisp(
         If all of the values in the grouping vector are unique.
     KeyError
         If there are ids in grouping that are not in distmat.
+    ValueError
+        If ``engine`` is not one of the supported compute engines.
+    ImportError
+        If ``engine="numba"`` is specified but Numba is not installed.
 
     See Also
     --------
@@ -304,7 +448,9 @@ def permdisp(
 
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 
-    test_stat_function = partial(_compute_groups, sample_data, test)
+    engine = _resolve_engine(engine, ("cython", "numba"))
+
+    test_stat_function = partial(_compute_groups, sample_data, test, engine)
 
     stat, p_value = _run_monte_carlo_stats(
         test_stat_function, grouping, permutations, seed
@@ -315,7 +461,7 @@ def permdisp(
     )
 
 
-def _compute_groups(samples, test_type, grouping):
+def _compute_groups(samples, test_type, engine, grouping):
     data = np.asarray(samples)
     groups = []
 
@@ -326,7 +472,7 @@ def _compute_groups(samples, test_type, grouping):
         if test_type == "centroid":
             center = group_data.mean(axis=0)
         else:  # median
-            center = np.asarray(geomedian_axis_one(group_data.T))
+            center = _geomedian_axis_one(group_data.T, engine)
 
         # Distances from each sample in this group to the group center.
         groups.append(np.linalg.norm(group_data - center, axis=1))

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -45,7 +45,7 @@ _GEOMEDIAN_MAXITERS = 500
 
 if NUMBA_AVAILABLE:
 
-    @njit(cache=True)
+    @njit
     def _geomedian_axis_one_nb(X, eps, maxiters):
         """Compute geometric median along axis 1 using Numba.
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -162,6 +162,8 @@ def _geomedian_axis_one(X, engine):
         The length-``p`` geometric median.
     """
     if engine == "numba":
+        if not NUMBA_AVAILABLE:
+            raise ImportError("engine='numba' requires the optional numba dependency.")
         # X is typically a transposed view (group_data.T); asarray (unlike
         # ascontiguousarray) only casts dtype and leaves an already-float64 array
         # as-is, so this avoids forcing a full transpose-copy on every call. Numba

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -461,7 +461,13 @@ def permdisp(
 
     num_groups, grouping = _preprocess_input_sng(ids, sample_size, grouping, column)
 
-    engine = _resolve_engine(engine, ("cython", "numba"))
+    # Only resolve engine for test="median": it's the only test type that
+    # reads it (see _compute_groups below), and the docstring documents
+    # engine as ignored for test="centroid". Resolving unconditionally would
+    # raise ImportError/ValueError for an unavailable/invalid engine even
+    # when test="centroid" never uses it.
+    if test == "median":
+        engine = _resolve_engine(engine, ("cython", "numba"))
 
     test_stat_function = partial(_compute_groups, sample_data, test, engine)
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -37,6 +37,11 @@ if TYPE_CHECKING:  # pragma: no cover
     import pandas as pd
     from skbio.util._typing import SeedLike
 
+# Must match the defaults of geomedian_axis_one's eps/maxiters in _cutils.pyx, so
+# the two engines resolve to the same behavior when the caller doesn't override them.
+_GEOMEDIAN_EPS = 1e-7
+_GEOMEDIAN_MAXITERS = 500
+
 
 if NUMBA_AVAILABLE:
 
@@ -87,7 +92,7 @@ if NUMBA_AVAILABLE:
                 else:
                     Dinv[i] = 0.0
 
-            # sequential reduction, same order as Cython's _sum
+            # accumulate in the same order as Cython's _sum, for bit-identical results
             Dinvs = 0.0
             for i in range(n):
                 Dinvs += Dinv[i]
@@ -157,8 +162,14 @@ def _geomedian_axis_one(X, engine):
         The length-``p`` geometric median.
     """
     if engine == "numba":
-        Xc = np.ascontiguousarray(X, dtype=np.float64)
-        return np.asarray(_geomedian_axis_one_nb(Xc, 1e-7, 500))
+        # X is typically a transposed view (group_data.T); asarray (unlike
+        # ascontiguousarray) only casts dtype and leaves an already-float64 array
+        # as-is, so this avoids forcing a full transpose-copy on every call. Numba
+        # handles the resulting non-contiguous 2-D array directly.
+        Xc = np.asarray(X, dtype=np.float64)
+        return np.asarray(
+            _geomedian_axis_one_nb(Xc, _GEOMEDIAN_EPS, _GEOMEDIAN_MAXITERS)
+        )
     return np.asarray(geomedian_axis_one(X))
 
 

--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -254,6 +254,8 @@ def permdisp(
         installed. If not provided, the global default is used (see
         :func:`skbio.set_config`). Ignored when ``test="centroid"``.
 
+        .. versionadded:: 0.7.4
+
     Returns
     -------
     pandas.Series

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from functools import partial
-from unittest import TestCase, main, skipIf
+from unittest import TestCase, main, mock, skipIf
 import platform
 
 import numpy as np
@@ -356,6 +356,11 @@ class PERMDISPTests(TestCase):
         cy = np.asarray(geomedian_axis_one(self.eq_mat.data))
         nb = _geomedian_axis_one(self.eq_mat.data, "numba")
         npt.assert_allclose(nb, cy, rtol=0, atol=1e-10)
+
+    def test_geomedian_numba_unavailable(self):
+        with mock.patch("skbio.stats.distance._permdisp.NUMBA_AVAILABLE", False):
+            with self.assertRaisesRegex(ImportError, "requires the optional numba"):
+                _geomedian_axis_one(self.eq_mat.data, "numba")
 
     @numba_code
     def test_permdisp_engine_equivalence(self):

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -373,6 +373,13 @@ class PERMDISPTests(TestCase):
                     dimensions=self.eq_mat.shape[0], warn_neg_eigval=False,
                     engine='bogus')
 
+    def test_permdisp_engine_ignored_for_centroid(self):
+        # engine is documented as ignored when test="centroid", so an
+        # invalid engine value must not raise in that case.
+        permdisp(self.eq_mat, self.grouping_eq, test='centroid',
+                 dimensions=self.eq_mat.shape[0], warn_neg_eigval=False,
+                 engine='bogus')
+
     def test_confirm_betadispr_results(self):
         mp_dm = DistanceMatrix.read(get_data_path('moving_pictures_dm.tsv'))
         mp_mf = pd.read_csv(get_data_path('moving_pictures_mf.tsv'), sep='\t')

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -19,9 +19,9 @@ from scipy.stats import f_oneway, ConstantInputWarning
 from skbio import DistanceMatrix
 from skbio.stats.ordination import pcoa
 from skbio.stats.distance import permdisp
-from skbio.stats.distance._permdisp import _compute_groups
+from skbio.stats.distance._permdisp import _compute_groups, _geomedian_axis_one
 from skbio.stats.distance._cutils import geomedian_axis_one
-from skbio.util import get_data_path
+from skbio.util import get_data_path, numba_code
 
 IS_INTEL_MAC = platform.system() == "Darwin" and platform.machine() == "x86_64"
 
@@ -123,10 +123,10 @@ class PERMDISPTests(TestCase):
         dm = pcoa(self.eq_mat, warn_neg_eigval=False)
         dm = dm.samples
 
-        obs = _compute_groups(dm, 'centroid', self.grouping_eq)
+        obs = _compute_groups(dm, 'centroid', 'cython', self.grouping_eq)
         self.assertAlmostEqual(obs, exp_stat, places=6)
 
-        obs_relab = _compute_groups(dm, 'centroid', self.grouping_eq_relab)
+        obs_relab = _compute_groups(dm, 'centroid', 'cython', self.grouping_eq_relab)
         self.assertAlmostEqual(obs_relab, obs, places=6)
 
     def test_centroids_uneq_groups(self):
@@ -143,10 +143,10 @@ class PERMDISPTests(TestCase):
         dm = pcoa(self.uneq_mat, warn_neg_eigval=False)
         dm = dm.samples
 
-        obs = _compute_groups(dm, 'centroid', self.grouping_uneq)
+        obs = _compute_groups(dm, 'centroid', 'cython', self.grouping_uneq)
         self.assertAlmostEqual(obs, exp_stat, places=6)
 
-        obs_relab = _compute_groups(dm, 'centroid', self.grouping_uneq_relab)
+        obs_relab = _compute_groups(dm, 'centroid', 'cython', self.grouping_uneq_relab)
         self.assertAlmostEqual(obs, obs_relab, places=6)
 
     def test_centroids_mixedgroups(self):
@@ -160,7 +160,7 @@ class PERMDISPTests(TestCase):
 
         exp_stat, _ = f_oneway(*exp)
 
-        obs_mixed = _compute_groups(dm, 'centroid', self.grouping_un_mixed)
+        obs_mixed = _compute_groups(dm, 'centroid', 'cython', self.grouping_un_mixed)
         self.assertAlmostEqual(exp_stat, obs_mixed, places=6)
 
     def test_centroids_null(self):
@@ -171,7 +171,7 @@ class PERMDISPTests(TestCase):
         # ConstantInputWarning may no longer be emitted for this case.
         # Once the expected behavior is clarified, consider reintroducing
         # an explicit warning assertion here.
-        obs_null = _compute_groups(dm, 'centroid', self.grouping_eq)
+        obs_null = _compute_groups(dm, 'centroid', 'cython', self.grouping_eq)
         np.isnan(obs_null)
 
     def test_centroid_normal(self):
@@ -334,6 +334,44 @@ class PERMDISPTests(TestCase):
                         1.76214416, 1.69943057])
         obs = np.array(geomedian_axis_one(self.eq_mat.data))
         npt.assert_almost_equal(obs, exp, decimal=6)
+
+    @numba_code
+    def test_geomedian_numba(self):
+        exp = np.array([2.01956244, 1.53164546, 2.60571752, 0.91424179,
+                        1.76214416, 1.69943057])
+        obs = _geomedian_axis_one(self.eq_mat.data, "numba")
+        npt.assert_almost_equal(obs, exp, decimal=6)
+
+    @numba_code
+    def test_geomedian_numba_parity(self):
+        rng = np.random.default_rng(0)
+        shapes = [(6, 12), (3, 5), (10, 4), (1, 7), (4, 9), (8, 1)]
+        for shape in shapes:
+            X = rng.standard_normal(shape)
+            cy = np.asarray(geomedian_axis_one(X.copy()))
+            nb = _geomedian_axis_one(X.copy(), "numba")
+            npt.assert_allclose(nb, cy, rtol=0, atol=1e-10)
+
+        # also on the real fixture matrix
+        cy = np.asarray(geomedian_axis_one(self.eq_mat.data))
+        nb = _geomedian_axis_one(self.eq_mat.data, "numba")
+        npt.assert_allclose(nb, cy, rtol=0, atol=1e-10)
+
+    @numba_code
+    def test_permdisp_engine_equivalence(self):
+        exp = permdisp(self.eq_mat, self.grouping_eq, test='median',
+                       dimensions=self.eq_mat.shape[0], warn_neg_eigval=False,
+                       seed=42, engine='cython')
+        obs = permdisp(self.eq_mat, self.grouping_eq, test='median',
+                       dimensions=self.eq_mat.shape[0], warn_neg_eigval=False,
+                       seed=42, engine='numba')
+        self.assert_series_equal(obs.astype('object'), exp.astype('object'))
+
+    def test_permdisp_engine_invalid(self):
+        with self.assertRaises(ValueError):
+            permdisp(self.eq_mat, self.grouping_eq,
+                    dimensions=self.eq_mat.shape[0], warn_neg_eigval=False,
+                    engine='bogus')
 
     def test_confirm_betadispr_results(self):
         mp_dm = DistanceMatrix.read(get_data_path('moving_pictures_dm.tsv'))


### PR DESCRIPTION
Adds an optional Numba compute engine for the geometric-median (`test="median"`) computation used by `permdisp`, wired through the existing `engine=`/`_resolve_engine` dispatch pattern used elsewhere in the package. The Cython `geomedian_axis_one` kernel is unchanged; the Numba kernel is numerically verified against it to `atol=1e-10`. `engine` is only resolved when `test="median"`, since that's the only test type that reads it; the docstring documents `engine` as ignored when `test="centroid"`.

The Numba kernel runs the Weiszfeld iteration sequentially rather than with `prange`: the inner per-point/per-dimension loops are only tens to low hundreds of elements, too small to amortize numba's per-region parallel dispatch overhead, which would otherwise be paid on every outer iteration and on every one of the thousands of calls `permdisp` makes per invocation (`num_groups * (permutations + 1)`).

The Numba branch casts its input with `np.asarray(X, dtype=np.float64)` rather than `np.ascontiguousarray`, since the input is typically a transposed view (`group_data.T`); `asarray` only casts dtype without forcing a copy, and numba handles the resulting non-contiguous array directly.

Benchmark, `permdisp(test="median", engine=...)`, `permutations=10`:

| n | cython | numba | speedup |
|---|---|---|---|
| 50 | 5.2ms | 4.7ms | 1.12x |
| 200 | 7.8ms | 6.6ms | 1.19x |
| 500 | 16.9ms | 14.8ms | 1.15x |

The geometric-median kernel is a small fraction of `permdisp`'s per-call cost, so the end-to-end speedup is modest.

Tests:
- numba kernel matches Cython to `atol=1e-10`, on both a fixed fixture and randomized shapes
- full `permdisp()` call agrees across engines
- invalid engine raises
- `engine` is ignored (does not raise, even if invalid) when `test="centroid"`
- calling the numba engine directly without numba installed raises `ImportError`

Checklist:
- [x] I have read the contribution guidelines.
- [x] I have documented all public-facing changes in the changelog.
- [x] This pull request does not include code, documentation, or other content derived from external source(s).