### PR TITLE
BUG: Forward extra keyword arguments in Stockholm TabularMSA reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Fixed `permanova` returning an inaccurate pseudo-F for float32 distance matrices, caused by accumulating the total sum of squares in float32 rather than float64 [#2509](https://github.com/scikit-bio/scikit-bio/pull/2509).
 * `permanova` and `pcoa` now honor `engine="numba"` by not taking the scikit-bio-binaries path (the Cython-equivalent acceleration) [#2510](https://github.com/scikit-bio/scikit-bio/pull/2510).
 * Fixed `SymmetricMatrix.filter` and `SymmetricMatrix.permute` silently resetting a non-zero diagonal to `0` when the matrix was stored in condensed form. Both methods reconstructed the result from its condensed representation, which only carries off-diagonal values, without passing the diagonal through. The diagonal is now subset and reordered along with the rows and columns. `DistanceMatrix` is unaffected because it is always hollow ([#2516](https://github.com/scikit-bio/scikit-bio/issues/2516)). Thank @LarytheLord for reporting and diagnosing the root cause.
+* Fixed the Stockholm `TabularMSA` reader rejecting all extra keyword arguments (e.g., `lowercase`), even though such arguments are accepted by sequence constructors and forwarded by other multi-sequence format readers. Keyword arguments other than `constructor` are now forwarded to `constructor` when building each aligned sequence ([#1543](https://github.com/scikit-bio/scikit-bio/issues/1543)).
 
 ## Version 0.7.3
 

--- a/skbio/io/format/stockholm.py
+++ b/skbio/io/format/stockholm.py
@@ -258,12 +258,17 @@ The final line of a Stockholm file must be the following footer::
 
 Format Parameters
 -----------------
-The only supported format parameter is ``constructor``, which specifies the
-type of in-memory sequence object to read each aligned sequence into. This must
-be a subclass of ``GrammaredSequence`` (e.g., ``DNA``, ``RNA``, ``Protein``)
-and is a required format parameter. For example, if you know that the Stockholm
-file you're reading contains DNA sequences, you would pass ``constructor=DNA``
-to the reader call.
+The ``constructor`` format parameter specifies the type of in-memory sequence
+object to read each aligned sequence into. This must be a subclass of
+``GrammaredSequence`` (e.g., ``DNA``, ``RNA``, ``Protein``) and is a required
+format parameter. For example, if you know that the Stockholm file you're
+reading contains DNA sequences, you would pass ``constructor=DNA`` to the
+reader call.
+
+Any other keyword arguments are forwarded to ``constructor`` when building each
+aligned sequence. For example, ``lowercase`` can be passed to accept lowercase
+characters that aren't in the sequence's alphabet, as with other sequence
+constructors.
 
 Examples
 --------
@@ -427,7 +432,7 @@ def _stockholm_sniffer(fh):
 
 
 @stockholm.reader(TabularMSA)
-def _stockholm_to_tabular_msa(fh, cls=None, constructor=None):
+def _stockholm_to_tabular_msa(fh, cls=None, constructor=None, **kwargs):
     # Checks that user has passed required constructor parameter
     if constructor is None:
         raise ValueError(
@@ -480,7 +485,7 @@ def _stockholm_to_tabular_msa(fh, cls=None, constructor=None):
             'Final line does not conform to Stockholm format. Must contain only "//".'
         )
 
-    return msa_data.build_tabular_msa(constructor)
+    return msa_data.build_tabular_msa(constructor, **kwargs)
 
 
 # For storing intermediate data used to construct a Sequence object.
@@ -558,7 +563,7 @@ class _MSAData:
             self._seqs[seq_name] = _SeqData(seq_name)
         self._seqs[seq_name].add_positional_metadata_feature(feature_name, feature_data)
 
-    def build_tabular_msa(self, constructor):
+    def build_tabular_msa(self, constructor, **kwargs):
         if len(self._seqs) != len(self._seq_order):
             invalid_seq_names = set(self._seqs) - set(self._seq_order)
             raise StockholmFormatError(
@@ -568,7 +573,7 @@ class _MSAData:
 
         seqs = []
         for seq_name in self._seq_order:
-            seqs.append(self._seqs[seq_name].build_sequence(constructor))
+            seqs.append(self._seqs[seq_name].build_sequence(constructor, **kwargs))
 
         positional_metadata = self._positional_metadata
         if not positional_metadata:
@@ -625,11 +630,12 @@ class _SeqData:
         else:
             self.positional_metadata[feature_name] = feature_data
 
-    def build_sequence(self, constructor):
+    def build_sequence(self, constructor, **kwargs):
         return constructor(
             self.seq,
             metadata=self.metadata,
             positional_metadata=(self.positional_metadata),
+            **kwargs,
         )
 
 

--- a/skbio/io/format/tests/data/stockholm_lowercase
+++ b/skbio/io/format/tests/data/stockholm_lowercase
@@ -1,0 +1,4 @@
+# STOCKHOLM 1.0
+seq1          ACDefGHIKLMN
+seq2          acdEFGHIKLMN
+//

--- a/skbio/io/format/tests/test_stockholm.py
+++ b/skbio/io/format/tests/test_stockholm.py
@@ -193,6 +193,23 @@ class TestStockholmReader(unittest.TestCase):
                          index=['RTC2231', 'RTF2124', 'RTH3322', 'RTB1512'])
         self.assertEqual(msa, exp)
 
+    def test_stockholm_lowercase(self):
+        # lowercase characters that aren't in the sequence's alphabet raise
+        # by default...
+        fp = get_data_path('stockholm_lowercase')
+        with self.assertRaisesRegex(ValueError, 'Invalid character'):
+            _stockholm_to_tabular_msa(fp, constructor=Protein)
+
+        # ...unless `lowercase` is passed, in which case it is forwarded to
+        # `constructor` just like other keyword arguments accepted by
+        # sequence constructors
+        msa = _stockholm_to_tabular_msa(fp, constructor=Protein,
+                                        lowercase=True)
+        exp = TabularMSA([Protein('ACDEFGHIKLMN', metadata={'id': 'seq1'}),
+                          Protein('ACDEFGHIKLMN', metadata={'id': 'seq2'})],
+                         index=['seq1', 'seq2'])
+        self.assertEqual(msa, exp)
+
     def test_stockholm_runon_gf(self):
         fp = get_data_path('stockholm_runon_gf_no_whitespace')
         msa = _stockholm_to_tabular_msa(fp, constructor=DNA)


### PR DESCRIPTION
Please complete the following checklist:

- [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
- [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
- [ ] **This pull request includes code, documentation, or other content derived from external source(s).**
- [x] This pull request does not include code, documentation, or other content derived from external source(s).

Closes #1543.

## Description

The Stockholm format spec explicitly allows lowercase sequence letters, and the module's own docs pointed users at the `lowercase` parameter (as used elsewhere, e.g. the FASTA reader) to accept them. But `_stockholm_to_tabular_msa(fh, cls=None, constructor=None)` had no catch-all for extra keyword arguments, so:

```python
>>> from skbio import Protein, TabularMSA
>>> msa = TabularMSA.read('aln.sto', constructor=Protein, lowercase=True)
TypeError: _stockholm_to_tabular_msa() got an unexpected keyword argument 'lowercase'
```

`lowercase` never reached the `Protein`/`DNA`/`RNA` constructor at all, so lowercase characters outside the sequence's alphabet always raised `ValueError: Invalid characters in sequence`, regardless of the `lowercase` argument.

The FASTA reader doesn't have this problem because its reader function already accepts `**kwargs` and forwards them straight to `constructor(seq, ..., **kwargs)`. This PR gives the Stockholm reader the same shape: `_stockholm_to_tabular_msa` now accepts `**kwargs`, threading it through `_MSAData.build_tabular_msa` and `_SeqData.build_sequence` down to the `constructor(...)` call, so `lowercase` (or any other constructor-supported keyword) now works the same way it does for FASTA. Updated the module's "Format Parameters" docs to reflect this.

Added a small `stockholm_lowercase` test fixture and a regression test (`test_stockholm_lowercase`) verifying both the previous `ValueError` (default) and the fixed `lowercase=True` behavior.

Note: `clustal` and `phylip` readers have the same gap (no `**kwargs` passthrough), but that wasn't reported in #1543, so I kept this PR scoped to Stockholm rather than bundling an unrelated fix — flagging it here in case a maintainer wants a follow-up covering those too.