### PR TITLE
ENH: Warn when beta_diversity's result contains nan values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 * `permanova` and `pcoa` now honor `engine="numba"` by not taking the scikit-bio-binaries path (the Cython-equivalent acceleration) [#2510](https://github.com/scikit-bio/scikit-bio/pull/2510).
 * Fixed `SymmetricMatrix.filter` and `SymmetricMatrix.permute` silently resetting a non-zero diagonal to `0` when the matrix was stored in condensed form. Both methods reconstructed the result from its condensed representation, which only carries off-diagonal values, without passing the diagonal through. The diagonal is now subset and reordered along with the rows and columns. `DistanceMatrix` is unaffected because it is always hollow ([#2516](https://github.com/scikit-bio/scikit-bio/issues/2516)). Thank @LarytheLord for reporting and diagnosing the root cause.
 
+### Miscellaneous
+
+* `beta_diversity` now emits a `UserWarning` when the returned distance matrix contains `nan` values, which can happen, for example, when two or more samples all have an all-zero count vector and the chosen metric (e.g., `'braycurtis'`) divides by the total count. Previously this passed silently ([#1702](https://github.com/scikit-bio/scikit-bio/issues/1702)).
+
 ## Version 0.7.3
 
 ### Features

--- a/skbio/diversity/_driver.py
+++ b/skbio/diversity/_driver.py
@@ -411,6 +411,16 @@ def beta_diversity(
         pairwise_func = pdist
 
     distances = pairwise_func(counts, metric=metric, **kwargs)
+    if np.isnan(distances).any():
+        warnings.warn(
+            "The computed distance matrix contains `nan` value(s). This can "
+            "happen, for example, when two samples both have an all-zero "
+            "count vector and the chosen metric divides by the total count "
+            "(e.g., 'braycurtis'). Consider removing empty samples from "
+            "`counts` beforehand, or inspect the returned distance matrix "
+            "for `nan` values.",
+            stacklevel=2,
+        )
     return DistanceMatrix(distances, ids)
 
 

--- a/skbio/diversity/tests/test_driver.py
+++ b/skbio/diversity/tests/test_driver.py
@@ -801,6 +801,29 @@ class BetaDiversityTests(TestCase):
                             taxa=self.oids1)
         self.assertEqual(dm.shape, (3, 3))
 
+    def test_all_zero_samples_nan_warns(self):
+        # Two or more all-zero samples make 'braycurtis' divide by zero,
+        # producing `nan` in the resulting distance matrix (see issue
+        # #1702). This should be surfaced to the user as a warning rather
+        # than passing silently.
+        counts = [[0, 0, 0],
+                 [1, 2, 3],
+                 [0, 0, 0]]
+        with self.assertWarnsRegex(UserWarning, "nan"):
+            dm = beta_diversity('braycurtis', counts)
+        self.assertTrue(np.isnan(dm[0, 2]))
+
+    def test_all_zero_samples_nan_does_not_warn_for_unaffected_metric(self):
+        # A single all-zero sample, or a metric that isn't susceptible to
+        # 0/0 division (e.g., 'euclidean'), should not trigger the warning.
+        counts = [[0, 0, 0],
+                 [1, 2, 3],
+                 [4, 5, 6]]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            beta_diversity('braycurtis', counts)
+            beta_diversity('euclidean', [[0, 0, 0], [0, 0, 0], [1, 2, 3]])
+
 
 class MetricGetters(TestCase):
 


### PR DESCRIPTION
Please complete the following checklist:

- [x] I have read the [contribution guidelines](https://scikit.bio/contribute.html).
- [x] I have documented all public-facing changes in the [changelog](https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md).
- [ ] **This pull request includes code, documentation, or other content derived from external source(s).**
- [x] This pull request does not include code, documentation, or other content derived from external source(s).

Addresses #1702.

## Description

As reported in #1702: when `counts` contains two or more all-zero samples, some beta diversity metrics divide by the total count of each pair (e.g. Bray-Curtis is `sum(|u-v|) / sum(u+v)`), so the distance between two all-zero samples is `0/0 = nan`. This currently passes through `beta_diversity` silently:

```python
>>> import numpy as np
>>> from skbio.diversity import beta_diversity
>>> counts = [[0, 0, 0], [1, 2, 3], [0, 0, 0]]
>>> dm = beta_diversity('braycurtis', counts)  # no error, no warning
>>> dm[0, 2]
nan
```

A maintainer's response in the issue thread confirmed a warning/error here "would be a good feature addition" and invited a PR.

This adds a check right after the pairwise distances are computed: if the resulting array contains any `nan`, `beta_diversity` emits a `UserWarning` explaining the likely cause (all-zero samples + a metric that divides by total count) and suggesting the user either filter out empty samples beforehand or inspect the returned matrix. I went with a warning rather than an error since:
- `DistanceMatrix` already accepts `nan` values (no exception is raised constructing it), so this isn't changing any return values or breaking existing callers, only surfacing something that was already happening;
- `nan` isn't necessarily wrong for all use cases (some callers may want to filter it out downstream), so silently succeeding is preferable to raising, but silently succeeding *without any indication* is what prompted the original report.

The check is generic (`np.isnan(distances).any()` on the actual computed result) rather than metric-specific, so it only fires when `nan` is actually present — it won't false-positive for metrics unaffected by this (e.g. `'euclidean'`) or when only a single sample is all-zero (which most metrics handle fine against a non-zero sample).

Added `test_all_zero_samples_nan_warns` and `test_all_zero_samples_nan_does_not_warn_for_unaffected_metric` to `skbio/diversity/tests/test_driver.py`.