### PR TITLE
BUG: apply the permdisp Numba dtype check per test

### DIFF
--- a/skbio/stats/distance/_permdisp.py
+++ b/skbio/stats/distance/_permdisp.py
@@ -376,6 +376,9 @@ def permdisp(
         If, when using the spatial median test, the pcoa ordination is not of
         type np.float32 or np.float64, the spatial median function will fail
         and the centroid test should be used instead
+    TypeError
+        If, when using the centroid test, the pcoa ordination is not of a
+        numeric type.
     ValueError
         If the test is not centroid or median, or if method is not eigh or fsvd.
     TypeError
@@ -599,19 +602,25 @@ def _run_permdisp_numba(sample_data, grouping, num_groups, permutations, seed, t
             "Number of permutations must be greater than or equal to zero."
         )
 
-    # geomedian_axis_one is fused over float32 and float64, so Cython's median
-    # path raises on any other dtype, and this rejects the same set so the two
-    # engines agree there. The check is not conditioned on the test, so it also
-    # covers test="centroid", which never reaches that kernel and which Cython
-    # computes for any numeric dtype; the Numba path is stricter in that case.
-    if np.asarray(sample_data).dtype not in (np.float32, np.float64):
-        raise TypeError(
-            "Ordination coordinates must be of type np.float32 or np.float64."
-        )
+    # Reject exactly what the Cython path rejects, so that engine= selects an
+    # implementation without changing which inputs are legal. The median test
+    # reaches geomedian_axis_one, which is fused over float32 and float64 and
+    # raises on anything else. The centroid test never reaches that kernel and
+    # is computed with numpy, which handles any numeric dtype but not object,
+    # string or datetime64 arrays.
+    dtype = np.asarray(sample_data).dtype
+    if test == "median":
+        if dtype not in (np.float32, np.float64):
+            raise TypeError(
+                "Ordination coordinates must be of type np.float32 or np.float64."
+            )
+    elif not (np.issubdtype(dtype, np.number) or dtype == np.bool_):
+        raise TypeError("Ordination coordinates must be of a numeric type.")
 
-    # An accepted float32 ordination is accumulated in float64, for the same
-    # reason as #2509. Cython computes in the input dtype instead, so the two
-    # engines differ by float32 precision on such an input.
+    # The kernels accumulate in float64 whatever comes in, for the same reason
+    # as #2509. Cython computes in the input dtype instead, so the engines
+    # differ by that dtype's precision on a float32 or float16 ordination.
+    # Integers agree, since numpy's mean promotes them to float64 anyway.
     samples = np.ascontiguousarray(sample_data, dtype=np.float64)
     codes = np.ascontiguousarray(grouping, dtype=np.int32)
     sample_size = codes.shape[0]

--- a/skbio/stats/distance/tests/test_permdisp.py
+++ b/skbio/stats/distance/tests/test_permdisp.py
@@ -626,9 +626,11 @@ class PERMDISPEngineTests(TestCase):
     @numba_code
     def test_non_float_ordination_raises_like_cython(self):
         # geomedian_axis_one only has single and double precision signatures,
-        # so the cython path raises on anything else. The numba kernels would
-        # happily widen an integer array and return a number instead, which is
-        # worse than the error, so the engine refuses the same inputs.
+        # so the cython median path raises on anything else. The numba kernels
+        # would happily widen an integer array and return a number instead,
+        # which is worse than the error, so the engine refuses the same inputs.
+        # The centroid test never reaches that kernel and cython computes it
+        # for any numeric dtype, so both engines have to accept those.
         ordination = pcoa(self.dm, method="eigh", dimensions=10)
 
         def recast(dtype):
@@ -648,6 +650,37 @@ class PERMDISPEngineTests(TestCase):
         for dtype in ("float32", "float64"):
             for engine in ("cython", "numba"):
                 permdisp(recast(dtype), self.grouping, test="median",
+                         permutations=0, engine=engine)
+        # the centroid test does not use geomedian_axis_one, so an integer
+        # ordination is computed rather than refused, and the two engines
+        # agree because numpy's mean promotes integers to float64. The pcoa
+        # coordinates are all smaller than one, so they have to be scaled
+        # before casting or every one of them truncates to zero and the
+        # comparison below is between two NaNs.
+        scaled = ordination.samples * 1000
+        for dtype in ("int64", "int32"):
+            as_int = OrdinationResults(
+                short_method_name=ordination.short_method_name,
+                long_method_name=ordination.long_method_name,
+                eigvals=ordination.eigvals,
+                samples=scaled.astype(dtype),
+                proportion_explained=ordination.proportion_explained)
+            obs = [permdisp(as_int, self.grouping, test="centroid",
+                            permutations=99, seed=42, engine=engine)
+                   for engine in ("cython", "numba")]
+            self.assertTrue(np.isfinite(obs[0]["test statistic"]))
+            npt.assert_allclose(obs[0]["test statistic"],
+                                obs[1]["test statistic"], rtol=1e-12)
+            # no permuted statistic lands within 1e-4 of the observed one on
+            # this fixture, so the ">=" counts cannot differ over a last-bit
+            # disagreement and the p-values are exactly equal.
+            self.assertEqual(obs[0]["p-value"], obs[1]["p-value"])
+        # a dtype numpy cannot do arithmetic on is refused by both engines
+        # rather than being quietly coerced by the numba path. Strings reach
+        # this as object too, since that is how pandas stores them.
+        for engine in ("cython", "numba"):
+            with self.assertRaises(TypeError):
+                permdisp(recast("object"), self.grouping, test="centroid",
                          permutations=0, engine=engine)
 
     @numba_code


### PR DESCRIPTION
### Description

Follow-up to #2547, as promised there.

`_run_permdisp_numba` rejects any ordination that is not float32 or float64, on
the grounds that the Cython path raises on anything else. That holds only for
`test="median"`, which reaches `geomedian_axis_one`, a fused function carrying
just those two signatures. `test="centroid"` never reaches that kernel: it uses
`group_data.mean(axis=0)`, which numpy is happy to compute for any numeric
dtype. So on an integer ordination the two engines disagree about whether the
call is even legal:

```
test="centroid", int64 ordination
  cython  0.5367018290895094
  numba   TypeError
```

This also contradicts the documented contract. `permdisp`'s own `Raises`
section already scopes the restriction to one test and names the centroid test
as the way around it:

> If, when using the spatial median test, the pcoa ordination is not of type
> np.float32 or np.float64, the spatial median function will fail and the
> centroid test should be used instead

Under `engine="numba"` that advice did not work, because the guard rejected the
input before the centroid test could run. `engine=` is meant to select an
implementation, not change which inputs are accepted, so the check is now made
per test.

The median test keeps the float32 or float64 requirement. The centroid test
accepts any numeric dtype and refuses the rest. That boundary is not arbitrary:
it is where numpy stops being able to do arithmetic, and it is where the Cython
path itself raises. Checking every dtype through both engines on the centroid
test now gives no case where one computes and the other raises:

| dtype | cython | numba |
|---|---|---|
| float64 | 0.5353619887121516 | 0.5353619887121513 |
| float32 | 0.535361647605896 | 0.535361832311309 |
| float16 | nan | 0.5372472502169272 |
| int64, int32 | 0.5367018290895094 | 0.5367018290895084 |
| bool | nan | nan |
| complex, timedelta64, longdouble | computes | computes |
| object, str, datetime64 | raises | raises |

Integers are the clean case because numpy's `mean` promotes them to float64
before the Cython path uses them, so both engines end up doing float64
arithmetic and agree to 1.9e-15 with identical p-values.

The engines are not bit-identical for every dtype, and the comment now says so
rather than implying otherwise. The Numba kernels accumulate in float64 whatever
comes in, while Cython computes in the input dtype, so a float32 or float16
ordination differs by that dtype's precision. That was already true for float32,
which the guard has always accepted.

Only a hand-built `OrdinationResults` can reach any of this: `pcoa` returns
float64 samples for both `eigh` and `fsvd`, even from a float32
`DistanceMatrix`.

The `Raises` section gains the matching entry. That condition is not new, since
the Cython path already raised for a non-numeric ordination on the centroid
test, but it was never written down.

### Testing

`test_non_float_ordination_raises_like_cython` only exercised `test="median"`,
which is why this was missed. It now covers the centroid test in both
directions: int64 and int32 are computed rather than refused and the two engines
return the same statistic and the same p-value, and an object ordination is
refused by both. Strings arrive as object too, since that is how pandas stores
them, so object is the only non-numeric dtype reachable through
`OrdinationResults`.

The integer ordination has to be scaled before casting: the pcoa coordinates on
this fixture are all smaller than one, so a direct `astype("int64")` truncates
every one of them to zero and the comparison degenerates into asserting that two
NaNs match. The test asserts the statistic is finite so that it cannot silently
become vacuous again.

Three checks that the assertions actually bite, each done by breaking one thing
and confirming the test fails: removing the guard entirely, removing only the
non-numeric clause, and removing the scaling. `pytest
skbio/stats/distance/tests/test_permdisp.py` passes, 38 tests, with and without
`NUMBA_DISABLE_JIT=1`, on arm64 macOS and on x86-64 Linux. `ruff check` is clean
on both files.

No changelog entry: `engine="numba"` for `permdisp` landed in #2547 and has
not been released, so this corrects unreleased behavior rather than something a
user could have depended on.
